### PR TITLE
fix(session-analysis): fold dots in Claude transcript-dir slug

### DIFF
--- a/docs/specs/2026-08-01-41-claude-transcript-dir-dot-slug.md
+++ b/docs/specs/2026-08-01-41-claude-transcript-dir-dot-slug.md
@@ -1,0 +1,65 @@
+# Claude transcript-dir slug must fold dots like Claude Code does
+
+## Traceability
+
+- Spec ID: 41-claude-transcript-dir-dot-slug
+- Story: QoderAI/better-harness#41
+- Status: Implemented
+
+## Intent
+
+The Claude session-evidence collector derives the project-transcript directory
+from the workspace path by replacing `/` (and drive-letter `:`) with `-`, but
+Claude Code's own project-directory naming also replaces `.` with `-`. For any
+workspace path containing a dot component (`~/.claude`, `~/src/foo.bar`,
+`~/work/my.project`), the computed root does not exist and every
+session-derived signal is silently computed from an empty set. The collector
+must resolve the same directory name Claude Code actually creates so dotted
+workspace paths stop reporting zero sessions.
+
+## Acceptance Scenarios
+
+- AC-1: `workspaceToClaudeSlugVariants("/Users/twurm/.claude")` includes
+  `-Users-twurm--claude` (each `/` and `.` folded to `-`, dots not collapsed),
+  and that variant is preferred as the primary slug.
+- AC-2: A Claude provider fixture whose workspace path contains a dotted
+  directory component discovers its transcript sessions from
+  `projects/<dot-substituted-slug>` via `sources` discovery instead of
+  reporting zero eligible sessions.
+- AC-3: Existing slug variants remain covered: dotless Unix workspaces still
+  resolve to the previous slug, and Windows drive paths still produce both
+  `C--...` and colonless variants (existing tests keep passing).
+
+## Non-goals
+
+- No changes to other platform slug functions (Cursor, Qwen, Qoder, Pi,
+  Workbuddy); the defect and evidence in the Story are Claude-specific.
+- No folding of further character classes (e.g. `_`, spaces) beyond `.`;
+  the Story only evidences the `.` substitution. A wider audit of Claude
+  Code's slug alphabet stays out of scope until concrete evidence exists.
+- No change to the `missing-required-root` warning flow itself.
+
+## Plan and Tasks
+
+- `scripts/session-analysis/platforms/claude.mjs`: extend
+  `workspaceToClaudeSlugVariants` so the dot-substituted forms
+  (`replace(/[\\/.]/g, "-")`, applied per character so `.claude` yields
+  `--claude`) are emitted first, while retaining the previous slash-only
+  variants for backward compatibility with directories created before the
+  fix or by older host versions. Discovery already probes every variant via
+  `paths`, so adding variants is additive and safe.
+- `test/session-analysis-providers.test.mjs`: add slug assertions for a
+  dotted Unix path plus a provider-level regression fixture that stores a
+  transcript under the dot-substituted project directory and asserts the
+  session is discovered.
+
+## Test and Review Evidence
+
+- AC-1/AC-3: `node --test test/session-analysis-providers.test.mjs`
+  (slug variant assertions, existing Unix/Windows expectations unchanged).
+- AC-2: same test file, new fixture "Claude provider resolves transcripts for
+  dotted workspace paths".
+- Regression safety: `node --test test/session-workspace-provider.test.mjs
+  test/session-analysis-claude-facets.test.mjs` exercise dependent flows.
+- Risk: low — additive slug variants; primary slug order changes only for
+  paths containing dots, which previously resolved to nonexistent roots.

