### PR TITLE
fix(cli): short-circuit leaf command help

### DIFF
--- a/docs/specs/2026-07-31-37-leaf-command-help.md
+++ b/docs/specs/2026-07-31-37-leaf-command-help.md
@@ -1,0 +1,36 @@
+# Leaf command help
+
+## Traceability
+
+- Spec ID: 37-leaf-command-help
+- Story: #37
+- Status: Draft
+
+## Intent
+
+Make `--help` and `-h` immediate, side-effect-free discovery requests for every registered Better Harness terminal path. The root dispatcher must select the registered command owner before it forwards help so invalid or incomplete user arguments cannot reach runtime handlers.
+
+## Acceptance Scenarios
+
+- AC-1: Every canonical registered command path and direct-command alias exits successfully with canonical help on stdout and no stderr when either help flag appears after arbitrary arguments.
+- AC-2: The dispatcher removes arbitrary arguments before invoking a registered leaf owner, retaining only a registered direct subcommand when that subcommand shares its owner's script.
+- AC-3: Root and group help retain their existing behavior, including audience filtering and unknown-subcommand diagnostics; an unknown root command falls back to root help when a help flag is present.
+
+## Non-goals
+
+- Changing command execution when no help flag is present.
+- Changing help text, command registry metadata, or the behavior of individual command implementations.
+- Adding new command paths or aliases.
+
+## Plan and Tasks
+
+1. Detect either help flag before built-in metadata handlers or runtime dispatch.
+2. Resolve a direct or group leaf only from the registry and forward a canonical help argument list to its exact owner.
+3. Add an inventory-driven regression that covers canonical paths, aliases, and both help flags.
+
+## Test and Review Evidence
+
+- AC-1 and AC-2: `node --test test/better-harness-cli.test.mjs` exercises every inventory-derived route with an invalid argument before each help flag.
+- AC-3: The same focused test covers invalid group and root paths with a help flag.
+- Regression gate: `npm test`.
+- Risk: centralized early exit could alter a metadata command's help behavior. The implementation scopes leaf dispatch through the existing registry and preserves normal execution paths when no help flag is present.

--- a/docs/specs/2026-07-31-37-leaf-command-help.md
+++ b/docs/specs/2026-07-31-37-leaf-command-help.md
@@ -4,33 +4,36 @@
 
 - Spec ID: 37-leaf-command-help
 - Story: #37
-- Status: Draft
+- Status: Implemented
 
 ## Intent
 
-Make `--help` and `-h` immediate, side-effect-free discovery requests for every registered Better Harness terminal path. The root dispatcher must select the registered command owner before it forwards help so invalid or incomplete user arguments cannot reach runtime handlers.
+Make `--help` and `-h` immediate, side-effect-free discovery requests for every registered Better Harness terminal path. The root dispatcher must select the registered command owner before it forwards help so invalid or incomplete user arguments cannot reach runtime handlers. Each selected owner must return help before reading workspace, home, or stdin state; writing files; starting processes; or accessing the network.
 
 ## Acceptance Scenarios
 
-- AC-1: Every canonical registered command path and direct-command alias exits successfully with canonical help on stdout and no stderr when either help flag appears after arbitrary arguments.
-- AC-2: The dispatcher removes arbitrary arguments before invoking a registered leaf owner, retaining only a registered direct subcommand when that subcommand shares its owner's script.
-- AC-3: Root and group help retain their existing behavior, including audience filtering and unknown-subcommand diagnostics; an unknown root command falls back to root help when a help flag is present.
+- AC-1: Every canonical registered command path and direct-command alias exits successfully with its canonical help on stdout and no stderr when either `--help` or `-h` appears after arbitrary or incomplete arguments.
+- AC-2: The dispatcher removes arbitrary arguments before invoking the exact registered leaf owner, retaining only a registered direct subcommand when that subcommand shares its owner's script.
+- AC-3: Root, group, and built-in discovery help retain their existing behavior, including audience filtering, JSON/schema output, and unknown-subcommand diagnostics; an unknown root command falls back to root help when a help flag is present.
+- AC-4: A positional value named `help` is not treated as a help flag and preserves normal command dispatch.
+- AC-5: Every AC-1 path returns before target-workspace, user-home, stdin, write, child-process, Git, or network operations.
 
 ## Non-goals
 
 - Changing command execution when no help flag is present.
-- Changing help text, command registry metadata, or the behavior of individual command implementations.
-- Adding new command paths or aliases.
+- Changing command registry metadata or adding command paths or aliases.
 
 ## Plan and Tasks
 
-1. Detect either help flag before built-in metadata handlers or runtime dispatch.
+1. Preserve built-in discovery handlers, then detect only `--help` and `-h` before runtime dispatch.
 2. Resolve a direct or group leaf only from the registry and forward a canonical help argument list to its exact owner.
