### PR TITLE
fix(templates): route WorkBuddy to the portable HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ observable behavior and compatibility, not every internal refactor.
 
 ## Unreleased
 
+### Fixed
+
+- The Portable HTML report route in `templates/reporting/routing.md` now
+  lists WorkBuddy, so agents on WorkBuddy are routed to the self-contained
+  HTML + Markdown output the 0.4.0 host adapter already ships. A derived
+  support-declaration check now requires every adapter-matrix host claiming
+  portable HTML output to appear in that routing row.
+
 ## 0.4.0 - 2026-07-30
 
 ### Added

--- a/docs/specs/2026-07-30-routing-workbuddy-host.md
+++ b/docs/specs/2026-07-30-routing-workbuddy-host.md
@@ -1,0 +1,72 @@
+# Report Routing WorkBuddy Host Gap
+
+Add WorkBuddy to the Portable HTML report route in
+`templates/reporting/routing.md` and add a derived consistency test so a
+future host with portable HTML output cannot be omitted from report routing
+again.
+
+## Traceability
+
+- Spec ID: 2026-07-30-routing-workbuddy-host
+- Story: follow-up to the WorkBuddy host adapter (`4b871d9`,
+  CHANGELOG 0.4.0)
+- Status: Implemented
+
+## Intent
+
+The WorkBuddy host adapter shipped with a `self-contained HTML + Markdown`
+Default Output claim in the [Host Adapter Matrix](../adapters/README.md), and
+the matrix Output Modes section, the docs site (English and zh-Hans), and
+CHANGELOG 0.4.0 all state that WorkBuddy portable HTML routing is
+implemented. However, the Portable HTML report route in
+[`templates/reporting/routing.md`](../../templates/reporting/routing.md)
+still lists only "Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, or
+Pi". Because `routing.md` is the routing switchboard agents load through
+`SKILL.md`, an agent running on WorkBuddy is never routed to the portable
+HTML report.
+
+The omission survived because the two guarding assertions
+(`test/better-harness-skill.test.mjs`, `test/style-templates.test.mjs`)
+hard-code the host list, and the A-06 support-declaration consistency tests
+(`test/support-declarations.test.mjs`) never compare the adapter matrix
+against `routing.md`.
+
+## Acceptance Scenarios
+
+- AC-1: The Portable HTML report row in `templates/reporting/routing.md`
+  lists WorkBuddy alongside the existing hosts; no other route changes.
+- AC-2: The hard-coded routing assertions in
+  `test/better-harness-skill.test.mjs` and `test/style-templates.test.mjs`
+  match the updated host list.
+- AC-3: `test/support-declarations.test.mjs` gains a derived check: every
+  adapter-matrix host whose Default Output cell claims
+  `self-contained HTML + Markdown` must appear in the Portable HTML report
+  route of `routing.md`. The check is one-directional so a host may be
+  removed from the matrix claim first (as the in-flight A-05 change does for
+  Cursor) without breaking routing.
+- AC-4: `npm test` passes; `node --test test/doc-link-graph.test.mjs` passes
+  with this spec's links resolving.
+
+## Non-Goals
+
+- No change to the Cursor entries in `routing.md` or the adapter matrix; the
+  Cursor durable-report gap stays tracked by the in-flight A-05 pull request
+  and roadmap item HA-03.
+- No new WorkBuddy capability, output mode, or renderer change; this only
+  routes the already-shipped portable HTML output.
+
+## Plan
+
+1. Add WorkBuddy to the Portable HTML report row in
+   `templates/reporting/routing.md`.
+2. Update the two hard-coded host-list assertions to match.
+3. Add the derived matrix-to-routing consistency test to
+   `test/support-declarations.test.mjs`.
+
+## Test Evidence
+
+- `node --test test/support-declarations.test.mjs`
+- `node --test test/better-harness-skill.test.mjs`
+- `node --test test/style-templates.test.mjs`
+- `node --test test/doc-link-graph.test.mjs`
+- Full suite: `npm test`

