### PR TITLE
fix(harness): avoid Home lookup for project outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ observable behavior and compatibility, not every internal refactor.
 
 ### Changed
 
+- `harness record-fix-output` now resolves Home only for Global output, so a
+  verified Project-only result remains recordable when Home is unavailable.
 - The `harness analyze` platform gate now names the full supported set
   (`qoder, codex, claude, cursor, qwen, copilot, pi`) when it rejects an
   unsupported `--platform`, matching the session-analysis and asset-baseline

--- a/docs/specs/2026-07-30-project-output-home-resolution.md
+++ b/docs/specs/2026-07-30-project-output-home-resolution.md
@@ -1,0 +1,75 @@
+# Project output avoids Home resolution
+
+## Traceability
+
+- Spec ID: project-output-home-resolution
+- Status: Implemented
+
+## Intent
+
+Allow `record-fix-output` to record verified Project-scoped output even when the
+current process Home directory is unavailable or cannot be canonicalized. This
+keeps Project output validation independent of unrelated Global-scope state.
+
+## Acceptance Scenarios
+
+- AC-1: A result whose `actualOutput` entries are all `scope: "Project"` is
+  accepted when every referenced file exists within the canonical workspace,
+  even if `HOME` and `USERPROFILE` point to a non-existent directory.
+- AC-2: A `scope: "Global"` output resolves and canonicalizes the process Home
+  on demand, accepts an existing `~/...` file within that canonical Home, and
+  fails without writing the report when Home is unavailable.
+- AC-3: Project output continues to require an existing file and rejects a
+  canonical target that escapes the workspace.
+
+## Non-goals
+
+- Change output schemas, CLI arguments, or result consumption behavior.
+- Relax existing-file, `realpath`, or scope-containment validation.
+- Add test-only production API parameters or alter host environment state.
+
+## Plan and Tasks
+
+1. Add a deterministic CLI regression test that invokes `record-fix-output`
+   with only Project output in a child process whose `HOME` and `USERPROFILE`
+   refer to a non-existent directory.
+2. Confirm the regression fails against the current eager Home resolution.
+3. Make Home canonicalization lazy in `assertOutputTargets`, retaining the
+   existing workspace canonicalization and Global validation behavior.
+4. Run focused, task-loop, documentation-link, packaging, and practical full
+   test gates; record any environment limitation.
+
+## Test and Review Evidence
+
+- AC-1: `node --test test/task-loop-report.test.mjs` exercises the isolated
+  child-process regression and verifies a successful JSON CLI result.
+- AC-2: `node --test test/task-loop-report.test.mjs` runs isolated Global
+  success and unavailable-Home failure cases; the latter verifies the JSON
+  error envelope and that findings bytes are unchanged.
+- AC-3: existing `record-fix-output` cases retain automated Project
+  existing-file rejection. Focused source review confirms the canonical
+  `realpath` containment check and its validation order are unchanged.
+- Documentation: regenerate `docs/better-harness-doc-links.mmd` and run
+  `node --test test/doc-link-graph.test.mjs` after adding this spec.
+- Packaging: run `npm run pack:verify`; run `npm test` when the local runtime
+  can complete the full suite.
+- Risk: `os.homedir()` stays intentionally reachable for Global output only;
+  a regression could weaken containment only if lazy initialization is applied
+  to the wrong scope, which focused scope tests mitigate.
+
+### Observed Evidence (2026-07-30)
+
+- Pre-fix regression: temporarily restoring eager Home resolution made the new
+  Project-only child-process test fail with exit code 1.
+- Focused gate:
+  `node --test --test-name-pattern="record-fix-output"
+  test/task-loop-report.test.mjs` passed 10/10.
+- Task-loop gate: `node --test test/task-loop-report.test.mjs` passed 76/76.
+- Documentation gate: the routing graph had no semantic diff and
+  `node --test test/doc-link-graph.test.mjs` passed 6/6.
+- Full regression: `npm test` exited 0; the suite retained its existing
+  Windows symlink-permission skip.
+- Package gate: `npm run pack:verify` passed using an isolated temporary npm
+  cache, which was removed afterward.
+- Environment limitation: Node `v22.17.0` and npm `10.9.2` are below the
+  repository minimums of Node `22.20.0` and npm `10.9.3`.

