### PR TITLE
fix(adapters): stop guessing Cursor plugin IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ observable behavior and compatibility, not every internal refactor.
 
 ### Changed
 
+- Cursor installed-plugin inventory now leaves unknown numeric or opaque IDs
+  unmatched instead of assigning them to cached plugins by name/order. Direct
+  manifest IDs and workspace project MCP hints remain supported.
 - `harness record-fix-output` now resolves Home only for Global output, so a
   verified Project-only result remains recordable when Home is unavailable.
 - The `harness analyze` platform gate now names the full supported set

--- a/docs/specs/2026-07-30-u-01-cursor-plugin-id-matching.md
+++ b/docs/specs/2026-07-30-u-01-cursor-plugin-id-matching.md
@@ -1,0 +1,113 @@
+# Fail closed for unknown Cursor plugin IDs
+
+## Traceability
+
+- Spec ID: U-01
+- Story: roadmap.md TODO U-01
+- Status: Implemented
+
+## Intent
+
+Prevent Cursor installed-plugin records with unknown numeric or opaque IDs from
+being assigned to unrelated cached plugins. Installed status must come only from
+direct plugin-manifest IDs or workspace-bound project MCP evidence, so cache
+enumeration and display-name order cannot change which plugin is reported as
+installed.
+
+## Acceptance Scenarios
+
+- **U01-AC-1 (unknown IDs fail closed):** Given one or more installed-plugin
+  records whose IDs match neither a cached plugin's `cursorPluginId` nor a
+  project MCP hint, the inventory reports no cached plugin as installed and
+  lists every unknown record ID in `unmatchedInstalledPluginIds`.
+- **U01-AC-2 (order invariance):** Reordering cache candidates without reliable
+  IDs does not change the installed-plugin inventory or attach an unknown
+  record's sources, scope, or install metadata to any candidate.
+- **U01-AC-3 (direct ID evidence):** A record that directly equals a cached
+  plugin's `cursorPluginId` remains installed with `installMatch: "id"` and
+  preserves install-record order.
+- **U01-AC-4 (project MCP evidence):** A record mapped by a workspace-bound MCP
+  tool snapshot remains installed with `installMatch: "project-mcp"`.
+- **U01-AC-5 (diagnostic compatibility):** Existing diagnostic field names
+  remain available. `installedPluginFallbackCount` remains numeric and is zero
+  because cache fallback assignment is no longer allowed; the matching summary
+  clearly distinguishes fully matched records from records left unknown.
+
+## Non-goals
+
+- Change Cursor capability declarations, session evidence, checkup behavior, or
+  report routing.
+- Infer plugin identity from cache order, display name, cache path position, or
+  numeric-ID shape.
+- Add new Cursor data sources or decode undocumented state.
+- Change roadmap items other than U-01 or broaden another Cursor capability
+  claim.
+
+## Plan and Tasks
+
+1. Add focused provider regressions for unknown IDs and cache-order invariance,
+   while retaining direct-ID and project-MCP positive coverage.
+2. Run the focused regression against the pre-fix provider and record that the
+   cache fallback behavior fails the new assertions.
+3. Remove cache-order fallback assignment from
+   `scripts/agent-customize/providers/cursor.mjs`; preserve existing diagnostic
+   keys and report unmatched records explicitly.
+4. Update the Unreleased changelog entry because installed-plugin inventory is
+   observable provider behavior.
+5. Mark roadmap U-01 complete and align its Cursor inventory description with
+   the implemented evidence boundary.
+6. Run focused provider tests, documentation link integrity, full tests,
+   package verification, and whitespace checks. Record any environment-specific
+   limitation without weakening the acceptance criteria.
+
+## Test and Review Evidence
+
+- **U01-AC-1/U01-AC-2:** focused assertions in
+  `test/agent-customize.test.mjs` use plugins without manifest IDs and compare
+  inventories across reversed cache names/order. Before implementation these
+  must fail by exposing `cache-fallback` assignments.
+- **U01-AC-3:** the existing direct-ID install-order test must continue to pass.
+- **U01-AC-4:** the existing project MCP numeric-ID hint test must continue to
+  pass.
+- **U01-AC-5:** focused assertions verify a zero fallback count, preserved
+  unmatched IDs, and diagnostic text that says unknown records remained
+  unmatched.
+- Provider gate: `node --test test/agent-customize.test.mjs`.
+- Documentation gate: regenerate the routing graph with
+  `node scripts/doc-link-graph/cli.mjs skills/better-harness`, then run
+  `node --test test/doc-link-graph.test.mjs`.
+- Regression gates: `npm test`, `npm run pack:verify`, and `git diff --check`.
+- Primary risk: downstream consumers may have treated heuristic plugin entries
+  as installed. The safe compatibility boundary keeps diagnostic keys and
+  direct/hinted matches intact while deliberately removing unproven entries.
+- Review readiness must confirm the diff is limited to the Cursor provider,
+  focused tests, this spec, U-01 roadmap declarations, generated documentation
+  routing if changed, and the changelog.
+
+### Observed Evidence (2026-07-30)
+
+- Pre-fix regression: the two new focused tests failed 0/2. The old provider
+  assigned ID `9001` to `Future Tool` and assigned two unknown records to cache
+  candidates including `Alpha Without Id` and `Hex`.
+- Provider plus architecture gate:
+  `node --test test/agent-customize.test.mjs
+  test/agent-customize-architecture.test.mjs` passed 33/33 after rebasing
+  onto `origin/main` at `686e1aa`, including direct-ID, project-MCP,
+  unknown-ID, and cache-order cases.
+- Documentation gate: the graph generator reported 34 files and 50 links; the
+  generated graph had no semantic diff because this spec is not in the
+  `skills/better-harness` routing chain. The doc-link suite passed 6/6.
+- Full regression: `npm test` ran 980 tests: 973 passed, 4 failed, and 3 were
+  skipped. The four failures are environment-specific Windows `EPERM`
+  failures while creating symlinks in
+  `test/core-change-watch-scope.test.mjs`,
+  `test/harness-report-render-cli.test.mjs`, and
+  `test/workspace-topology.test.mjs`; a focused rerun reproduced the same four
+  failures without any Cursor provider failure.
+- Package gate: `npm --cache .npm-cache run pack:verify` passed with 333 npm
+  entries and 356 runtime ZIP entries. The temporary cache was removed
+  afterward.
+- Environment limitation: Node `v22.17.0` and npm `10.9.2` are below the
+  repository minimums of Node `22.20.0` and npm `10.9.3`.
+- `git diff --check` passed before this evidence update and is rerun during the
+  final readiness check.

