### PR TITLE
fix(analysis): allow safe contained instruction aliases

### DIFF
--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -13,14 +13,14 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
 - AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
-- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, a manifest route rather than an instruction adapter, or an instruction route owned by a different directory scope, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, reached through another symlink hop, a manifest route rather than an instruction adapter, or an instruction route owned by a different directory scope, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
 - AC-4: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
 
 ## Non-goals
 
 - Do not follow links whose canonical target escapes the topology root.
 - Do not use a tracked structural link to admit ignored, untracked, or non-structural target content.
-- Do not alias workspace or package manifests or borrow instructions from another ownership scope: redirected structural links are limited to tracked instruction routes in the same directory.
+- Do not alias workspace or package manifests, borrow instructions from another ownership scope, or traverse a symlink chain: redirected structural links are limited to one relative hop between tracked instruction routes in the same directory.
 - Do not change source-mutation, secret-scan, or backup-path symlink policies.
 - Do not change workspace topology, finding, or report schemas.
 
@@ -34,9 +34,9 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
 - AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
-- AC-3: `node --test --test-name-pattern='across ownership scopes|ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
+- AC-3: `node --test --test-name-pattern='across ownership scopes|untracked hop|ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
 - AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
 - AC-4: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
-- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked same-scope instruction target proof would expose ignored local content or let one route fabricate another route's ownership. Review must verify every check before the item enters structural discovery.
+- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without direct, tracked, same-scope instruction target proof would expose ignored local content or let one route fabricate another route's ownership. Review must verify every check before the item enters structural discovery.
 
-Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus cross-owner, outside-root, ignored-target, non-structural-target, and manifest-alias rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.
+Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus chained-hop, cross-owner, outside-root, ignored-target, non-structural-target, and manifest-alias rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.

--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -13,26 +13,29 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
 - AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
-- AC-3: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
+- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, or not itself a tracked structural inventory entry, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-4: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
 
 ## Non-goals
 
 - Do not follow links whose canonical target escapes the topology root.
+- Do not use a tracked structural link to admit ignored, untracked, or non-structural target content.
 - Do not change source-mutation, secret-scan, or backup-path symlink policies.
 - Do not change workspace topology, finding, or report schemas.
 
 ## Plan and Tasks
 
 1. Add a real-filesystem topology regression for an in-root tracked instruction link.
-2. Resolve each structural candidate before deciding whether it is a safe file, while retaining canonical-root containment.
-3. Re-run the contained-link test, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
+2. Resolve each structural candidate before deciding whether it is a safe file, retaining canonical-root containment and requiring redirected targets to be tracked structural inventory entries.
+3. Re-run the contained-link test, ignored/non-structural target tests, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
 
 ## Test and Review Evidence
 
 - AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
 - AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
+- AC-3: `node --test --test-name-pattern='ignored in-root file|non-structural file' test/workspace-topology.test.mjs`
 - AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
-- AC-3: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
-- Risk: accepting a link before canonical containment would expose external files. Review must verify that containment is checked before the item enters structural discovery.
+- AC-4: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
+- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked structural target proof would expose ignored local content. Review must verify both checks before the item enters structural discovery.
 
-Local evidence on 2026-08-02: the complete topology test file passes, including both contained and escaping structural links; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.
+Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus outside-root, ignored-target, and non-structural-target rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.

--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -1,0 +1,38 @@
+# Contained Structural Symlinks
+
+## Traceability
+
+- Spec ID: `contained-structural-symlinks`
+- Status: Implemented
+
+## Intent
+
+Let workspace topology inspect tracked structural files reached through a symbolic link when the canonical file remains inside the topology root. This supports repositories that expose one canonical agent guide through provider-specific adapter links without downgrading otherwise complete evidence collection.
+
+## Acceptance Scenarios
+
+- AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
+- AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-3: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
+
+## Non-goals
+
+- Do not follow links whose canonical target escapes the topology root.
+- Do not change source-mutation, secret-scan, or backup-path symlink policies.
+- Do not change workspace topology, finding, or report schemas.
+
+## Plan and Tasks
+
+1. Add a real-filesystem topology regression for an in-root tracked instruction link.
+2. Resolve each structural candidate before deciding whether it is a safe file, while retaining canonical-root containment.
+3. Re-run the contained-link test, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
+
+## Test and Review Evidence
+
+- AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
+- AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
+- AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
+- AC-3: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
+- Risk: accepting a link before canonical containment would expose external files. Review must verify that containment is checked before the item enters structural discovery.
+
+Local evidence on 2026-08-02: the complete topology test file passes, including both contained and escaping structural links; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.