-3. Add an inventory-driven regression that covers canonical paths, aliases, and both help flags.
+3. Add early help exits to every selected owner that otherwise reads runtime state.
+4. Add an inventory-driven, isolated non-Git regression that covers canonical paths, aliases, both help flags, exact owner dispatch, canonical stdout, and prohibited-operation canaries.
 
 ## Test and Review Evidence
 
-- AC-1 and AC-2: `node --test test/better-harness-cli.test.mjs` exercises every inventory-derived route with an invalid argument before each help flag.
-- AC-3: The same focused test covers invalid group and root paths with a help flag.
+- AC-1 and AC-2: `node --test test/better-harness-cli.test.mjs` exercises every inventory-derived route from an isolated non-Git directory, with an invalid argument before each help flag, and compares stdout with the route's canonical help.
+- AC-3 and AC-4: The same focused test covers discovery commands, audience filtering, and a literal positional `help` value.
+- AC-5: A preloaded test guard rejects target-workspace, user-home, stdin, write, child-process, Git, and network access while allowing only the exact owner invocation.
 - Regression gate: `npm test`.
-- Risk: centralized early exit could alter a metadata command's help behavior. The implementation scopes leaf dispatch through the existing registry and preserves normal execution paths when no help flag is present.
+- Risk: centralized early exit could alter metadata command behavior or normalize positional values. The implementation scopes leaf dispatch through the existing registry, preserves discovery handlers, and recognizes only explicit help flags.

