### PR TITLE
fix(scripts): add help-only path to agent-customize CLI

### DIFF
--- a/docs/specs/2026-07-28-a04-agent-customize-help-only.md
+++ b/docs/specs/2026-07-28-a04-agent-customize-help-only.md
@@ -1,0 +1,60 @@
+# Agent Customize Help-only Path
+
+Give `agent-customize` a help-only path so `--help` returns before the CLI
+reads HOME, workspace, SQLite, or plugin caches. This is roadmap P0 item A-04.
+
+## Traceability
+
+- Spec ID: 2026-07-28-a04-agent-customize-help-only
+- Story: roadmap.md TODO A-04
+- Status: Implemented
+
+## Intent
+
+`scripts/agent-customize/cli.mjs` has no help branch. Any invocation —
+including `--help` — runs `collectAgentCustomizeInventory`, which resolves the
+provider home, walks the workspace, and opens provider caches (Cursor plugin
+cache, Qoder SharedClientCache, Claude state, Codex app paths). A discovery
+call such as `better-harness agent-customize --help` therefore reads private
+host data before printing anything, and the root facade passes `--help`
+through to this script unchanged for direct-dispatch commands.
+
+The unsupported-behavior rule in `roadmap.md` (Definition of Done) requires
+help and other unsupported paths to fail or return before reading private
+data.
+
+## Acceptance Scenarios
+
+- AC-1: `node scripts/agent-customize/cli.mjs --help` (also `-h` and the
+  `help` command word) prints usage to stdout and exits 0 without calling
+  `collectAgentCustomizeInventory` or any provider collector.
+- AC-2: The help-only path performs no HOME, workspace, SQLite, or plugin
+  cache access. Evidence: `--help` combined with an unsupported
+  `--provider` value still exits 0, while the same unsupported provider
+  without `--help` keeps failing with the existing collector error.
+- AC-3: `better-harness agent-customize --help` through the root facade
+  reaches the same help-only path and exits 0.
+- AC-4: Existing `inventory` and `manage` behavior is unchanged for all
+  non-help invocations; `npm test` passes.
+
+## Non-Goals
+
+- No checkup capability states (A-01), provider-aware plan/apply (A-02), or
+  provider-home binding (A-03).
+- No change to `collectAgentCustomizeInventory`, provider collectors, or the
+  root facade dispatch contract.
+- No new flags beyond help recognition.
+
+## Plan
+
+1. Add a `usage()` string and an early help gate to
+   `scripts/agent-customize/cli.mjs`, following the `agent-lint` CLI pattern:
+   detect `--help`, `-h`, or a leading `help` command before parsing options
+   or importing collector work, print usage, and return exit code 0.
+2. Add CLI tests in `test/agent-customize.test.mjs` that spawn the script
+   and the root facade to cover AC-1 through AC-3.
+
+## Test Evidence
+
+- `node --test test/agent-customize.test.mjs`
+- `npm test`

--- a/roadmap.md
+++ b/roadmap.md
@@ -44,7 +44,7 @@ platform depth.
 | [ ] | P0 | A-01 | Add `full-session`, `inventory-only`, and `unsupported` checkup capability states. | Cursor inventory scan succeeds without session evidence and produces no cleanup candidates. |
 | [ ] | P0 | A-02 | Make checkup plan/apply provider-aware and fail closed by default. | Codex and Cursor plans never contain `qodercli` actions. |
 | [ ] | P0 | A-03 | Bind source references and provider-home paths to an explicit provider. | A patch cannot resolve into another host's configuration root. |
-| [ ] | P0 | A-04 | Add a help-only path to `agent-customize`. | `--help` returns before reading HOME, workspace, SQLite, or plugin caches. |
+| [x] | P0 | A-04 | Add a help-only path to `agent-customize`. | `--help` returns before reading HOME, workspace, SQLite, or plugin caches. |
 | [ ] | P0 | A-05 | Fix stale adapter documentation and smoke commands. | The matrix uses current `harness analyze` / `harness render` commands and does not overstate Cursor output support. |
 | [ ] | P0 | A-06 | Add support-declaration consistency tests. | CLI help, provider registry, session platforms, report platforms, and docs agree. |
 | [ ] | P1 | C-01 | Add Codex-specific configuration source precedence. | Checkup distinguishes editable sources from cache, audit, and session data. |

--- a/scripts/agent-customize/cli.mjs
+++ b/scripts/agent-customize/cli.mjs
@@ -3,6 +3,22 @@
 import { parseArgs } from "../session-analysis/cli.mjs";
 import { collectAgentCustomizeInventory, filterManageItems, groupManageItems } from "./index.mjs";
 