--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -13,29 +13,30 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
 - AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
-- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, or not itself a tracked structural inventory entry, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, or a manifest route rather than an instruction adapter, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
 - AC-4: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
 
 ## Non-goals
 
 - Do not follow links whose canonical target escapes the topology root.
 - Do not use a tracked structural link to admit ignored, untracked, or non-structural target content.
+- Do not alias workspace or package manifests: redirected structural links are limited to tracked instruction routes.
 - Do not change source-mutation, secret-scan, or backup-path symlink policies.
 - Do not change workspace topology, finding, or report schemas.
 
 ## Plan and Tasks
 
 1. Add a real-filesystem topology regression for an in-root tracked instruction link.
-2. Resolve each structural candidate before deciding whether it is a safe file, retaining canonical-root containment and requiring redirected targets to be tracked structural inventory entries.
+2. Resolve each structural candidate before deciding whether it is a safe file, retaining canonical-root containment and requiring redirected targets to be tracked instruction inventory entries.
 3. Re-run the contained-link test, ignored/non-structural target tests, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
 
 ## Test and Review Evidence
 
 - AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
 - AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
-- AC-3: `node --test --test-name-pattern='ignored in-root file|non-structural file' test/workspace-topology.test.mjs`
+- AC-3: `node --test --test-name-pattern='ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
 - AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
 - AC-4: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
-- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked structural target proof would expose ignored local content. Review must verify both checks before the item enters structural discovery.
+- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked instruction target proof would expose ignored local content or let one manifest fabricate another route's ownership. Review must verify both checks before the item enters structural discovery.
 
 Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus outside-root, ignored-target, and non-structural-target rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.

--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -13,14 +13,14 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
 - AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
-- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, or a manifest route rather than an instruction adapter, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, a manifest route rather than an instruction adapter, or an instruction route owned by a different directory scope, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
 - AC-4: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
 
 ## Non-goals
 
 - Do not follow links whose canonical target escapes the topology root.
 - Do not use a tracked structural link to admit ignored, untracked, or non-structural target content.
-- Do not alias workspace or package manifests: redirected structural links are limited to tracked instruction routes.
+- Do not alias workspace or package manifests or borrow instructions from another ownership scope: redirected structural links are limited to tracked instruction routes in the same directory.
 - Do not change source-mutation, secret-scan, or backup-path symlink policies.
 - Do not change workspace topology, finding, or report schemas.
 
@@ -34,9 +34,9 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 - AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
 - AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
-- AC-3: `node --test --test-name-pattern='ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
+- AC-3: `node --test --test-name-pattern='across ownership scopes|ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
 - AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
 - AC-4: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
-- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked instruction target proof would expose ignored local content or let one manifest fabricate another route's ownership. Review must verify both checks before the item enters structural discovery.
+- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without tracked same-scope instruction target proof would expose ignored local content or let one route fabricate another route's ownership. Review must verify every check before the item enters structural discovery.
 
-Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus outside-root, ignored-target, and non-structural-target rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.
+Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus cross-owner, outside-root, ignored-target, non-structural-target, and manifest-alias rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.

--- a/docs/specs/2026-08-02-contained-structural-symlinks.md
+++ b/docs/specs/2026-08-02-contained-structural-symlinks.md
@@ -11,16 +11,19 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 ## Acceptance Scenarios
 
-- AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope.
+- AC-1: Given a tracked root `CLAUDE.md` link whose canonical target is the tracked root `AGENTS.md`, resolving workspace topology returns complete coverage and discovers the linked Claude instruction scope. The same holds for a tracked link inside a package directory.
 - AC-2: Given a tracked structural link whose canonical target is outside the topology root, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
-- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, reached through another symlink hop, a manifest route rather than an instruction adapter, or an instruction route owned by a different directory scope, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
+- AC-3: Given a tracked structural link whose in-root target is ignored, untracked, not itself a tracked structural inventory entry, reached through another symlink hop, written as an absolute path, a manifest route rather than an instruction adapter, or an instruction route owned by a different directory scope, resolving workspace topology remains partial and emits `structure-entry-unsafe` for that route.
 - AC-4: A normal Evidence Bundle for a repository using an in-root agent-guide link can complete when its other required lanes and lead evidence are available.
+- AC-5: Given a tracked structural link whose target does not exist, resolving workspace topology remains partial and emits `structure-entry-unavailable` rather than `structure-entry-unsafe`, because the entry cannot be inspected at all.
+- AC-6: Structural route identity folds case only on Windows, so an ordinary tracked file whose on-disk casing differs from its inventory route is not reported as `structure-entry-unsafe`; safety decisions never depend on a non-canonical topology root.
 
 ## Non-goals
 
 - Do not follow links whose canonical target escapes the topology root.
 - Do not use a tracked structural link to admit ignored, untracked, or non-structural target content.
 - Do not alias workspace or package manifests, borrow instructions from another ownership scope, or traverse a symlink chain: redirected structural links are limited to one relative hop between tracked instruction routes in the same directory.
+- Do not accept cross-directory adapter links, such as a tracked `.github/copilot-instructions.md`, `.claude/CLAUDE.md`, or `.cursor/rules/*.mdc` entry that links up to the canonical root agent guide in a parent directory, and do not accept absolute link targets even when they stay inside the root. Those routes keep emitting `structure-entry-unsafe`, which keeps topology partial and therefore fails a normal-depth Evidence Bundle. Widening the accepted hop is tracked separately.
 - Do not change source-mutation, secret-scan, or backup-path symlink policies.
 - Do not change workspace topology, finding, or report schemas.
 
@@ -28,15 +31,23 @@ Let workspace topology inspect tracked structural files reached through a symbol
 
 1. Add a real-filesystem topology regression for an in-root tracked instruction link.
 2. Resolve each structural candidate before deciding whether it is a safe file, retaining canonical-root containment and requiring redirected targets to be tracked instruction inventory entries.
-3. Re-run the contained-link test, ignored/non-structural target tests, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
+3. Compare structural routes and link targets through a shared `pathIdentityKey` helper that folds case only on Windows, and validate the link target against the canonical directory so the decision does not depend on how the caller spelled the topology root.
+4. Re-run the contained-link test, ignored/non-structural target tests, the existing escaping-link test, the complete topology suite, and the real Evidence Bundle command.
+
+Route containment and real-path identity follow the workspace topology contract in
+[monorepo workspace support](2026-07-25-monorepo-workspace-support.md) (AC13).
 
 ## Test and Review Evidence
 
 - AC-1: `node --test --test-name-pattern='contained tracked structural symlink' test/workspace-topology.test.mjs`
 - AC-2: `node --test --test-name-pattern='does not follow a tracked structural symlink outside' test/workspace-topology.test.mjs`
-- AC-3: `node --test --test-name-pattern='across ownership scopes|untracked hop|ignored in-root file|non-structural file|tracked manifest symlink' test/workspace-topology.test.mjs`
+- AC-3: `node --test --test-name-pattern='across ownership scopes|untracked hop|ignored in-root file|non-structural file|tracked manifest symlink|as an absolute path' test/workspace-topology.test.mjs`
+- AC-5: `node --test --test-name-pattern='dangling tracked structural symlink' test/workspace-topology.test.mjs`
+- AC-6: `node --test --test-name-pattern='folds case only on Windows' test/workspace-topology.test.mjs`, plus a manual `discoverWorkspaceStructure` call against a deliberately non-canonical root (`/tmp` symlink on macOS) that accepts the alias with no warnings.
 - AC-1 and AC-2: `node --test test/workspace-topology.test.mjs`
 - AC-4: the frozen `harness evidence-bundle` command recorded in the general-tasks ultrawork evidence ledger.
-- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without direct, tracked, same-scope instruction target proof would expose ignored local content or let one route fabricate another route's ownership. Review must verify every check before the item enters structural discovery.
+- Risk: accepting a link before canonical containment would expose external files; accepting an in-root redirect without direct, tracked, same-scope instruction target proof would expose ignored local content or let one route fabricate another route's ownership. Review must verify every check before the item enters structural discovery. Case-sensitive route comparison is itself a risk in the other direction: on Windows `realpath` reports on-disk casing, so a case-only divergence from the inventory route would otherwise mark an ordinary tracked file unsafe and fail the whole bundle.
 
-Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus chained-hop, cross-owner, outside-root, ignored-target, non-structural-target, and manifest-alias rejection; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.
+Local evidence on 2026-08-02: the complete topology test file passes, including contained structural links plus chained-hop, cross-owner, outside-root, ignored-target, non-structural-target, absolute-target, and manifest-alias rejection, and dangling-link unavailability; the frozen normal Evidence Bundle for `general-tasks` exits 0 with complete topology and every required owner available.
+
+Local evidence on 2026-08-03: `node --test test/workspace-topology.test.mjs` passes 20 tests, and the full `npm run check` suite passes with the nested-package alias, absolute-target rejection, dangling-link warning code, and route-identity cases added.

--- a/scripts/workspace-topology/contract.mjs
+++ b/scripts/workspace-topology/contract.mjs
@@ -35,6 +35,11 @@ function sameAbsolutePath(left, right) {
     : leftPath === rightPath;
 }
 
+export function pathIdentityKey(value) {
+  const text = String(value ?? "");
+  return process.platform === "win32" ? text.toLowerCase() : text;
+}
+
 export function normalizeRoute(value, name = "route") {
   let route = String(value ?? "").replaceAll("\\", "/").trim();
   route = route.replace(/^\.\/+/u, "").replace(/\/+$/u, "");

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -1,4 +1,4 @@
-import { lstat, readFile, realpath } from "node:fs/promises";
+import { lstat, readFile, readlink, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import { normalizeRoute, routeContains } from "./contract.mjs";
@@ -165,6 +165,15 @@ function isInstructionRoute(route) {
       && new Set([".md", ".mdc"]).has(extension));
 }
 
+async function isDirectSameDirectoryLink(absolute, canonical) {
+  const metadata = await lstat(absolute);
+  if (!metadata.isSymbolicLink()) return false;
+  const target = path.normalize(await readlink(absolute));
+  return !path.isAbsolute(target)
+    && path.dirname(target) === "."
+    && path.resolve(path.dirname(absolute), target) === canonical;
+}
+
 async function safeStructureItems(root, items, warnings) {
   const canonicalRoot = await realpath(root);
   const trackedRoutes = new Set(
@@ -184,6 +193,7 @@ async function safeStructureItems(root, items, warnings) {
           && isInstructionRoute(item.route)
           && isInstructionRoute(canonicalRoute)
           && dirnameRoute(item.route) === dirnameRoute(canonicalRoute)
+          && await isDirectSameDirectoryLink(absolute, canonical)
         );
       if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical) || !safeRedirect) {
         warnings.push(warning("structure-entry-unsafe", item.route));

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -150,13 +150,19 @@ function isWithinRoot(root, candidate) {
 
 async function safeStructureItems(root, items, warnings) {
   const canonicalRoot = await realpath(root);
+  const trackedRoutes = new Set(
+    items.filter((item) => item.provenance === "tracked").map((item) => item.route),
+  );
   const safe = [];
   for (const item of items) {
     const absolute = path.resolve(root, ...item.route.split("/"));
     try {
       const canonical = await realpath(absolute);
       const metadata = await lstat(canonical);
-      if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical)) {
+      const canonicalRoute = path.relative(canonicalRoot, canonical).split(path.sep).join("/");
+      const safeRedirect = canonicalRoute === item.route
+        || (item.provenance === "tracked" && trackedRoutes.has(canonicalRoute));
+      if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical) || !safeRedirect) {
         warnings.push(warning("structure-entry-unsafe", item.route));
         continue;
       }

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -154,17 +154,13 @@ async function safeStructureItems(root, items, warnings) {
   for (const item of items) {
     const absolute = path.resolve(root, ...item.route.split("/"));
     try {
-      const metadata = await lstat(absolute);
-      if (metadata.isSymbolicLink() || !metadata.isFile()) {
-        warnings.push(warning("structure-entry-unsafe", item.route));
-        continue;
-      }
       const canonical = await realpath(absolute);
-      if (!isWithinRoot(canonicalRoot, canonical)) {
+      const metadata = await lstat(canonical);
+      if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical)) {
         warnings.push(warning("structure-entry-unsafe", item.route));
         continue;
       }
-      safe.push(item);
+      safe.push({ ...item, canonical });
     } catch {
       warnings.push(warning("structure-entry-unavailable", item.route));
     }
@@ -174,7 +170,7 @@ async function safeStructureItems(root, items, warnings) {
 
 async function readInventoryFile(root, item, warnings) {
   try {
-    return await readFile(path.join(root, ...item.route.split("/")), "utf8");
+    return await readFile(item.canonical, "utf8");
   } catch {
     warnings.push(warning("manifest-read-unavailable", item.route));
     return null;

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -1,7 +1,7 @@
 import { lstat, readFile, readlink, realpath } from "node:fs/promises";
 import path from "node:path";
 
-import { normalizeRoute, routeContains } from "./contract.mjs";
+import { normalizeRoute, pathIdentityKey, routeContains } from "./contract.mjs";
 
 const PACKAGE_MARKERS = new Set(["package.json", "go.mod", "Cargo.toml"]);
 const CONTAINER_ROOTS = new Set([
@@ -169,15 +169,17 @@ async function isDirectSameDirectoryLink(absolute, canonical) {
   const metadata = await lstat(absolute);
   if (!metadata.isSymbolicLink()) return false;
   const target = path.normalize(await readlink(absolute));
-  return !path.isAbsolute(target)
-    && path.dirname(target) === "."
-    && path.resolve(path.dirname(absolute), target) === canonical;
+  if (path.isAbsolute(target) || path.dirname(target) !== ".") return false;
+  const resolved = path.resolve(path.dirname(canonical), target);
+  return pathIdentityKey(resolved) === pathIdentityKey(canonical);
 }
 
 async function safeStructureItems(root, items, warnings) {
   const canonicalRoot = await realpath(root);
-  const trackedRoutes = new Set(
-    items.filter((item) => item.provenance === "tracked").map((item) => item.route),
+  const trackedRoutes = new Map(
+    items
+      .filter((item) => item.provenance === "tracked")
+      .map((item) => [pathIdentityKey(item.route), item.route]),
   );
   const safe = [];
   for (const item of items) {
@@ -186,20 +188,21 @@ async function safeStructureItems(root, items, warnings) {
       const canonical = await realpath(absolute);
       const metadata = await lstat(canonical);
       const canonicalRoute = path.relative(canonicalRoot, canonical).split(path.sep).join("/");
-      const safeRedirect = canonicalRoute === item.route
+      const targetRoute = trackedRoutes.get(pathIdentityKey(canonicalRoute));
+      const safeRedirect = pathIdentityKey(canonicalRoute) === pathIdentityKey(item.route)
         || (
           item.provenance === "tracked"
-          && trackedRoutes.has(canonicalRoute)
+          && targetRoute !== undefined
           && isInstructionRoute(item.route)
-          && isInstructionRoute(canonicalRoute)
-          && dirnameRoute(item.route) === dirnameRoute(canonicalRoute)
+          && isInstructionRoute(targetRoute)
+          && dirnameRoute(item.route) === dirnameRoute(targetRoute)
           && await isDirectSameDirectoryLink(absolute, canonical)
         );
       if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical) || !safeRedirect) {
         warnings.push(warning("structure-entry-unsafe", item.route));
         continue;
       }
-      safe.push({ ...item, canonical });
+      safe.push(item);
     } catch {
       warnings.push(warning("structure-entry-unavailable", item.route));
     }
@@ -209,7 +212,7 @@ async function safeStructureItems(root, items, warnings) {
 
 async function readInventoryFile(root, item, warnings) {
   try {
-    return await readFile(item.canonical, "utf8");
+    return await readFile(path.join(root, ...item.route.split("/")), "utf8");
   } catch {
     warnings.push(warning("manifest-read-unavailable", item.route));
     return null;

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -148,6 +148,23 @@ function isWithinRoot(root, candidate) {
     || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
+function isInstructionRoute(route) {
+  const base = path.posix.basename(route);
+  const extension = path.posix.extname(route).toLowerCase();
+  return base === "AGENTS.md"
+    || base === "CLAUDE.md"
+    || base === "CLAUDE.local.md"
+    || base === "QWEN.md"
+    || route === ".github/copilot-instructions.md"
+    || (route.startsWith(".github/instructions/") && route.endsWith(".instructions.md"))
+    || ((route.includes("/.claude/rules/") || route.startsWith(".claude/rules/"))
+      && new Set([".md", ".mdc"]).has(extension))
+    || ((route.includes("/.cursor/rules/") || route.startsWith(".cursor/rules/"))
+      && new Set([".md", ".mdc"]).has(extension))
+    || ((route.includes("/.qoder/rules/") || route.startsWith(".qoder/rules/"))
+      && new Set([".md", ".mdc"]).has(extension));
+}
+
 async function safeStructureItems(root, items, warnings) {
   const canonicalRoot = await realpath(root);
   const trackedRoutes = new Set(
@@ -161,7 +178,12 @@ async function safeStructureItems(root, items, warnings) {
       const metadata = await lstat(canonical);
       const canonicalRoute = path.relative(canonicalRoot, canonical).split(path.sep).join("/");
       const safeRedirect = canonicalRoute === item.route
-        || (item.provenance === "tracked" && trackedRoutes.has(canonicalRoute));
+        || (
+          item.provenance === "tracked"
+          && trackedRoutes.has(canonicalRoute)
+          && isInstructionRoute(item.route)
+          && isInstructionRoute(canonicalRoute)
+        );
       if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical) || !safeRedirect) {
         warnings.push(warning("structure-entry-unsafe", item.route));
         continue;
@@ -294,22 +316,7 @@ export async function discoverWorkspaceStructure({
   }
 
   const instructionScopes = [];
-  const instructionItems = structureItems.filter((item) => {
-    const base = path.posix.basename(item.route);
-    const extension = path.posix.extname(item.route).toLowerCase();
-    return base === "AGENTS.md"
-      || base === "CLAUDE.md"
-      || base === "CLAUDE.local.md"
-      || base === "QWEN.md"
-      || item.route === ".github/copilot-instructions.md"
-      || (item.route.startsWith(".github/instructions/") && item.route.endsWith(".instructions.md"))
-      || ((item.route.includes("/.claude/rules/") || item.route.startsWith(".claude/rules/"))
-        && new Set([".md", ".mdc"]).has(extension))
-      || ((item.route.includes("/.cursor/rules/") || item.route.startsWith(".cursor/rules/"))
-        && new Set([".md", ".mdc"]).has(extension))
-      || ((item.route.includes("/.qoder/rules/") || item.route.startsWith(".qoder/rules/"))
-        && new Set([".md", ".mdc"]).has(extension));
-  });
+  const instructionItems = structureItems.filter((item) => isInstructionRoute(item.route));
 
   for (const item of instructionItems) {
     const base = path.posix.basename(item.route);

--- a/scripts/workspace-topology/manifests.mjs
+++ b/scripts/workspace-topology/manifests.mjs
@@ -183,6 +183,7 @@ async function safeStructureItems(root, items, warnings) {
           && trackedRoutes.has(canonicalRoute)
           && isInstructionRoute(item.route)
           && isInstructionRoute(canonicalRoute)
+          && dirnameRoute(item.route) === dirnameRoute(canonicalRoute)
         );
       if (!metadata.isFile() || !isWithinRoot(canonicalRoot, canonical) || !safeRedirect) {
         warnings.push(warning("structure-entry-unsafe", item.route));

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -417,6 +417,64 @@ test("workspace topology accepts a contained tracked structural symlink", async 
   }
 });
 
+test("workspace topology rejects a tracked structural symlink to an ignored in-root file", async (t) => {
+  const repo = await makeGitRepo({
+    ".gitignore": ".env\n",
+  }, {
+    ".env": "LOCAL_ONLY=placeholder\n",
+  });
+  try {
+    try {
+      await symlink(".env", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add ignored-target structural symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.equal(
+      result.topology.instructionScopes.items.some((item) => item.route === "CLAUDE.md"),
+      false,
+    );
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("workspace topology rejects a tracked structural symlink to a non-structural file", async (t) => {
+  const repo = await makeGitRepo({
+    "README.md": "# project\n",
+  });
+  try {
+    try {
+      await symlink("README.md", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add non-structural-target symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.equal(
+      result.topology.instructionScopes.items.some((item) => item.route === "CLAUDE.md"),
+      false,
+    );
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
 test("workspace topology does not follow a tracked structural symlink outside the Git root", async () => {
   const repo = await makeGitRepo({
     "package.json": JSON.stringify({ workspaces: ["packages/*"] }),

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -475,6 +475,32 @@ test("workspace topology rejects a tracked structural symlink to a non-structura
   }
 });
 
+test("workspace topology rejects a tracked manifest symlink to another manifest route", async (t) => {
+  const repo = await makeGitRepo({
+    "package.json": JSON.stringify({ name: "root" }),
+    "packages/source/package.json": JSON.stringify({ name: "source" }),
+  });
+  try {
+    await mkdir(path.join(repo, "packages", "alias"), { recursive: true });
+    try {
+      await symlink("../source/package.json", path.join(repo, "packages", "alias", "package.json"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "packages/alias/package.json"]);
+    git(repo, ["commit", "-q", "-m", "add tracked manifest alias fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "packages/alias/package.json"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
 test("workspace topology does not follow a tracked structural symlink outside the Git root", async () => {
   const repo = await makeGitRepo({
     "package.json": JSON.stringify({ workspaces: ["packages/*"] }),

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { main as topologyMain, parseArgs as parseTopologyArgs } from "../scripts/workspace-topology/cli.mjs";
+import { pathIdentityKey } from "../scripts/workspace-topology/contract.mjs";
 import {
   WORKSPACE_TOPOLOGY_KIND,
   findingTargetErrors,
@@ -415,6 +416,100 @@ test("workspace topology accepts a contained tracked structural symlink", async 
   } finally {
     await rm(repo, { recursive: true, force: true });
   }
+});
+
+test("workspace topology accepts a contained tracked structural symlink inside a package", async (t) => {
+  const repo = await makeGitRepo({
+    "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+    "packages/app/package.json": JSON.stringify({ name: "app" }),
+    "packages/app/AGENTS.md": "# package instructions\n",
+  });
+  try {
+    try {
+      await symlink("AGENTS.md", path.join(repo, "packages", "app", "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "packages/app/CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add nested structural symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "complete");
+    assert.ok(result.topology.instructionScopes.items.some((item) =>
+      item.route === "packages/app/CLAUDE.md" && item.provider === "claude"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("workspace topology rejects a tracked instruction symlink written as an absolute path", async (t) => {
+  const repo = await makeGitRepo({
+    "AGENTS.md": "# canonical instructions\n",
+  });
+  try {
+    try {
+      await symlink(path.join(repo, "AGENTS.md"), path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add absolute-target instruction symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.equal(
+      result.topology.instructionScopes.items.some((item) => item.route === "CLAUDE.md"),
+      false,
+    );
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("workspace topology reports a dangling tracked structural symlink as unavailable", async (t) => {
+  const repo = await makeGitRepo({
+    "AGENTS.md": "# canonical instructions\n",
+  });
+  try {
+    try {
+      await symlink("MISSING.md", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add dangling structural symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unavailable" && item.route === "CLAUDE.md"));
+    assert.equal(
+      result.topology.discovery.warnings.some((item) =>
+        item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"),
+      false,
+    );
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("structural route identity folds case only on Windows", () => {
+  assert.equal(pathIdentityKey("packages/App/AGENTS.md"), process.platform === "win32"
+    ? "packages/app/agents.md"
+    : "packages/App/AGENTS.md");
+  assert.equal(pathIdentityKey(undefined), "");
+  assert.equal(
+    pathIdentityKey("AGENTS.md") === pathIdentityKey("agents.md"),
+    process.platform === "win32",
+  );
 });
 
 test("workspace topology rejects a tracked instruction symlink across ownership scopes", async (t) => {

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -445,6 +445,36 @@ test("workspace topology rejects a tracked instruction symlink across ownership 
   }
 });
 
+test("workspace topology rejects a tracked instruction symlink with an untracked hop", async (t) => {
+  const repo = await makeGitRepo({
+    ".gitignore": ".adapter\n",
+    "AGENTS.md": "# canonical instructions\n",
+  });
+  try {
+    try {
+      await symlink("AGENTS.md", path.join(repo, ".adapter"));
+      await symlink(".adapter", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add chained instruction symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.equal(
+      result.topology.instructionScopes.items.some((item) => item.route === "CLAUDE.md"),
+      false,
+    );
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
 test("workspace topology rejects a tracked structural symlink to an ignored in-root file", async (t) => {
   const repo = await makeGitRepo({
     ".gitignore": ".env\n",

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -417,6 +417,34 @@ test("workspace topology accepts a contained tracked structural symlink", async 
   }
 });
 
+test("workspace topology rejects a tracked instruction symlink across ownership scopes", async (t) => {
+  const repo = await makeGitRepo({
+    "packages/app/AGENTS.md": "# package instructions\n",
+  });
+  try {
+    try {
+      await symlink("packages/app/AGENTS.md", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add cross-scope instruction symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "partial");
+    assert.equal(
+      result.topology.instructionScopes.items.some((item) => item.route === "CLAUDE.md"),
+      false,
+    );
+    assert.ok(result.topology.discovery.warnings.some((item) =>
+      item.code === "structure-entry-unsafe" && item.route === "CLAUDE.md"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
 test("workspace topology rejects a tracked structural symlink to an ignored in-root file", async (t) => {
   const repo = await makeGitRepo({
     ".gitignore": ".env\n",

--- a/test/workspace-topology.test.mjs
+++ b/test/workspace-topology.test.mjs
@@ -393,6 +393,30 @@ test("workspace topology resolves a symlinked package through its real path", as
   }
 });
 
+test("workspace topology accepts a contained tracked structural symlink", async (t) => {
+  const repo = await makeGitRepo({
+    "AGENTS.md": "# canonical instructions\n",
+  });
+  try {
+    try {
+      await symlink("AGENTS.md", path.join(repo, "CLAUDE.md"));
+    } catch (error) {
+      t.skip(`symlink unavailable: ${error.message}`);
+      return;
+    }
+    git(repo, ["add", "CLAUDE.md"]);
+    git(repo, ["commit", "-q", "-m", "add contained structural symlink fixture"]);
+
+    const result = await resolveWorkspaceTopology({ workspace: repo });
+
+    assert.equal(result.topology.status, "complete");
+    assert.ok(result.topology.instructionScopes.items.some((item) =>
+      item.route === "CLAUDE.md" && item.provider === "claude" && item.activation === "effective"));
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
 test("workspace topology does not follow a tracked structural symlink outside the Git root", async () => {
   const repo = await makeGitRepo({
     "package.json": JSON.stringify({ workspaces: ["packages/*"] }),


### PR DESCRIPTION
## Summary

- allow direct, relative, same-directory tracked instruction-route symlinks to resolve inside a Git workspace
- reject links that escape the root, target ignored/untracked/non-structural files, alias manifests, cross ownership scopes, or introduce symlink chains
- use the canonical target for reads and document the accepted topology contract

## Verification

- `node --test test/workspace-topology.test.mjs` (16 tests passed)
- `npm run check` after `npm ci` (1101 tests passed; npm package and runtime bundle verification passed)

No matching open upstream issue was found.