--- a/roadmap.md
+++ b/roadmap.md
@@ -14,7 +14,7 @@ Legend: **Yes** = implemented and tested; **Partial** = limited or source-local;
 | --- | --- | --- | --- | --- |
 | Host shell | Yes | Yes | Yes | Yes |
 | Installation / distribution | Yes: built-in + npm bundle | Partial: source-local artifact | Partial: source-local plugin | Partial: repository marketplace |
-| Configured asset inventory | Yes | Yes | Partial: plugin ID fallback is heuristic | No unified provider |
+| Configured asset inventory | Yes | Yes | Partial: direct IDs and project MCP hints only; unknown IDs remain unmatched | No unified provider |
 | Session evidence | Yes | Yes | No | No |
 | Hook runtime evidence | Yes | Partial: hook facets are empty | No | No |
 | Model / token evidence | Yes | Partial: model facets are empty | No | No |
@@ -51,7 +51,7 @@ platform depth.
 | [ ] | P1 | C-02 | Normalize Codex model, usage, and hook evidence when present. | Missing data stays unavailable; no model, token, or hook values are invented. |
 | [ ] | P1 | C-03 | Add a real Codex installation smoke. | Build, install, discover Skills, analyze, render HTML, validate, and reinstall all pass. |
 | [ ] | P1 | C-04 | Decide whether Codex apply remains read-only. | Automatic apply is added only after an accepted provider-native mutation contract. |
-| [ ] | P2 | U-01 | Remove deterministic Cursor plugin assignment by cache order. | Unmatched numeric IDs remain unknown instead of being attached to the wrong plugin. |
+| [x] | P2 | U-01 | Remove deterministic Cursor plugin assignment by cache order. | Unmatched numeric IDs remain unknown instead of being attached to the wrong plugin. |
 | [ ] | P2 | U-02 | Add Cursor inventory-only checkup. | Results are configured-only and cleanup/apply remains blocked. |
 | [ ] | P2 | U-03 | Add a Cursor static-only Harness report route. | HTML/Markdown output passes validation and clearly marks session evidence unavailable. |
 | [ ] | P2 | U-04 | Add a Cursor artifact and runtime smoke. | A packaged plugin works with `cursor-agent --plugin-dir` without source-tree assumptions. |