--- a/scripts/session-analysis/platforms/claude.mjs
+++ b/scripts/session-analysis/platforms/claude.mjs
@@ -34,7 +34,11 @@ function isScopedWorkspaceMatch(candidate, scope) {
 export function workspaceToClaudeSlugVariants(workspace) {
   const expanded = expandHome(workspace ?? process.cwd());
   const normalized = path.win32.isAbsolute(expanded) ? path.win32.normalize(expanded) : normalizeWorkspace(expanded);
+  // Claude Code folds "." into "-" per character (".claude" -> "--claude"), so the
+  // dot-substituted forms come first; slash-only forms stay as legacy fallbacks.
   return [...new Set([
+    normalized.replace(/:/g, "-").replace(/[\\/.]/g, "-"),
+    normalized.replace(/:/g, "").replace(/[\\/.]/g, "-"),
     normalized.replace(/:/g, "-").replace(/[\\/]+/g, "-"),
     normalized.replace(/:/g, "").replace(/[\\/]+/g, "-"),
   ])];

--- a/test/session-analysis-providers.test.mjs
+++ b/test/session-analysis-providers.test.mjs
@@ -95,6 +95,35 @@ test("Claude, Cursor, and Qwen workspace slugs cover Unix and Windows layouts", 
   assert.ok(workspaceToWorkbuddySlugVariants("C:\\workspace\\project").exact.includes("C--workspace-project"));
 });
 
+test("Claude workspace slug folds dots the way Claude Code names project directories", () => {
+  assert.equal(workspaceToClaudeSlugVariants("/Users/twurm/.claude")[0], "-Users-twurm--claude");
+  assert.deepEqual(workspaceToClaudeSlugVariants("/work/my.project"), [
+    "-work-my-project",
+    "-work-my.project",
+  ]);
+  assert.deepEqual(workspaceToClaudeSlugVariants("/workspace/project"), ["-workspace-project"]);
+});
+
+test("Claude provider discovers transcripts for dotted workspace paths", async () => {
+  const root = await fixtureRoot("session-claude-dotted-");
+  const home = path.join(root, ".claude");
+  const workspace = path.join(root, "work", "my.project");
+  const sessionId = "33333333-3333-4333-8333-333333333333";
+  const dottedSlug = workspaceToClaudeSlugVariants(workspace)[0];
+  assert.ok(dottedSlug.endsWith("-work-my-project"));
+  await writeJsonl(path.join(home, "projects", dottedSlug, `${sessionId}.jsonl`), [{
+    type: "user",
+    sessionId,
+    cwd: workspace,
+    timestamp: "2026-07-20T01:00:00.000Z",
+    message: { role: "user", content: [{ type: "text", text: "hello from a dotted workspace" }] },
+  }]);
+  const result = await new ClaudeSessionAnalyzer().analyze({ command: "sources", workspace, home });
+  assert.equal(result.sessions.length, 1);
+  assert.equal(result.sessions[0].sessionId, sessionId);
+  assert.equal(result.sources.find((source) => source.kind === "claude-project-jsonl")?.exists, true);
+});
+
 test("Claude provider expands nested tool requests and results without using generated facets", async () => {
   const root = await fixtureRoot("session-claude-provider-");
   const home = path.join(root, ".claude");


### PR DESCRIPTION
## Summary

Fixes #41

Claude Code names project-transcript directories by replacing both `/` and `.` with `-`, but `workspaceToClaudeSlugVariants` only folded slashes. Any workspace path with a dotted component (`~/.claude`, `~/work/my.project`) resolved to a nonexistent projects root, so all session evidence was silently dropped as zero eligible sessions.

## Changes

- `scripts/session-analysis/platforms/claude.mjs`: emit dot-substituted slug variants first (per-character, so `.claude` yields `--claude`), keeping the slash-only forms as legacy fallbacks; discovery already probes every variant.
- `test/session-analysis-providers.test.mjs`: slug assertions (incl. the issue's `/Users/twurm/.claude` case) and a dotted-workspace provider regression fixture.
- Spec: `docs/specs/2026-08-01-41-claude-transcript-dir-dot-slug.md`

## Test Evidence

- `node --test test/session-analysis-providers.test.mjs test/session-workspace-provider.test.mjs test/session-analysis-claude-facets.test.mjs` — 54 passing
- Full `npm test` — 1040 passing, no regressions
- Smoke of the issue's repro command: required root now resolves to `.../projects/-Users-phodal--claude` (double dash)