--- a/docs/specs/2026-07-30-routing-workbuddy-host.md
+++ b/docs/specs/2026-07-30-routing-workbuddy-host.md
@@ -40,10 +40,11 @@ against `routing.md`.
   match the updated host list.
 - AC-3: `test/support-declarations.test.mjs` gains a derived check: every
   adapter-matrix host whose Default Output cell claims
-  `self-contained HTML + Markdown` must appear in the Portable HTML report
-  route of `routing.md`. The check is one-directional so a host may be
-  removed from the matrix claim first (as the in-flight A-05 change does for
-  Cursor) without breaking routing.
+  `self-contained HTML + Markdown` must appear as an exact host entry in the
+  Portable HTML report route of `routing.md`. A prefix collision such as
+  `WorkBuddy` versus `WorkBuddy Enterprise` must fail. The check is
+  one-directional so a host may be removed from the matrix claim first (as the
+  in-flight A-05 change does for Cursor) without breaking routing.
 - AC-4: `npm test` passes; `node --test test/doc-link-graph.test.mjs` passes
   with this spec's links resolving.
 
@@ -61,11 +62,14 @@ against `routing.md`.
    `templates/reporting/routing.md`.
 2. Update the two hard-coded host-list assertions to match.
 3. Add the derived matrix-to-routing consistency test to
-   `test/support-declarations.test.mjs`.
+   `test/support-declarations.test.mjs`, parsing the route declaration into
+   normalized host entries and covering a host-prefix collision.
 
 ## Test Evidence
 
 - `node --test test/support-declarations.test.mjs`
+- Mutation regression: replacing the exact `WorkBuddy` route entry with
+  `WorkBuddy Enterprise` must report WorkBuddy as missing.
 - `node --test test/better-harness-skill.test.mjs`
 - `node --test test/style-templates.test.mjs`
 - `node --test test/doc-link-graph.test.mjs`

--- a/templates/reporting/routing.md
+++ b/templates/reporting/routing.md
@@ -28,6 +28,6 @@ files from other routes.
 | Route | Use when | Artifacts | Runtime owner |
 | --- | --- | --- | --- |
 | Qoder Canvas report | Active host is Qoder | renderer-owned `findings.json`, `canvas.json`, `report.canvas.tsx` | `qoder-canvas.md` |
-| Portable HTML report | Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, or Pi, or a portable visual is explicitly requested | renderer-owned `findings.json`, `report.md`, `report.html` | `html-visual.md` |
+| Portable HTML report | Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy, or a portable visual is explicitly requested | renderer-owned `findings.json`, `report.md`, `report.html` | `html-visual.md` |
 | Markdown only | Markdown without a visual companion is explicitly requested | `report.md`, `findings.json` | none |
 | Inline only | Inline or no-files output is explicitly requested | none; inline analysis writes nothing | none |