--- a/scripts/better-harness-cli/cli.mjs
+++ b/scripts/better-harness-cli/cli.mjs
@@ -251,7 +251,7 @@ function isVersion(value) {
 }
 
 function hasHelpFlag(argv) {
-  return argv.some(isHelp);
+  return argv.some((value) => value === "--help" || value === "-h");
 }
 
 function hasJsonFlag(argv) {
@@ -343,31 +343,6 @@ export function resolveDispatch(argv = []) {
     return { kind: "help", text: `${programName} ${packageVersion()}\n`, exitCode: 0 };
   }
 
-  if (hasHelpFlag(argv)) {
-    const direct = directDispatchFor(command, subcommand);
-    if (direct) {
-      const metadata = commandMetadata(command);
-      const registeredSubcommand = metadata?.subcommands?.some((entry) => entry.name === subcommand);
-      return {
-        kind: "dispatch",
-        script: scriptPath(direct.script),
-        args: !direct.consumesSubcommand && registeredSubcommand ? [subcommand, "--help"] : ["--help"],
-      };
-    }
-
-    const group = groupCommand(command);
-    if (group && !isHelp(subcommand)) {
-      const script = group.subcommands.find((entry) => entry.name === subcommand)?.script;
-      if (script) {
-        return { kind: "dispatch", script: scriptPath(script), args: ["--help"] };
-      }
-    }
-
-    if (!group) {
-      return { kind: "help", text: usage(), exitCode: 0 };
-    }
-  }
-
   if (command === "commands") {
     let audience;
     try {
@@ -438,6 +413,31 @@ export function resolveDispatch(argv = []) {
 
   if (command === "schema") {
     return commandSchema(argv.slice(1));
+  }
+
+  if (hasHelpFlag(argv)) {
+    const direct = directDispatchFor(command, subcommand);
+    if (direct) {
+      const metadata = commandMetadata(command);
+      const registeredSubcommand = metadata?.subcommands?.some((entry) => entry.name === subcommand);
+      return {
+        kind: "dispatch",
+        script: scriptPath(direct.script),
+        args: !direct.consumesSubcommand && registeredSubcommand ? [subcommand, "--help"] : ["--help"],
+      };
+    }
+
+    const group = groupCommand(command);
+    if (group && !isHelp(subcommand)) {
+      const script = group.subcommands.find((entry) => entry.name === subcommand)?.script;
+      if (script) {
+        return { kind: "dispatch", script: scriptPath(script), args: ["--help"] };
+      }
+    }
+
+    if (!group) {
+      return { kind: "help", text: usage(), exitCode: 0 };
+    }
   }
 
   const direct = directDispatchFor(command, subcommand);

--- a/scripts/better-harness-cli/cli.mjs
+++ b/scripts/better-harness-cli/cli.mjs
@@ -250,6 +250,10 @@ function isVersion(value) {
   return value === "--version" || value === "-V" || value === "version";
 }
 
+function hasHelpFlag(argv) {
+  return argv.some(isHelp);
+}
+
 function hasJsonFlag(argv) {
   return argv.includes("--json");
 }
@@ -337,6 +341,31 @@ export function resolveDispatch(argv = []) {
 
   if (isVersion(command)) {
     return { kind: "help", text: `${programName} ${packageVersion()}\n`, exitCode: 0 };
+  }
+
+  if (hasHelpFlag(argv)) {
+    const direct = directDispatchFor(command, subcommand);
+    if (direct) {
+      const metadata = commandMetadata(command);
+      const registeredSubcommand = metadata?.subcommands?.some((entry) => entry.name === subcommand);
+      return {
+        kind: "dispatch",
+        script: scriptPath(direct.script),
+        args: !direct.consumesSubcommand && registeredSubcommand ? [subcommand, "--help"] : ["--help"],
+      };
+    }
+
+    const group = groupCommand(command);
+    if (group && !isHelp(subcommand)) {
+      const script = group.subcommands.find((entry) => entry.name === subcommand)?.script;
+      if (script) {
+        return { kind: "dispatch", script: scriptPath(script), args: ["--help"] };
+      }
+    }
+
+    if (!group) {
+      return { kind: "help", text: usage(), exitCode: 0 };
+    }
   }
 
   if (command === "commands") {

--- a/scripts/cloc/cli.mjs
+++ b/scripts/cloc/cli.mjs
@@ -6,6 +6,21 @@ import { fileURLToPath } from "node:url";
 
 import { analyzeCloc } from "./analyze.mjs";
 
+const CLOC_HELP = `Usage: better-harness cloc [paths...] [options]
+
+Count code, comments, and blank lines.
+
+Options:
+  --cwd <path>              Analyze this directory
+  --workers <count>         Set the worker count
+  --no-git                  Do not use Git for file discovery
+  --tracked-only            Count tracked files only
+  --markdown-code           Include Markdown code blocks
+  --files                   Include counted file paths
+  --json                    Emit JSON output
+  -h, --help                Print help
+`;
+
 function parseArgs(argv = process.argv.slice(2)) {
   const args = { _: [] };
   for (let index = 0; index < argv.length; index += 1) {
@@ -50,6 +65,10 @@ function printTextReport(report) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (argv.some((arg) => arg === "--help" || arg === "-h")) {
+    process.stdout.write(CLOC_HELP);
+    return;
+  }
   const args = parseArgs(argv);
   const report = await analyzeCloc({
     cwd: args.cwd,

--- a/scripts/coding-agent-practices/checkup/cli.mjs
+++ b/scripts/coding-agent-practices/checkup/cli.mjs
@@ -6,6 +6,19 @@ import { applyCheckupPlan } from "./apply.mjs";
 import { buildCheckupPlan } from "./plan.mjs";
 import { runCheckupScan } from "./scan.mjs";
 
+const CHECKUP_HELP = `Usage: better-harness harness checkup [scan|plan|apply] [options]
+
+Scan agent customizations and produce a read-only cleanup plan.
+
+Options:
+  --phase <scan|plan|apply> Select the checkup phase
+  --workspace <path>        Analyze this workspace
+  --provider <name>         Select an agent provider
+  --plan <path>             Read a plan for the apply phase
+  --json                    Emit JSON output
+  -h, --help                Print help
+`;
+
 function optionsFromArgs(options) {
   return {
     provider: options.provider,
@@ -134,6 +147,10 @@ async function readPlan(filePath) {
 }
 
 export async function main(argv = process.argv.slice(2), dependencies = {}) {
+  if (argv.some((arg) => arg === "--help" || arg === "-h")) {
+    process.stdout.write(CHECKUP_HELP);
+    return;
+  }
   const { command, options } = parseArgs(argv);
   const phase = options.phase ?? command ?? "scan";
   if (!new Set(["scan", "plan", "apply"]).has(phase)) {

--- a/scripts/core-change-watch/change-drift.mjs
+++ b/scripts/core-change-watch/change-drift.mjs
@@ -25,6 +25,7 @@ import {
   unique,
   writeJsonResult,
 } from "./common.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 
 const TYPE_METADATA = {
   "public-api-docs": {
@@ -302,6 +303,7 @@ export async function analyzeChangeDrift(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("change-drift", argv)) return;
   const args = parseArgs(argv);
   const result = await analyzeChangeDrift({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/core-candidates.mjs
+++ b/scripts/core-change-watch/core-candidates.mjs
@@ -27,6 +27,7 @@ import {
   writeJsonResult,
 } from "./common.mjs";
 import { analyzeGitHistoryProfile } from "./git-history-profile.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 import { analyzeProjectProfile } from "./project-profile.mjs";
 
 const CORE_PATH_PATTERNS = [
@@ -290,6 +291,7 @@ export async function analyzeCoreCandidates(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("core-candidates", argv)) return;
   const args = parseArgs(argv);
   const result = await analyzeCoreCandidates({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/diff-impact.mjs
+++ b/scripts/core-change-watch/diff-impact.mjs
@@ -28,6 +28,7 @@ import {
 } from "./common.mjs";
 import { analyzeCoreCandidates } from "./core-candidates.mjs";
 import { analyzeGitHistoryProfile } from "./git-history-profile.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 import { analyzeProjectProfile } from "./project-profile.mjs";
 
 function severityFor(score) {
@@ -232,6 +233,7 @@ export async function analyzeDiffImpact(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("diff-impact", argv)) return;
   const args = parseArgs(argv);
   const result = await analyzeDiffImpact({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/evidence-pack.mjs
+++ b/scripts/core-change-watch/evidence-pack.mjs
@@ -25,6 +25,7 @@ import { analyzeChangeDrift } from "./change-drift.mjs";
 import { analyzeCoreCandidates } from "./core-candidates.mjs";
 import { analyzeDiffImpact } from "./diff-impact.mjs";
 import { analyzeGitHistoryProfile } from "./git-history-profile.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 import { analyzeProjectProfile } from "./project-profile.mjs";
 
 function addRead(reads, path, reason, priority = 50, currentPaths = null) {
@@ -597,6 +598,7 @@ export async function buildEvidencePack(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("evidence-pack", argv)) return;
   const args = parseArgs(argv);
   const result = await buildEvidencePack({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/git-history-profile.mjs
+++ b/scripts/core-change-watch/git-history-profile.mjs
@@ -23,6 +23,7 @@ import {
   sortedCounts,
   writeJsonResult,
 } from "./common.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 
 function parseLogWithNumstat(output, analysisScope) {
   const commits = [];
@@ -290,6 +291,7 @@ export async function analyzeGitHistoryProfile(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("git-history-profile", argv)) return;
   const args = parseArgs(argv);
   const result = await analyzeGitHistoryProfile({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/help.mjs
+++ b/scripts/core-change-watch/help.mjs
@@ -1,0 +1,24 @@
+const CORE_CHANGE_WATCH_HELP = Object.freeze({
+  "change-drift": "Compare the current repository state with a base revision.",
+  "core-candidates": "Identify paths that merit core-change review.",
+  "diff-impact": "Estimate the impact of changes from a base revision.",
+  "evidence-pack": "Build a bounded project and history evidence pack.",
+  "git-history-profile": "Summarize repository history and churn evidence.",
+  "project-profile": "Summarize the repository's static project profile.",
+  "qoder-consistency-schema": "Validate and normalize a Qoder consistency result.",
+});
+
+export function printCoreChangeWatchHelp(command, argv = []) {
+  if (!argv.some((value) => value === "--help" || value === "-h")) {
+    return false;
+  }
+
+  const summary = CORE_CHANGE_WATCH_HELP[command];
+  if (!summary) {
+    throw new Error(`Unknown core-change-watch help owner: ${command}`);
+  }
+
+  const input = command === "qoder-consistency-schema" ? " --input <path>" : "";
+  process.stdout.write(`Usage: better-harness core-change-watch ${command}${input} [options]\n\n${summary}\n\nOptions:\n  --cwd <path>              Analyze a repository from this directory\n  --json                    Emit JSON output\n  -h, --help                Print help\n`);
+  return true;
+}

--- a/scripts/core-change-watch/project-profile.mjs
+++ b/scripts/core-change-watch/project-profile.mjs
@@ -29,6 +29,7 @@ import {
   toPosix,
   writeJsonResult,
 } from "./common.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 
 const MANIFESTS = new Set([
   "package.json",
@@ -765,6 +766,7 @@ export async function analyzeProjectProfile(options = {}) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("project-profile", argv)) return;
   const args = parseArgs(argv);
   const result = await analyzeProjectProfile({
     cwd: option(args, "cwd"),

--- a/scripts/core-change-watch/qoder-consistency-schema.mjs
+++ b/scripts/core-change-watch/qoder-consistency-schema.mjs
@@ -9,6 +9,7 @@ import {
   parseArgs,
   writeJsonResult,
 } from "./common.mjs";
+import { printCoreChangeWatchHelp } from "./help.mjs";
 
 const ALLOWED_VERDICTS = new Set(["consistent", "mostly_consistent", "mixed", "inconsistent", "blocked"]);
 const ALLOWED_CONFIDENCE = new Set(["high", "medium", "low"]);
@@ -130,6 +131,7 @@ export function parseAndNormalizeQoderOutput(text) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (printCoreChangeWatchHelp("qoder-consistency-schema", argv)) return;
   const args = parseArgs(argv);
   const inputPath = option(args, "input");
   const text = inputPath && inputPath !== true

--- a/scripts/dependency-governance/cli.mjs
+++ b/scripts/dependency-governance/cli.mjs
@@ -10,6 +10,19 @@ const DEFAULT_STALE_DAYS = 180;
 const DEFAULT_VERSION = "v5";
 const DEFAULT_BENCHMARK_ITERATIONS = 80;
 const CLASSIFIER_VERSIONS = ["v1", "v2", "v3", "v4", "v5"];
+const DEPENDENCY_GOVERNANCE_HELP = `Usage: better-harness dependency-governance [options]
+
+Detect dependency governance files, automation, audit signals, and stale evidence.
+
+Options:
+  --cwd <path>              Analyze this directory
+  --version <version>       Select a classifier version
+  --stale-days <days>       Set the stale-evidence threshold
+  --now <timestamp>         Set the analysis time
+  --benchmark               Benchmark classifier versions
+  --json                    Emit JSON output
+  -h, --help                Print help
+`;
 
 const MANIFEST_BASENAMES = new Set([
   "package.json",
@@ -791,6 +804,10 @@ function printBenchmark(benchmark) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (argv.some((arg) => arg === "--help" || arg === "-h")) {
+    process.stdout.write(DEPENDENCY_GOVERNANCE_HELP);
+    return;
+  }
   const args = parseArgs(argv);
   const version = args.version ?? DEFAULT_VERSION;
   if (!CLASSIFIER_VERSIONS.includes(version)) {

--- a/scripts/harness-analysis/report-quality.mjs
+++ b/scripts/harness-analysis/report-quality.mjs
@@ -14,6 +14,16 @@ const REQUIRED_SECTIONS = [
   "Unverified Items",
 ];
 
+const REPORT_QUALITY_HELP = `Usage: better-harness harness report-quality (--report <path> | --canvas <path>)
+
+Validate Better Harness Markdown reports or Qoder Canvas artifacts.
+
+Options:
+  --report <path>    Validate a Markdown report
+  --canvas <path>    Validate a Canvas artifact
+  -h, --help         Print help
+`;
+
 const LEGACY_REQUIRED_SECTION_KEYS = [
   "executiveVerdict",
   "evidenceBoundary",
@@ -1188,6 +1198,10 @@ function parseArgs(argv) {
 }
 
 export function main(argv = process.argv.slice(2)) {
+  if (argv.some((arg) => arg === "--help" || arg === "-h")) {
+    process.stdout.write(REPORT_QUALITY_HELP);
+    return;
+  }
   const args = parseArgs(argv);
   const input = args.report || args.canvas
     ? readFileSync(resolve(String(args.report ?? args.canvas)), "utf8")

--- a/scripts/harness-analysis/validate-canvas.mjs
+++ b/scripts/harness-analysis/validate-canvas.mjs
@@ -31,6 +31,20 @@ import { findingTargetErrors } from "../workspace-topology/index.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = path.resolve(__dirname, "../..");
+const VALIDATE_CANVAS_HELP = `Usage: better-harness harness validate-canvas --canvas <path> [options]
+
+Validate Qoder Canvas artifacts and their linked report inputs.
+
+Options:
+  --canvas <path>             Canvas artifact to validate
+  --report <path>             Linked Markdown report
+  --findings <path>           Linked findings JSON
+  --repo-root <path>          Repository root for path validation
+  --preview                   Start a local preview during validation
+  --browser                   Open the preview in a browser
+  --json                      Emit JSON output
+  -h, --help                  Print help
+`;
 
 const SECTION_LABELS = {
   riskFindings: ["Risk Findings", "风险发现"],
@@ -2001,6 +2015,10 @@ function parseArgs(argv) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (argv.some((arg) => arg === "--help" || arg === "-h")) {
+    process.stdout.write(VALIDATE_CANVAS_HELP);
+    return;
+  }
   const args = parseArgs(argv);
   const result = await validateHarnessCanvasArtifacts(args);
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/test/better-harness-cli.test.mjs
+++ b/test/better-harness-cli.test.mjs
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { resolveDispatch } from "../scripts/better-harness-cli/cli.mjs";
 import { commandInventory } from "../scripts/better-harness-cli/registry.mjs";
 
 const cliPath = path.join(process.cwd(), "scripts", "better-harness.mjs");
+const helpSideEffectGuardPath = path.join(process.cwd(), "test", "fixtures", "help-side-effect-guard.mjs");
 
 function runBetterHarness(args, options = {}) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -15,6 +17,77 @@ function runBetterHarness(args, options = {}) {
     encoding: "utf8",
     ...options,
   });
+}
+
+function helpGuardEnvironment(expectedOwner, expectedOwnerArgs) {
+  const inheritedOptions = process.env.NODE_OPTIONS?.trim();
+  return {
+    ...process.env,
+    NODE_OPTIONS: [inheritedOptions, `--import=${pathToFileURL(helpSideEffectGuardPath).href}`]
+      .filter(Boolean)
+      .join(" "),
+    BETTER_HARNESS_HELP_GUARD_ALLOWED_ROOT: process.cwd(),
+    BETTER_HARNESS_HELP_GUARD_DISPATCHER: cliPath,
+    ...(expectedOwner
+      ? {
+        BETTER_HARNESS_HELP_GUARD_OWNER: expectedOwner,
+        BETTER_HARNESS_HELP_GUARD_OWNER_ARGS: JSON.stringify(expectedOwnerArgs),
+      }
+      : {}),
+  };
+}
+
+function runGuardedNode(args, { cwd, expectedOwner, expectedOwnerArgs } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd,
+      env: helpGuardEnvironment(expectedOwner, expectedOwnerArgs),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timed out while running node ${args.join(" ")}`));
+    }, 10_000);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stdin.on("error", () => {});
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(timeout);
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
+async function runGuardedBetterHarness(args, options) {
+  return runGuardedNode([cliPath, ...args], options);
+}
+
+function assertHelpGuardCanaries(cwd) {
+  const probes = [
+    ["read", "import { readFileSync } from 'node:fs'; readFileSync(process.cwd(), 'utf8');", "HELP_GUARD_READ"],
+    ["write", "import { writeFileSync } from 'node:fs'; writeFileSync('guard-probe.txt', 'x');", "HELP_GUARD_WRITE"],
+    ["stdin", "import { readFileSync } from 'node:fs'; readFileSync(0, 'utf8');", "HELP_GUARD_STDIN"],
+    ["process", "import { spawnSync } from 'node:child_process'; spawnSync('git', ['rev-parse', '--show-toplevel']);", "HELP_GUARD_PROCESS"],
+    ["network", "import { connect } from 'node:net'; connect({ host: '127.0.0.1', port: 1 });", "HELP_GUARD_NETWORK"],
+  ];
+  for (const [name, program, marker] of probes) {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", program], {
+      cwd,
+      env: helpGuardEnvironment(),
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0, name);
+    assert.match(result.stderr, new RegExp(marker), name);
+  }
 }
 
 function listedSubcommands(output) {
@@ -397,22 +470,60 @@ test("better-harness CLI describes command aliases as their canonical command", 
   assert.deepEqual(payload.data.command.aliases, [{ name: "customize", hidden: true }]);
 });
 
-test("better-harness CLI short-circuits help for every registered terminal path", () => {
-  for (const helpFlag of ["--help", "-h"]) {
+test("better-harness CLI short-circuits help for every registered terminal path", async () => {
+  const isolatedRoot = await mkdtemp(path.join(os.tmpdir(), "better-harness-leaf-help-"));
+  try {
+    assertHelpGuardCanaries(isolatedRoot);
     for (const pathSegments of registeredTerminalPaths()) {
-      const args = [...pathSegments, "invalid-before-help", helpFlag];
-      const dispatch = resolveDispatch(args);
+      const canonicalArgs = [...pathSegments, "--help"];
+      const canonicalDispatch = resolveDispatch(canonicalArgs);
+      assert.equal(canonicalDispatch.kind, "dispatch", canonicalArgs.join(" "));
+      const canonical = await runGuardedBetterHarness(canonicalArgs, {
+        cwd: isolatedRoot,
+        expectedOwner: canonicalDispatch.script,
+        expectedOwnerArgs: canonicalDispatch.args,
+      });
+      assert.equal(canonical.status, 0, `${canonicalArgs.join(" ")}\n${canonical.stderr}`);
+      assert.equal(canonical.stderr, "", canonicalArgs.join(" "));
+      assert.notEqual(canonical.stdout, "", canonicalArgs.join(" "));
 
-      assert.equal(dispatch.kind, "dispatch", args.join(" "));
-      assert.equal(dispatch.args.includes("invalid-before-help"), false, args.join(" "));
-      assert.equal(dispatch.args.at(-1), "--help", args.join(" "));
+      for (const helpFlag of ["--help", "-h"]) {
+        const args = [...pathSegments, "invalid-before-help", helpFlag];
+        const dispatch = resolveDispatch(args);
 
-      const result = runBetterHarness(args);
-      assert.equal(result.status, 0, `${args.join(" ")}\n${result.stderr}`);
-      assert.equal(result.stderr, "", args.join(" "));
-      assert.notEqual(result.stdout, "", args.join(" "));
+        assert.equal(dispatch.kind, "dispatch", args.join(" "));
+        assert.equal(dispatch.script, canonicalDispatch.script, args.join(" "));
+        assert.equal(dispatch.args.includes("invalid-before-help"), false, args.join(" "));
+        assert.equal(dispatch.args.at(-1), "--help", args.join(" "));
+
+        const result = await runGuardedBetterHarness(args, {
+          cwd: isolatedRoot,
+          expectedOwner: dispatch.script,
+          expectedOwnerArgs: dispatch.args,
+        });
+        assert.equal(result.status, 0, `${args.join(" ")}\n${result.stderr}`);
+        assert.equal(result.stderr, "", args.join(" "));
+        assert.equal(result.stdout, canonical.stdout, args.join(" "));
+      }
     }
+  } finally {
+    await rm(isolatedRoot, { recursive: true, force: true });
   }
+});
+
+test("better-harness CLI preserves built-in discovery help and literal positional help", () => {
+  const commands = runBetterHarness(["commands", "--help", "--audience", "advanced"]);
+  assert.equal(commands.status, 0, commands.stderr);
+  assert.match(commands.stdout, /agent-customize/u);
+  assert.match(commands.stdout, /session-analysis/u);
+
+  const schema = runBetterHarness(["schema", "--help"]);
+  assert.equal(schema.status, 0, schema.stderr);
+  assert.equal(JSON.parse(schema.stdout).ok, true);
+
+  const positional = resolveDispatch(["cloc", "help"]);
+  assert.equal(positional.kind, "dispatch");
+  assert.deepEqual(positional.args, ["help"]);
 });
 
 test("better-harness CLI group help projects workflow commands", () => {

--- a/test/better-harness-cli.test.mjs
+++ b/test/better-harness-cli.test.mjs
@@ -4,6 +4,8 @@ import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promis
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { resolveDispatch } from "../scripts/better-harness-cli/cli.mjs";
+import { commandInventory } from "../scripts/better-harness-cli/registry.mjs";
 
 const cliPath = path.join(process.cwd(), "scripts", "better-harness.mjs");
 
@@ -18,6 +20,21 @@ function runBetterHarness(args, options = {}) {
 function listedSubcommands(output) {
   const section = output.match(/Subcommands:\n([\s\S]*?)(?:\n\nExamples:|\n\nDiscovery:|\n\nOptions:)/u)?.[1] ?? "";
   return [...section.matchAll(/^  ([a-z][a-z0-9-]+)\s{2,}/gmu)].map((match) => match[1]);
+}
+
+function registeredTerminalPaths() {
+  const paths = [];
+  for (const command of commandInventory().commands) {
+    if (command.kind === "group") {
+      paths.push(...command.subcommands.map((subcommand) => [command.name, subcommand.name]));
+      continue;
+    }
+
+    paths.push([command.name]);
+    paths.push(...command.aliases.map((alias) => [alias.name]));
+    paths.push(...command.subcommands.map((subcommand) => [command.name, subcommand.name]));
+  }
+  return paths;
 }
 
 function git(cwd, args) {
@@ -378,6 +395,24 @@ test("better-harness CLI describes command aliases as their canonical command", 
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.data.command.name, "agent-customize");
   assert.deepEqual(payload.data.command.aliases, [{ name: "customize", hidden: true }]);
+});
+
+test("better-harness CLI short-circuits help for every registered terminal path", () => {
+  for (const helpFlag of ["--help", "-h"]) {
+    for (const pathSegments of registeredTerminalPaths()) {
+      const args = [...pathSegments, "invalid-before-help", helpFlag];
+      const dispatch = resolveDispatch(args);
+
+      assert.equal(dispatch.kind, "dispatch", args.join(" "));
+      assert.equal(dispatch.args.includes("invalid-before-help"), false, args.join(" "));
+      assert.equal(dispatch.args.at(-1), "--help", args.join(" "));
+
+      const result = runBetterHarness(args);
+      assert.equal(result.status, 0, `${args.join(" ")}\n${result.stderr}`);
+      assert.equal(result.stderr, "", args.join(" "));
+      assert.notEqual(result.stdout, "", args.join(" "));
+    }
+  }
 });
 
 test("better-harness CLI group help projects workflow commands", () => {

--- a/test/fixtures/help-side-effect-guard.mjs
+++ b/test/fixtures/help-side-effect-guard.mjs
@@ -1,0 +1,147 @@
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import { syncBuiltinESMExports } from "node:module";
+import net from "node:net";
+import path from "node:path";
+import tls from "node:tls";
+import { fileURLToPath } from "node:url";
+
+const allowedRoot = path.resolve(process.env.BETTER_HARNESS_HELP_GUARD_ALLOWED_ROOT ?? process.cwd());
+const expectedOwner = process.env.BETTER_HARNESS_HELP_GUARD_OWNER
+  ? path.resolve(process.env.BETTER_HARNESS_HELP_GUARD_OWNER)
+  : undefined;
+const expectedOwnerArgs = process.env.BETTER_HARNESS_HELP_GUARD_OWNER_ARGS
+  ? JSON.parse(process.env.BETTER_HARNESS_HELP_GUARD_OWNER_ARGS)
+  : undefined;
+const dispatcher = process.env.BETTER_HARNESS_HELP_GUARD_DISPATCHER
+  ? path.resolve(process.env.BETTER_HARNESS_HELP_GUARD_DISPATCHER)
+  : undefined;
+
+function blocked(kind) {
+  const error = new Error(`HELP_GUARD_${kind}`);
+  error.code = `HELP_GUARD_${kind}`;
+  throw error;
+}
+
+function localPath(value) {
+  if (value instanceof URL) return fileURLToPath(value);
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString();
+  return undefined;
+}
+
+function mayRead(value) {
+  if (typeof value === "number") {
+    if (value === 0) blocked("STDIN");
+    return true;
+  }
+  const candidate = localPath(value);
+  if (!candidate) blocked("READ");
+  const relative = path.relative(allowedRoot, path.resolve(candidate));
+  if (relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))) {
+    return true;
+  }
+  blocked("READ");
+}
+
+function guardRead(object, name) {
+  const original = object[name];
+  if (typeof original !== "function") return;
+  object[name] = function guardedRead(value, ...rest) {
+    mayRead(value);
+    return original.call(this, value, ...rest);
+  };
+}
+
+function guardWrite(object, name) {
+  const original = object[name];
+  if (typeof original !== "function") return;
+  object[name] = function guardedWrite() {
+    blocked("WRITE");
+  };
+}
+
+function opensForWriting(flags) {
+  if (typeof flags === "number") {
+    return (flags & (fs.constants.O_WRONLY | fs.constants.O_RDWR | fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_TRUNC)) !== 0;
+  }
+  return /[wa+]/u.test(String(flags ?? "r"));
+}
+
+function guardOpen(object, name) {
+  const original = object[name];
+  if (typeof original !== "function") return;
+  object[name] = function guardedOpen(value, flags, ...rest) {
+    if (opensForWriting(flags)) blocked("WRITE");
+    mayRead(value);
+    return original.call(this, value, flags, ...rest);
+  };
+}
+
+for (const name of [
+  "accessSync", "createReadStream", "existsSync", "lstatSync", "opendirSync",
+  "readFileSync", "readdirSync", "readlinkSync", "realpathSync", "statSync", "watch", "watchFile",
+]) {
+  guardRead(fs, name);
+}
+for (const name of ["access", "opendir", "readFile", "readdir", "readlink", "realpath", "stat", "lstat", "watch"]) {
+  guardRead(fsPromises, name);
+}
+guardOpen(fs, "openSync");
+guardOpen(fsPromises, "open");
+for (const name of [
+  "appendFileSync", "chmodSync", "chownSync", "copyFileSync", "cpSync", "createWriteStream", "mkdirSync",
+  "renameSync", "rmSync", "rmdirSync", "truncateSync", "unlinkSync", "utimesSync", "writeFileSync",
+]) {
+  guardWrite(fs, name);
+}
+for (const name of ["appendFile", "chmod", "chown", "copyFile", "cp", "mkdir", "rename", "rm", "rmdir", "truncate", "unlink", "utimes", "writeFile"]) {
+  guardWrite(fsPromises, name);
+}
+
+function isExpectedOwner(command, args) {
+  return expectedOwner
+    && dispatcher
+    && process.argv[1]
+    && path.resolve(process.argv[1]) === dispatcher
+    && path.resolve(command) === path.resolve(process.execPath)
+    && Array.isArray(args)
+    && path.resolve(args[0]) === expectedOwner
+    && JSON.stringify(args.slice(1)) === JSON.stringify(expectedOwnerArgs);
+}
+
+for (const name of ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"]) {
+  const original = childProcess[name];
+  if (typeof original !== "function") continue;
+  childProcess[name] = function guardedProcess(command, args, ...rest) {
+    if (name === "spawnSync" && isExpectedOwner(command, args)) {
+      return original.call(this, command, args, ...rest);
+    }
+    return blocked("PROCESS");
+  };
+}
+
+for (const [object, names] of [
+  [net, ["connect", "createConnection"]],
+  [tls, ["connect"]],
+  [http, ["get", "request"]],
+  [https, ["get", "request"]],
+]) {
+  for (const name of names) {
+    if (typeof object[name] === "function") object[name] = () => blocked("NETWORK");
+  }
+}
+net.Socket.prototype.connect = () => blocked("NETWORK");
+globalThis.fetch = () => blocked("NETWORK");
+
+Object.defineProperty(process, "stdin", {
+  configurable: true,
+  get() {
+    return blocked("STDIN");
+  },
+});
+
+syncBuiltinESMExports();


### PR DESCRIPTION
## Summary

Complete side-effect-free `--help` and `-h` handling for every registered leaf command.

## Why

- Issue/Story: #37
- User or maintainer outcome: invalid or incomplete arguments before help no longer trigger runtime work.

## Traceability and Scope

- Spec/ADR: `docs/specs/2026-07-31-37-leaf-command-help.md`
- Acceptance criteria addressed: AC-1, AC-2, AC-3, AC-4, AC-5
- Canonical owners changed: CLI dispatcher; `cloc`; `dependency-governance`; `harness checkup`; `core-change-watch` help handlers
- Explicit non-goals: normal command execution, command registry metadata, and command paths remain unchanged.

## Change Type

- [x] Bug fix

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `node --test test/better-harness-cli.test.mjs` | 35 passed; 1 Windows symlink skip |
| `node --test test/doc-link-graph.test.mjs` | 6 passed |
| `npm run pack:verify` | passed |
| `npm test` | 1041 passed; 4 local Windows symlink-permission failures |

The inventory test runs every registered terminal path from an isolated non-Git directory, compares canonical help output, verifies exact owner dispatch, and activates filesystem, stdin, process/Git, and network canaries.

## Risk and Recovery

- Cross-platform: argv-only dispatch; CI covers Windows, macOS, and Linux.
- Package impact: package verification passed.
- Recovery: revert this PR.
- Residual risk: the new CI run requires maintainer approval before execution.

## AI Involvement

- Level: Generated
- Human review and validation: automated checks listed above; no independent human review recorded.