--- a/scripts/harness-analysis/record-fix-output.mjs
+++ b/scripts/harness-analysis/record-fix-output.mjs
@@ -121,11 +121,13 @@ function isWithin(root, candidate) {
 
 async function assertOutputTargets(actualOutput, workspacePath) {
   const workspaceRealPath = await realpath(workspacePath);
-  const homeRealPath = await realpath(os.homedir());
+  let homeRealPath;
   for (const [index, output] of actualOutput.entries()) {
     if (!output?.path) continue;
     const logicalPath = String(output.path);
-    const root = output.scope === "Global" ? homeRealPath : workspaceRealPath;
+    const isGlobal = output.scope === "Global";
+    if (isGlobal) homeRealPath ??= await realpath(os.homedir());
+    const root = isGlobal ? homeRealPath : workspaceRealPath;
     const relativePath = output.scope === "Global" ? logicalPath.slice(2) : logicalPath;
     const targetPath = path.resolve(root, ...relativePath.split("/"));
     const targetStat = await stat(targetPath).catch(() => null);

--- a/test/task-loop-report.test.mjs
+++ b/test/task-loop-report.test.mjs
@@ -2868,6 +2868,120 @@ test("record-fix-output replaces one latest result and increments its revision",
   });
 });
 
+test("record-fix-output does not resolve Home for purely Project actualOutput", async () => {
+  await withTempDir(async (root) => {
+    const workspace = path.join(root, "workspace");
+    const runDir = path.join(workspace, ".Qoder", "better-harness", "run");
+    const findingsPath = path.join(runDir, "findings.json");
+    const canvasPath = path.join(runDir, "canvas.json");
+    const targetPath = "fix-output/project-owner.md";
+    const split = splitTaskLoopFindings(projectTaskLoopFindings(reportSource()));
+    const finding = split.findings.findings[0];
+    const resultPath = path.join(root, "result.json");
+    const unavailableHome = path.join(root, "unavailable-home");
+    await mkdir(path.join(workspace, path.dirname(targetPath)), { recursive: true });
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(workspace, targetPath), "# Project owner\n");
+    await writeFile(findingsPath, `${JSON.stringify(split.findings, null, 2)}\n`);
+    await writeFile(canvasPath, `${JSON.stringify(split.canvas, null, 2)}\n`);
+    await writeFile(resultPath, JSON.stringify({
+      actualOutput: [{
+        action: "updated",
+        artifact: finding.expectedArtifact,
+        name: `${finding.expectedArtifact} project owner`,
+        scope: "Project",
+        path: targetPath,
+        summary: "Recorded the verified Project-scoped owner result.",
+      }],
+      assignmentSummary: assignmentSummary(),
+    }));
+
+    const invocation = spawnSync(process.execPath, [
+      path.resolve("scripts/harness-analysis/record-fix-output.mjs"),
+      "--workspace", workspace,
+      "--findings", findingsPath,
+      "--finding-id", finding.id,
+      "--expected-revision", "0",
+      "--result", resultPath,
+      "--json",
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, HOME: unavailableHome, USERPROFILE: unavailableHome },
+    });
+
+    assert.equal(invocation.status, 0, invocation.stderr);
+    const result = JSON.parse(invocation.stdout);
+    assert.equal(result.kind, "harness-fix-output-record");
+    assert.equal(result.status, "pass");
+    assert.equal(result.findingsPath, findingsPath);
+    assert.equal(result.findingId, finding.id);
+    assert.equal(result.revision, 1);
+    assert.equal(result.actualOutputCount, 1);
+  });
+});
+
+test("record-fix-output resolves Home only for Global actualOutput", async () => {
+  await withTempDir(async (root) => {
+    const prepareGlobalFixture = async (name) => {
+      const workspace = path.join(root, name, "workspace");
+      const runDir = path.join(workspace, ".Qoder", "better-harness", "run");
+      const findingsPath = path.join(runDir, "findings.json");
+      const resultPath = path.join(root, name, "result.json");
+      const split = splitTaskLoopFindings(projectTaskLoopFindings(reportSource()));
+      const finding = split.findings.findings[0];
+      await mkdir(runDir, { recursive: true });
+      await writeFile(findingsPath, `${JSON.stringify(split.findings, null, 2)}\n`);
+      await writeFile(path.join(runDir, "canvas.json"), `${JSON.stringify(split.canvas, null, 2)}\n`);
+      await writeFile(resultPath, JSON.stringify({
+        actualOutput: [{
+          action: "updated",
+          artifact: finding.expectedArtifact,
+          name: `${finding.expectedArtifact} global owner`,
+          scope: "Global",
+          path: "~/global-owner.md",
+          summary: "Recorded the verified Global-scoped owner result.",
+        }],
+        assignmentSummary: assignmentSummary(),
+      }));
+      return { workspace, findingsPath, resultPath, finding };
+    };
+    const invoke = (fixture, home) => spawnSync(process.execPath, [
+      path.resolve("scripts/harness-analysis/record-fix-output.mjs"),
+      "--workspace", fixture.workspace,
+      "--findings", fixture.findingsPath,
+      "--finding-id", fixture.finding.id,
+      "--expected-revision", "0",
+      "--result", fixture.resultPath,
+      "--json",
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+
+    const fakeHome = path.join(root, "fake-home");
+    await mkdir(fakeHome, { recursive: true });
+    await writeFile(path.join(fakeHome, "global-owner.md"), "# Global owner\n");
+    const successful = await prepareGlobalFixture("success");
+    const successfulInvocation = invoke(successful, fakeHome);
+    assert.equal(successfulInvocation.status, 0, successfulInvocation.stderr);
+    assert.equal(JSON.parse(successfulInvocation.stdout).status, "pass");
+    assert.equal(JSON.parse(await readFile(successful.findingsPath, "utf8")).findings[0].actualOutputRevision, 1);
+
+    const unavailable = await prepareGlobalFixture("unavailable");
+    const before = await readFile(unavailable.findingsPath, "utf8");
+    const unavailableInvocation = invoke(unavailable, path.join(root, "unavailable-home"));
+    assert.equal(unavailableInvocation.status, 1);
+    assert.equal(unavailableInvocation.stderr, "");
+    const error = JSON.parse(unavailableInvocation.stdout);
+    assert.equal(error.kind, "harness-fix-output-record");
+    assert.equal(error.status, "error");
+    assert.match(error.message, /ENOENT|no such file|realpath/u);
+    assert.equal(await readFile(unavailable.findingsPath, "utf8"), before);
+  });
+});
+
 test("record-fix-output keeps JSON failures machine-readable", () => {
   const result = spawnSync(process.execPath, [
     path.resolve("scripts/better-harness.mjs"),


### PR DESCRIPTION
## Summary

Resolve Home only when validating a Global output target, so verified Project-only results remain recordable when the process Home directory is unavailable. Existing file and scope-containment checks remain unchanged.

## Why

- Issue/Story: No issue. GitHub issue creation is restricted for this repository; this is focused compatibility maintenance discovered while validating Project-scoped output recording.
- User or maintainer outcome: Project output validation no longer fails because of unrelated Global/Home state in restricted environments.

## Traceability and Scope

- Spec/ADR, if applicable: `docs/specs/2026-07-30-project-output-home-resolution.md`
- Acceptance criteria addressed: AC-1 (Project-only output avoids Home), AC-2 (Global output resolves Home on demand), AC-3 (existing-file and workspace-containment guards remain in force).
- Canonical owners changed: `scripts/harness-analysis/record-fix-output.mjs`, `test/task-loop-report.test.mjs`, the behavior spec, and `CHANGELOG.md`.
- Explicit non-goals: No schema, CLI, result-consumption, or containment-policy changes; no test-only production API parameters.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `node --test --test-name-pattern="record-fix-output" test/task-loop-report.test.mjs` | Passed 10/10 |
| `node --test test/task-loop-report.test.mjs` | Passed 76/76 |
| `node --test test/doc-link-graph.test.mjs` | Passed 6/6 |
| `npm test` | Exited 0; retained the existing Windows symlink-permission skip |
| `npm run pack:verify` | Passed using an isolated temporary npm cache |
| `git diff --check origin/main..HEAD` | Passed |

Manual or visual evidence: Temporarily restoring eager Home resolution made the new Project-only child-process regression fail with exit code 1. With this change, the Project-only case succeeds, while an unavailable Home still fails for Global output without modifying the report.

## Risk and Recovery

- Compatibility and cross-platform impact: The change only defers `os.homedir()`/`realpath()` until a Global target is encountered. Existing canonical-path containment and file-existence checks are unchanged. Windows was tested locally; CI should confirm macOS and Linux.
- Package, plugin, schema, or generated-file impact: None. No dependency, schema, or generated routing changes; the observable compatibility change is recorded in `CHANGELOG.md`.
- Rollback or recovery path: Revert commit `0df03e7`.
- Residual risk or unverified boundary: Local Node `v22.17.0` and npm `10.9.2` are below the repository minimums, so CI must confirm the supported runtime matrix. Open PR #21 touches the same validation area and may require a rebase if it lands first.

## AI Involvement

- Level: Assisted (Codex).
- Human review and validation: UIOSUN selected the contribution scope, verified the GitHub identity/fork and isolated-branch strategy, and reviewed the recorded local reproduction and test evidence.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [x] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [x] I have the right to contribute this work under the repository's MIT License.