### PR TITLE
fix(qwen): remove dangling QWEN.md context reference

### DIFF
--- a/docs/specs/2026-07-29-qwen-extension-context-file.md
+++ b/docs/specs/2026-07-29-qwen-extension-context-file.md
@@ -1,0 +1,107 @@
+# Qwen Extension Dangling Context File Reference
+
+Remove the `contextFileName` declaration from `qwen-extension.json` because it
+references a `QWEN.md` file that does not exist in the repository and is not
+included in the published npm package.
+
+## Traceability
+
+- Spec ID: 2026-07-29-qwen-extension-context-file
+- Story: none; justified maintenance on the Qwen host manifest
+- Status: Implemented
+
+## Intent
+
+`qwen-extension.json` declares `"contextFileName": "QWEN.md"`, but no `QWEN.md`
+exists at the repository root, and `package.json` `files` does not include one,
+so the published package cannot ship it either.
+
+The reference is user-visible: Qwen Code `0.21.1` announces it before the
+install confirmation in both registration paths — `qwen extensions link
+<local-path>` and `qwen extensions install <git-repository-url>` — with the
+same message (observed on Windows with isolated `QWEN_HOME` directories):
+
+```text
+This extension will append info to your QWEN.md context using QWEN.md
+```
+
+The extension promises durable context that it cannot deliver. The existing
+manifest test pins the dangling value instead of catching it
+(`test/plugin-manifests.test.mjs` asserts
+`qwen.contextFileName === "QWEN.md"`).
+
+Better Harness manifests should not declare files they do not ship. The
+extension's behavior is fully owned by the canonical root `skills/` directory,
+which the manifest already routes through `"skills": "./skills/"`; no shipped
+behavior depends on an extension-owned context file.
+
+## Acceptance Scenarios
+
+- AC-1: `qwen-extension.json` no longer contains a `contextFileName` field; the
+  remaining fields (`name`, `version`, `displayName`, `description`, `skills`)
+  are unchanged.
+- AC-2: `test/plugin-manifests.test.mjs` asserts that `qwen.contextFileName`
+  is `undefined`, so a future reintroduction without the shipped file is
+  caught at review time.
+- AC-3: `node --test test/plugin-manifests.test.mjs` passes.
+- AC-4: `npm run pack:verify` passes; the packaged `qwen-extension.json` stays
+  version-aligned with `package.json`.
+- AC-5: With Qwen Code `0.21.1`, both local `extensions link` and Git URL
+  `extensions install --ref fix/qwen-context-manifest` still discover the
+  `better-harness` Skill but no longer print the missing-`QWEN.md` context
+  promise before confirmation. The Git install can complete and appear in
+  `extensions list` inside an isolated `QWEN_HOME` without invoking an LLM.
+
+## Non-Goals
+
+- No new `QWEN.md` context file. What durable context, if any, the extension
+  should inject into every Qwen session is a product decision; if maintainers
+  want one, adding the file plus a `files` entry and an existence test is a
+  separate change.
+- No change to the Qwen configured-asset provider or session analyzer; the
+  workspace-level `QWEN.md` inventory in
+  `scripts/agent-customize/providers/qwen.mjs` reads the user's repository,
+  not this extension manifest, and stays as is.
+- No change to the other host manifests.
+
+## Plan
+
+1. Remove the `contextFileName` line from `qwen-extension.json`.
+2. Update the Qwen manifest assertion in `test/plugin-manifests.test.mjs` to
+   require the field to be absent.
+3. Compare current upstream and the fix with Qwen Code `0.21.1` using isolated
+   homes, covering local link, Git URL install/ref selection, Skill discovery,
+   and installed-extension listing without starting a model session.
+
+## Test Evidence
+
+- `node --test test/plugin-manifests.test.mjs`
+- `npm run pack:verify`
+- `QWEN_HOME=<isolated-base> qwen extensions link <current-upstream-path>`
+- `QWEN_HOME=<isolated-base-install> qwen extensions install
+  https://github.com/QoderAI/better-harness.git`
+- `QWEN_HOME=<isolated-fix> qwen extensions link <fixed-worktree-path>`
+- `QWEN_HOME=<isolated-fix-install> qwen extensions install
+  https://github.com/KDB-Wind/better-harness.git --ref
+  fix/qwen-context-manifest --consent`
+- `QWEN_HOME=<isolated-fix-install> qwen extensions list`
+
+The isolated native-host checks do not open a chat or call an LLM. The
+upstream link/install prompts include the dangling context message; the fixed
+link/install prompts omit it while retaining the Skill declaration. The
+completed fixed install is confined to the temporary `QWEN_HOME`.
+
+Observed on 2026-07-30 after refreshing onto
+`main@30047662936e996b433f1d0ee0bcb582c0b839f0`:
+
+- Qwen Code `0.21.1` produced the expected upstream/fixed prompt difference;
+  the fixed Git-ref install completed and `extensions list` reported version
+  `0.3.0`, the fork source, the requested ref, and the `better-harness` Skill.
+- `node --test test/plugin-manifests.test.mjs
+  test/doc-link-graph.test.mjs` passed 9/9.
+- `npm run pack:verify` passed with 319 npm entries and 343 runtime ZIP
+  entries.
+- `npm test` reported 881 tests: 876 passed, 2 failed, and 3 skipped. The
+  unmodified current-upstream worktree produced the same two failures: an
+  environment-provided ancestor `CLAUDE.md`, and a Windows Git-failure fixture
+  that returned zero instead of the expected nonzero status.

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -3,6 +3,5 @@
   "version": "0.4.0",
   "displayName": "Better Harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "contextFileName": "QWEN.md",
   "skills": "./skills/"
 }