--- a/test/better-harness-skill.test.mjs
+++ b/test/better-harness-skill.test.mjs
@@ -77,7 +77,7 @@ test("non-Qoder providers default to validated durable HTML with an explicit inl
   assert.match(skill, /HTML artifacts: findings\.json, report\.md, report\.html/);
   assert.match(skill, /Succeed only on\s+`status: pass`/);
   assert.match(skill, /Never hand-write\s+Canvas, Markdown, or HTML/);
-  assert.match(routing, /Portable HTML report \| Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, or Pi/);
+  assert.match(routing, /Portable HTML report \| Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy/);
   assert.match(routing, /Inline only \| Inline or no-files output is explicitly requested \| none; inline analysis writes nothing/);
   assert.match(adapters, /Claude Code[^\n]+scripts\/session-analysis\/platforms\/claude\.mjs[^\n]+self-contained HTML \+ Markdown/);
   assert.match(adapters, /Cursor[^\n]+scripts\/session-analysis\/platforms\/cursor\.mjs[^\n]+self-contained HTML \+ Markdown/);

--- a/test/better-harness-skill.test.mjs
+++ b/test/better-harness-skill.test.mjs
@@ -77,7 +77,10 @@ test("non-Qoder providers default to validated durable HTML with an explicit inl
   assert.match(skill, /HTML artifacts: findings\.json, report\.md, report\.html/);
   assert.match(skill, /Succeed only on\s+`status: pass`/);
   assert.match(skill, /Never hand-write\s+Canvas, Markdown, or HTML/);
-  assert.match(routing, /Portable HTML report \| Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy/);
+  assert.match(
+    routing,
+    /Portable HTML report \| Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy, or a portable visual is explicitly requested \|/,
+  );
   assert.match(routing, /Inline only \| Inline or no-files output is explicitly requested \| none; inline analysis writes nothing/);
   assert.match(adapters, /Claude Code[^\n]+scripts\/session-analysis\/platforms\/claude\.mjs[^\n]+self-contained HTML \+ Markdown/);
   assert.match(adapters, /Cursor[^\n]+scripts\/session-analysis\/platforms\/cursor\.mjs[^\n]+self-contained HTML \+ Markdown/);

--- a/test/style-templates.test.mjs
+++ b/test/style-templates.test.mjs
@@ -75,7 +75,7 @@ test("harness report routing owns output-mode selection and exclusions", () => {
   assert.match(reportRouting, /Choose exactly one output route/);
   assert.match(reportRouting, /Qoder Canvas report/);
   assert.match(reportRouting, /Portable HTML report/);
-  assert.match(reportRouting, /Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, or Pi/);
+  assert.match(reportRouting, /Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy/);
   assert.match(reportRouting, /Markdown only/);
   assert.match(reportRouting, /Inline only/);
   assert.match(reportRouting, /inline analysis writes nothing/);

--- a/test/style-templates.test.mjs
+++ b/test/style-templates.test.mjs
@@ -75,7 +75,10 @@ test("harness report routing owns output-mode selection and exclusions", () => {
   assert.match(reportRouting, /Choose exactly one output route/);
   assert.match(reportRouting, /Qoder Canvas report/);
   assert.match(reportRouting, /Portable HTML report/);
-  assert.match(reportRouting, /Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy/);
+  assert.match(
+    reportRouting,
+    /Active host is Claude Code, Codex, Cursor, Qwen Code, GitHub Copilot, Pi, or WorkBuddy, or a portable visual is explicitly requested \|/,
+  );
   assert.match(reportRouting, /Markdown only/);
   assert.match(reportRouting, /Inline only/);
   assert.match(reportRouting, /inline analysis writes nothing/);

--- a/test/support-declarations.test.mjs
+++ b/test/support-declarations.test.mjs
@@ -13,6 +13,7 @@ const SUPPORTED_PLATFORMS = ["qoder", "codex", "claude", "cursor", "qwen", "copi
 
 const cliPath = path.join(process.cwd(), "scripts", "better-harness.mjs");
 const adapterMatrixPath = path.join(process.cwd(), "docs", "adapters", "README.md");
+const reportRoutingPath = path.join(process.cwd(), "templates", "reporting", "routing.md");
 
 function runBetterHarness(args) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -118,4 +119,25 @@ test("host adapter matrix documents exactly the supported platforms", () => {
   const documentedPlatforms = [...matrix.matchAll(/session-analysis\/platforms\/([a-z-]+)\.mjs/gu)].map((match) => match[1]);
   assertSameSet(documentedProviders, "adapter matrix configured-asset providers");
   assertSameSet(documentedPlatforms, "adapter matrix session platforms");
+});
+
+test("adapter-matrix portable HTML hosts appear in the portable HTML report route", () => {
+  const matrix = readFileSync(adapterMatrixPath, "utf8");
+  const routing = readFileSync(reportRoutingPath, "utf8");
+
+  // Hosts whose matrix Default Output cell claims the portable HTML pipeline.
+  // One-directional on purpose: a host may drop the matrix claim first (for
+  // example a pending durable-report gap) without breaking report routing.
+  const htmlHosts = matrix
+    .split("\n")
+    .map((line) => line.split("|").map((cell) => cell.trim()))
+    .filter((cells) => cells[6] === "self-contained HTML + Markdown")
+    .map((cells) => cells[1]);
+  assert.ok(htmlHosts.length > 0, "adapter matrix declares no self-contained HTML + Markdown hosts");
+
+  const routeHosts = routing.match(/\| Portable HTML report \| Active host is ([^|]+)\|/u)?.[1];
+  assert.ok(routeHosts, "reporting/routing.md does not declare a Portable HTML report route");
+  for (const host of htmlHosts) {
+    assert.ok(routeHosts.includes(host), `Portable HTML report route is missing matrix HTML host: ${host}`);
+  }
 });

--- a/test/support-declarations.test.mjs
+++ b/test/support-declarations.test.mjs
@@ -30,6 +30,29 @@ function assertSameSet(actual, label) {
   assert.deepEqual(sortedSet(actual), sortedSet(SUPPORTED_PLATFORMS), `${label} disagrees with the supported platform set`);
 }
 
+function portableHtmlMatrixHosts(matrix) {
+  return matrix
+    .split("\n")
+    .map((line) => line.split("|").map((cell) => cell.trim()))
+    .filter((cells) => cells[6] === "self-contained HTML + Markdown")
+    .map((cells) => cells[1]);
+}
+
+function portableHtmlRouteHosts(routing) {
+  const declaration = routing.match(
+    /\| Portable HTML report \| Active host is (.+?), or a portable visual is explicitly requested \|/u,
+  )?.[1];
+  assert.ok(declaration, "reporting/routing.md does not declare a Portable HTML report route");
+  return new Set(declaration.split(/,\s*(?:or\s+)?/u).map((host) => host.trim()));
+}
+
+function missingPortableHtmlRouteHosts(matrix, routing) {
+  const htmlHosts = portableHtmlMatrixHosts(matrix);
+  assert.ok(htmlHosts.length > 0, "adapter matrix declares no self-contained HTML + Markdown hosts");
+  const routeHosts = portableHtmlRouteHosts(routing);
+  return htmlHosts.filter((host) => !routeHosts.has(host));
+}
+
 test("agent-customize provider registry declares exactly the supported platforms", () => {
   assertSameSet([...PROVIDER_COLLECTORS.keys()], "PROVIDER_COLLECTORS");
 
@@ -128,16 +151,14 @@ test("adapter-matrix portable HTML hosts appear in the portable HTML report rout
   // Hosts whose matrix Default Output cell claims the portable HTML pipeline.
   // One-directional on purpose: a host may drop the matrix claim first (for
   // example a pending durable-report gap) without breaking report routing.
-  const htmlHosts = matrix
-    .split("\n")
-    .map((line) => line.split("|").map((cell) => cell.trim()))
-    .filter((cells) => cells[6] === "self-contained HTML + Markdown")
-    .map((cells) => cells[1]);
-  assert.ok(htmlHosts.length > 0, "adapter matrix declares no self-contained HTML + Markdown hosts");
-
-  const routeHosts = routing.match(/\| Portable HTML report \| Active host is ([^|]+)\|/u)?.[1];
-  assert.ok(routeHosts, "reporting/routing.md does not declare a Portable HTML report route");
-  for (const host of htmlHosts) {
-    assert.ok(routeHosts.includes(host), `Portable HTML report route is missing matrix HTML host: ${host}`);
+  for (const host of missingPortableHtmlRouteHosts(matrix, routing)) {
+    assert.fail(`Portable HTML report route is missing matrix HTML host: ${host}`);
   }
+
+  const prefixCollisionRouting = routing.replace(
+    ", or WorkBuddy, or a portable visual is explicitly requested",
+    ", or WorkBuddy Enterprise, or a portable visual is explicitly requested",
+  );
+  assert.notEqual(prefixCollisionRouting, routing, "prefix-collision fixture did not replace the WorkBuddy route entry");
+  assert.deepEqual(missingPortableHtmlRouteHosts(matrix, prefixCollisionRouting), ["WorkBuddy"]);
 });


### PR DESCRIPTION
The WorkBuddy host adapter shipped claiming self-contained HTML + Markdown
output in the adapter matrix, docs site, and CHANGELOG 0.4.0, but
`templates/reporting/routing.md` never listed WorkBuddy in the Portable HTML
report route, so agents on WorkBuddy were never routed to the shipped output.

## Summary

Agents running on the WorkBuddy host are now routed to the shipped
self-contained HTML + Markdown report output. A new derived
support-declaration check makes it impossible to add a matrix host claiming
portable HTML output without listing it in the report routing row.

## Why

- Issue/Story: none; justified maintenance — follow-up to the WorkBuddy host
  adapter (`4b871d9`, CHANGELOG 0.4.0), which claims portable HTML routing
  is implemented while the routing switchboard never listed WorkBuddy.
- User or maintainer outcome: WorkBuddy users get the portable HTML report
  the matrix and docs already promise; maintainers get a consistency test
  that catches this class of omission for every future host.

## Traceability and Scope

- Spec/ADR, if applicable: `docs/specs/2026-07-30-routing-workbuddy-host.md`
- Acceptance criteria addressed: AC-1 (routing row lists WorkBuddy), AC-2
  (both hard-coded assertions updated), AC-3 (derived one-directional
  matrix-to-routing check), AC-4 (full suite and doc-link-graph pass)
- Canonical owners changed: `templates/reporting/routing.md` (report
  routing switchboard); guarding tests in `test/better-harness-skill.test.mjs`,
  `test/style-templates.test.mjs`, `test/support-declarations.test.mjs`;
  `CHANGELOG.md` Unreleased entry
- Explicit non-goals: no change to the Cursor entries (the Cursor
  durable-report gap stays tracked by the in-flight A-05 PR and roadmap
  HA-03); no new WorkBuddy capability, output mode, or renderer change

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| Red-green proof: `node --test test/support-declarations.test.mjs` with the old `routing.md` restored | Fails as intended: `Portable HTML report route is missing matrix HTML host: WorkBuddy` |
| `node --test test/support-declarations.test.mjs` (with fix) | 7/7 pass |
| Exact-entry regression (`WorkBuddy` vs `WorkBuddy Enterprise`) | Prefix collision correctly reports `WorkBuddy` as missing; focused routing/docs suite 31/31 pass |
| `node --test test/better-harness-skill.test.mjs` | 12/12 pass |
| `node --test test/style-templates.test.mjs` | pass |
| `node --test test/doc-link-graph.test.mjs` | pass; regenerating via `node scripts/doc-link-graph/cli.mjs skills/better-harness` produces zero diff |
| Full suite: `npm test` (Node 22.20.0 / npm 10.9.3) | 1019 pass / 0 fail (net +1 test) |
| `npm run pack:verify` | pack verification passed: npm 354 entries, runtime zip 377 entries |
| Merge preview vs in-flight A-05 branch: `git merge-tree` | 0 text conflicts; derived check verified to pass against the A-05 matrix (Cursor claim removed) because it is one-directional |

Manual or visual evidence: parsed host sets printed and inspected —
`htmlHosts` resolves to exactly the seven matrix hosts claiming
`self-contained HTML + Markdown` (Qoder's `better-harness` output correctly
excluded), and the routing row captures all of them.

## Risk and Recovery

- Compatibility and cross-platform impact: none; a one-line Markdown routing
  change plus test updates. No runtime code changed.
- Package, plugin, schema, or generated-file impact: `templates/` ships in
  the npm package, so the published routing table gains WorkBuddy;
  `npm run pack:verify` passes. No schema or generated files change;
  doc-link graph regenerated with zero diff.
- Rollback or recovery path: revert the three commits (`ef16c6b`, `55d44cc`,
  `4cddf91`); no data or state migration involved.
- Residual risk or unverified boundary: host names are parsed into normalized
  route entries and compared exactly, including a prefix-collision regression.
  The check remains deliberately one-directional and does not force routing-row
  removal when a matrix claim is dropped. No live WorkBuddy runtime smoke was
  run; validation is source, fixture, and test evidence.

## AI Involvement

- Level: Generated
- Human review and validation: maintainer reviewed the diff, the red-green
  test behavior, the full-suite results, and the pack verification before
  push.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [x] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [x] I have the right to contribute this work under the repository's MIT License.