--- a/scripts/agent-customize/providers/cursor.mjs
+++ b/scripts/agent-customize/providers/cursor.mjs
@@ -215,14 +215,6 @@ function installSourcesForRecord(record) {
 }
 
 function attachInstallRecord(plugin, record, matchKind, installOrder) {
-  if (matchKind === "cache-fallback") {
-    return {
-      ...plugin,
-      installSources: installSourcesForRecord(record),
-      installSource: record.source,
-      installMatch: matchKind,
-    };
-  }
   return {
     ...plugin,
     cursorPluginId: plugin.cursorPluginId ?? record.id,
@@ -270,8 +262,6 @@ function filterInstalledPlugins(plugins, installState, pluginIdHints) {
   const pluginById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
   const included = new Map();
   const matchedRecordIds = new Set();
-  const unmatchedRecords = [];
-  let fallbackCount = 0;
 
   records.forEach((record, installOrder) => {
     const match = matchInstallRecord(record, plugins, pluginById, pluginIdHints);
@@ -280,29 +270,11 @@ function filterInstalledPlugins(plugins, installState, pluginIdHints) {
       matchedRecordIds.add(record.id);
       return;
     }
-    unmatchedRecords.push({ record, installOrder });
   });
 
-  const remainingSlots = records.length - included.size;
-  if (remainingSlots > 0) {
-    const fallbackCandidates = plugins
-      .filter((plugin) => !included.has(plugin.id) && !plugin.hasCursorMarketplaceManifest)
-      .sort(sortByName)
-      .slice(0, remainingSlots);
-    for (const [index, plugin] of fallbackCandidates.entries()) {
-      const unmatched = unmatchedRecords[index];
-      fallbackCount += 1;
-      included.set(
-        plugin.id,
-        attachInstallRecord(
-          plugin,
-          unmatched?.record ?? { id: plugin.cursorPluginId ?? plugin.id, sources: ["user"] },
-          "cache-fallback",
-          unmatched?.installOrder,
-        ),
-      );
-    }
-  }
+  const unmatchedInstalledPluginIds = records
+    .filter((record) => !matchedRecordIds.has(record.id))
+    .map((record) => record.id);
 
   return {
     plugins: [...included.values()].sort(sortByInstallOrder),
@@ -310,12 +282,10 @@ function filterInstalledPlugins(plugins, installState, pluginIdHints) {
       installedPluginState: installState.source,
       installedPluginStorageKey: installState.storageKey,
       installedPluginRecordCount: records.length,
-      installedPluginFallbackCount: fallbackCount,
-      unmatchedInstalledPluginIds: records
-        .filter((record) => !matchedRecordIds.has(record.id))
-        .map((record) => record.id),
-      installedPluginMatching: fallbackCount > 0
-        ? "numeric plugin IDs without local manifests were matched by cache fallback order"
+      installedPluginFallbackCount: 0,
+      unmatchedInstalledPluginIds,
+      installedPluginMatching: unmatchedInstalledPluginIds.length > 0
+        ? "only direct plugin IDs and project MCP hints were matched; unknown installed plugin records remained unmatched"
         : "local evidence matched all installed plugin records",
     },
   };

--- a/test/agent-customize.test.mjs
+++ b/test/agent-customize.test.mjs
@@ -1022,7 +1022,7 @@ test("project MCP tool snapshots map numeric plugin ids when local evidence exis
   }
 });
 
-test("unproven numeric plugin ids use cache fallback with diagnostics", async () => {
+test("unproven numeric plugin ids remain unmatched with diagnostics", async () => {
   const fixture = await makeCursorFixture();
 
   try {
@@ -1047,17 +1047,68 @@ test("unproven numeric plugin ids use cache fallback with diagnostics", async ()
 
     assert.deepEqual(
       inventory.plugins.map((plugin) => plugin.displayName),
-      ["Future Tool"],
+      [],
     );
-    assert.deepEqual(
-      inventory.plugins.map((plugin) => plugin.installMatch),
-      ["cache-fallback"],
-    );
-    assert.equal(inventory.plugins[0].cursorPluginId, undefined);
-    assert.equal(inventory.plugins[0].installedPluginRecordId, undefined);
-    assert.equal(inventory.plugins[0].installOrder, undefined);
-    assert.equal(inventory.diagnostics.installedPluginFallbackCount, 1);
+    assert.equal(inventory.diagnostics.installedPluginFallbackCount, 0);
     assert.deepEqual(inventory.diagnostics.unmatchedInstalledPluginIds, ["9001"]);
+    assert.match(inventory.diagnostics.installedPluginMatching, /remained unmatched/u);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("unknown Cursor plugin ids are invariant to cache candidate order", async () => {
+  const fixture = await makeCursorFixture();
+
+  try {
+    const cacheRoot = path.join(fixture.cursorHome, "plugins", "cache", "cursor-public");
+    const candidates = [
+      ["alpha-without-id", "aaa111"],
+      ["zulu-without-id", "zzz999"],
+    ];
+    for (const [pluginName, revision] of candidates) {
+      await writeJson(path.join(cacheRoot, pluginName, revision, ".cursor-plugin", "plugin.json"), {
+        name: pluginName,
+        displayName: pluginName,
+        description: `${pluginName} plugin`,
+      });
+    }
+
+    const records = [
+      { id: "9001", sources: ["user"] },
+      { id: "opaque-install-record", sources: ["project"] },
+    ];
+    const first = await collectAgentCustomizeInventory({
+      cursorHome: fixture.cursorHome,
+      workspace: fixture.workspace,
+      installedPluginRecords: records,
+    });
+
+    for (const [index, [pluginName, revision]] of candidates.entries()) {
+      await writeJson(path.join(cacheRoot, pluginName, revision, ".cursor-plugin", "plugin.json"), {
+        name: pluginName,
+        displayName: candidates.at(-(index + 1))[0],
+        description: `${pluginName} plugin`,
+      });
+    }
+    const reordered = await collectAgentCustomizeInventory({
+      cursorHome: fixture.cursorHome,
+      workspace: fixture.workspace,
+      installedPluginRecords: records,
+    });
+
+    assert.deepEqual(first.plugins, []);
+    assert.deepEqual(reordered.plugins, []);
+    assert.deepEqual(first.diagnostics.unmatchedInstalledPluginIds, [
+      "9001",
+      "opaque-install-record",
+    ]);
+    assert.deepEqual(reordered.diagnostics.unmatchedInstalledPluginIds, [
+      "9001",
+      "opaque-install-record",
+    ]);
+    assert.equal(first.diagnostics.installedPluginFallbackCount, 0);
+    assert.equal(reordered.diagnostics.installedPluginFallbackCount, 0);
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Stop assigning unknown numeric or opaque Cursor install-record IDs to cached plugins by name/order.
- Keep only evidence-backed matches: direct `cursorPluginId` matches and workspace project-MCP hints.
- Preserve unknown record IDs in diagnostics instead of reporting an unrelated plugin as installed.

## Why

- Issue/Story: `roadmap.md` U-01.
- User or maintainer outcome: Cursor inventory is stable across cache ordering and no longer produces false installed-plugin attribution from undocumented IDs.

## Traceability and Scope

- Spec/ADR: `docs/specs/2026-07-30-u-01-cursor-plugin-id-matching.md`
- Acceptance criteria addressed: U01-AC-1 through U01-AC-5.
- Canonical owners changed: Cursor provider, its focused tests, roadmap, changelog, and the U-01 spec.
- Explicit non-goals: no new Cursor data source, no decoding of undocumented state, and no changes to session/checkup/report routing.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| Pre-fix focused regression | 0/2 as expected: ID `9001` was assigned to `Future Tool`, and cache order changed attribution |
| `node --test test/agent-customize.test.mjs test/agent-customize-architecture.test.mjs` | 33/33 passed |
| `node --test test/doc-link-graph.test.mjs` | 6/6 passed |
| `npm --cache .npm-cache run pack:verify` | Passed: 333 npm entries, 356 runtime ZIP entries |
| `git diff --check origin/main..HEAD` | Passed |
| `npm test` | 980 total: 973 passed, 3 skipped, 4 Windows symlink-permission failures; no Cursor-provider failure |

Manual or visual evidence: the pre-fix provider attached unknown IDs by cache order; the fixed inventory returns no plugin for those records and reports the unknown IDs in `unmatchedInstalledPluginIds`. A focused rerun confirmed all four full-suite failures are `EPERM` while creating symlinks in unrelated scope/render/topology tests.

## Risk and Recovery

- Compatibility and cross-platform impact: inventories may contain fewer installed plugins when Cursor exposes an ID that cannot be proven locally; this is the intended fail-closed behavior. Direct-ID and project-MCP matches remain covered.
- Package, plugin, schema, or generated-file impact: no dependency, schema, or generated-file changes; existing diagnostic keys remain present and `installedPluginFallbackCount` remains numeric at zero.
- Rollback or recovery path: revert commit `2d5a966a9a60718ae4dd5c3843cf4435d54a6f45`.
- Residual risk or unverified boundary: local Node `v22.17.0` and npm `10.9.2` are below the repository minimums; CI should confirm on the supported toolchain and a symlink-capable host.

## AI Involvement

- Level: Assisted (Codex, GPT 5.6 Sol).
- Human review and validation: the contributor approved the scoped problem and test strategy; Codex inspected the final diff and ran the recorded automated gates.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [x] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [x] I have the right to contribute this work under the repository's MIT License.