--- a/test/plugin-manifests.test.mjs
+++ b/test/plugin-manifests.test.mjs
@@ -159,7 +159,7 @@ test("host plugin manifests expose canonical Better Harness resources", () => {
   assert.equal(qwen.version, qoder.version);
   assert.equal(qwen.description, qoder.description);
   assert.equal(qwen.displayName, qoder.displayName);
-  assert.equal(qwen.contextFileName, "QWEN.md");
+  assert.equal(qwen.contextFileName, undefined);
   assert.equal(qwen.skills, "./skills/");
 
   assert.equal(copilot.name, qoder.name);


### PR DESCRIPTION
## Summary

Remove the dangling `contextFileName: "QWEN.md"` declaration from
`qwen-extension.json` because the referenced file does not exist in the
repository and is not included in the published npm package.

Update the manifest test to require the field to remain absent. No replacement
`QWEN.md` is introduced, so this change does not add extension-wide context or
alter the canonical root `skills/` behavior.

## Why

- Issue/Story: No issue; justified maintenance of the shipped Qwen Code
  extension manifest.
- User or maintainer outcome: Qwen Code no longer presents an install-time
  promise to append extension context from a file the extension cannot provide.

Qwen Code 0.21.1 was verified on Windows through both registration paths with
isolated `QWEN_HOME` directories:

- `qwen extensions link <local-path>`
- `qwen extensions install <git-repository-url>`

Current upstream displayed the same dangling `QWEN.md` context message through
both paths. The fixed branch omitted the message while retaining the
`better-harness` Skill. A fixed Git-ref install was completed inside the
isolated home and confirmed with `qwen extensions list`; no chat or LLM call
was made.

## Traceability and Scope

- Spec/ADR, if applicable:
  `docs/specs/2026-07-29-qwen-extension-context-file.md`
- Acceptance criteria addressed:
  - AC-1: `qwen-extension.json` no longer declares `contextFileName`; all
    remaining manifest fields are unchanged.
  - AC-2: `test/plugin-manifests.test.mjs` requires
    `qwen.contextFileName === undefined`.
  - AC-3: The focused plugin-manifest tests pass 3/3.
  - AC-4: Package verification passes and keeps the packaged Qwen manifest
    version-aligned with `package.json`.
  - AC-5: Qwen Code 0.21.1 link and Git-ref install omit the dangling context
    promise, retain Skill discovery, and can be listed from an isolated home.
- Canonical owners changed:
  - `qwen-extension.json`
  - `test/plugin-manifests.test.mjs`
  - `docs/specs/2026-07-29-qwen-extension-context-file.md`
- Explicit non-goals:
  - No new extension-owned `QWEN.md`.
  - No change to the workspace-level `QWEN.md` inventory.
  - No change to the Qwen session analyzer or configured-asset provider.
  - No change to other host manifests.
  - No new Qwen capability or installation command.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `node --test test/plugin-manifests.test.mjs test/doc-link-graph.test.mjs` | 9/9 pass |
| `npm run pack:verify` | Pass: npm 319 entries, runtime ZIP 343 entries |
| `git diff --check origin/main` | Pass |
| Qwen 0.21.1 isolated link/install/list | Pass; no LLM call |
| Full `npm test` | 881 total: 876 pass, 2 baseline failures, 3 skipped |
| Full `npm test` on unmodified current upstream | Same 876/2/3 result |

Manual evidence: the repository contains no root `QWEN.md`, and the
`package.json` `files` list does not ship one. The staged patch was also
compared with the reviewed source patch before the final commit was created.

The two full-suite failures reproduce on unmodified current upstream:

- one instruction-ledger test detects an environment-provided ancestor
  `CLAUDE.md`;
- one Windows review-trigger fixture expects Git inspection to fail, but its
  simulated command exits zero in this environment.

Focused affected-area tests and package verification pass. Clean GitHub CI
remains the authoritative full-suite result.

## Risk and Recovery

- Compatibility and cross-platform impact: The manifest change is
  platform-neutral JSON. It removes an undeliverable context reference and
  leaves Skill discovery unchanged.
- Package, plugin, schema, or generated-file impact: The published
  `qwen-extension.json` changes by one optional field. Package verification
  passes; no schema or generated file changes.
- Rollback or recovery path: Revert the single commit to restore the field.
- Residual risk or unverified boundary: Maintainers may prefer to ship a real
  extension-owned `QWEN.md` instead. That would be a product decision requiring
  the file, package inclusion, context content review, and an existence test.
- Changelog boundary: No release entry is added because this removes a
  declaration for behavior that was never deliverable; it introduces no new
  capability.

## AI Involvement

- Level: Assisted
- Human review and validation: AI assisted with drafting and reviewing the
  patch, spec, and validation workflow. The contributor made and reviewed the
  remove-versus-add product decision, inspected the final diff and acceptance
  criteria, and checked the recorded validation evidence. The focused tests,
  doc-link checks, package verification, and diff checks were rerun after the
  final commit was rebuilt.

## Checklist

- [ ] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [x] User-facing or compatibility changes are recorded in `CHANGELOG.md`, or the no-entry rationale is documented above.
- [x] I have the right to contribute this work under the repository's MIT License.