+function usage() {
+  return [
+    "Usage: better-harness agent-customize [inventory|manage] --provider <cursor|qoder|codex|claude> [--workspace <path>]",
+    "       better-harness agent-customize manage --provider <provider> [--tab <tab>] [--query <text>] [--scope <scope>] [--group-by <key>]",
+    "",
+    "Collect configured agent-customize inventory for one provider as JSON.",
+    "Provider home overrides: --cursor-home, --qoder-home, --codex-home, --claude-home,",
+    "--claude-state, --codex-app-path, --qoder-shared-client-cache-root.",
+    "",
+  ].join("\n");
+}
+
+function wantsHelp(argv) {
+  return argv[0] === "help" || argv.includes("--help") || argv.includes("-h");
+}
+
 function summarize(inventory, options) {
   const tab = options.tab ?? "plugins";
   const items = filterManageItems(inventory, options);
@@ -37,7 +53,14 @@ function summarize(inventory, options) {
 }
 
 async function main() {
-  const { command = "inventory", options } = parseArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  // Help-only path: return before any HOME, workspace, SQLite, or plugin
+  // cache access (roadmap A-04).
+  if (wantsHelp(argv)) {
+    process.stdout.write(usage());
+    return;
+  }
+  const { command = "inventory", options } = parseArgs(argv);
   if (command !== "inventory" && command !== "manage") {
     throw new Error(`Unknown command: ${command}`);
   }

--- a/test/agent-customize.test.mjs
+++ b/test/agent-customize.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1372,4 +1373,40 @@ test("tab availability matches Cursor Customize manage scope rules", () => {
   assert.equal(tabAvailableForScope("hooks", "team"), false);
   assert.equal(tabAvailableForScope("skills", "workspace"), true);
   assert.equal(tabAvailableForScope("hooks", "user"), true);
+});
+
+const agentCustomizeCliPath = path.join(process.cwd(), "scripts", "agent-customize", "cli.mjs");
+const betterHarnessCliPath = path.join(process.cwd(), "scripts", "better-harness.mjs");
+
+function runAgentCustomizeCli(args, entry = agentCustomizeCliPath) {
+  return spawnSync(process.execPath, [entry, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+}
+
+test("agent-customize --help returns before reading provider inventory sources", () => {
+  // An unsupported provider fails in the collector, so exit 0 with --help
+  // proves the help-only path returned before any inventory access.
+  for (const args of [
+    ["--help"],
+    ["-h"],
+    ["help"],
+    ["--provider", "does-not-exist", "--help"],
+    ["inventory", "--provider", "does-not-exist", "--help"],
+  ]) {
+    const result = runAgentCustomizeCli(args);
+    assert.equal(result.status, 0, `${args.join(" ")}: ${result.stderr}`);
+    assert.match(result.stdout, /Usage: better-harness agent-customize/u);
+  }
+
+  const failing = runAgentCustomizeCli(["--provider", "does-not-exist"]);
+  assert.equal(failing.status, 1);
+  assert.match(failing.stderr, /Unsupported agent-customize provider/u);
+});
+
+test("agent-customize --help stays help-only through the root facade", () => {
+  const result = runAgentCustomizeCli(["agent-customize", "--help"], betterHarnessCliPath);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage: better-harness agent-customize/u);
 });


### PR DESCRIPTION
agent-customize had no help branch, so a discovery call such as `better-harness agent-customize --help` ran the full provider inventory collection and read HOME, workspace, SQLite, and plugin caches before printing anything. Gate --help, -h, and the help command word in scripts/agent-customize/cli.mjs before argument parsing and any collector work, printing usage and exiting 0 instead.

This closes roadmap P0 item A-04. Validated with new CLI tests that prove the early return via an unsupported provider plus --help exiting 0 while the same provider without --help still fails in the collector, and a root-facade pass-through check.

Story: roadmap.md TODO A-04
Spec: docs/specs/2026-07-28-a04-agent-customize-help-only.md
Test: node --test test/agent-customize.test.mjs (19 pass)

## Summary

<!-- What observable outcome changes? Keep this answer concise. -->

## Why

<!-- Link the issue or explain why this is justified maintenance without one. -->

- Issue/Story:
- User or maintainer outcome:

## Traceability and Scope

- Spec/ADR, if applicable:
- Acceptance criteria addressed:
- Canonical owners changed:
- Explicit non-goals:

## Change Type

- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

<!-- List exact commands and observed results. Do not list checks that were not run. -->

| Check | Result |
| --- | --- |
|  |  |

Manual or visual evidence:

## Risk and Recovery

- Compatibility and cross-platform impact:
- Package, plugin, schema, or generated-file impact:
- Rollback or recovery path:
- Residual risk or unverified boundary:

## AI Involvement

<!-- State None, Assisted, or Generated; name the human verification performed. -->

- Level:
- Human review and validation:

## Checklist

- [ ] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [ ] The change is focused and does not include unrelated local or generated state.
- [ ] Tests and documentation match the behavior actually delivered.
- [ ] Markdown links were checked when documentation moved or changed.
- [ ] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [ ] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [ ] I have the right to contribute this work under the repository's MIT License.
