### PR TITLE
docs(github): simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting a bug. Please keep the reproduction focused on the observable problem.
+        Thanks for reporting a bug. Share the shortest path to the observable problem; maintainers can ask for deeper diagnostics later.
 
   - type: checkboxes
     id: preflight
@@ -17,19 +17,20 @@ body:
         - label: I searched existing issues for this problem.
           required: true
 
-  - type: input
-    id: version
+  - type: textarea
+    id: summary
     attributes:
-      label: Better Harness version
-      description: Copy the version from installed package or plugin metadata. If unavailable, enter a commit SHA or unknown.
-      placeholder: x.y.z, commit SHA, or unknown
+      label: What happened?
+      description: Describe the failure in one or two sentences.
+      placeholder: The report command fails when ...
     validations:
       required: true
 
   - type: dropdown
     id: host
     attributes:
-      label: Host
+      label: Where did it happen?
+      description: Pick the closest host or runtime.
       options:
         - Claude Code
         - Codex
@@ -43,86 +44,46 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: operating-system
-    attributes:
-      label: Operating system
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: installation
-    attributes:
-      label: Installation method
-      options:
-        - Bundled with Qoder Desktop
-        - Host marketplace or plugin manager
-        - Qwen Code extension
-        - Cursor source-local --plugin-dir
-        - Pi package (pi install or pi -e)
-        - npm package or standalone CLI
-        - Source checkout
-        - Other
-    validations:
-      required: true
-
   - type: input
-    id: command
+    id: environment
     attributes:
-      label: Command or feature
-      placeholder: better-harness report --no-sessions
+      label: Version and environment
+      description: Include the Better Harness version if known, plus OS or install source when relevant.
+      placeholder: x.y.z on macOS via npm, or unknown
     validations:
       required: true
 
   - type: textarea
     id: reproduction
     attributes:
-      label: Minimal reproduction
-      description: Use the smallest repository or fixture that reproduces the problem.
+      label: Steps to reproduce
+      description: Include the command, file, or project state needed to see the issue.
       placeholder: |
-        1. Start from ...
-        2. Run ...
-        3. Observe ...
+        1. Run ...
+        2. Open ...
+        3. See ...
     validations:
       required: true
 
   - type: textarea
-    id: expected
+    id: result
     attributes:
-      label: Expected result
-      placeholder: Describe the observable success condition.
+      label: Expected vs actual result
+      description: Tell us what you expected and what happened instead.
+      placeholder: |
+        Expected: ...
+        Actual: ...
     validations:
       required: true
 
   - type: textarea
-    id: actual
+    id: logs
     attributes:
-      label: Actual result
-      description: Include the smallest useful error or artifact excerpt.
-    validations:
-      required: true
-
-  - type: textarea
-    id: diagnostics
-    attributes:
-      label: Diagnostics
-      description: Include relevant Node.js, npm, host versions, or focused test output.
-      render: shell
+      label: Logs or screenshots
+      description: Paste the smallest useful error, test output, report excerpt, or screenshot link.
 
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional context
-      description: Note regressions, workarounds, frequency, and whether the issue reproduces with `--no-sessions` when applicable.
-
-  - type: checkboxes
-    id: contribution
-    attributes:
-      label: Contribution
-      options:
-        - label: I can submit a focused fix or fixture after the issue is triaged.
+      label: Anything else?
+      description: Add regressions, workarounds, frequency, or other context if it helps triage.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,99 +7,51 @@ body:
   - type: markdown
     attributes:
       value: |
-        Describe the user or maintainer outcome before the implementation. Read `docs/community.md` when proposing a Skill, model, detector, hook, adapter, report mode, or style.
+        Tell us the user or maintainer outcome you want. A rough idea is enough; maintainers can help shape scope and validation.
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight
       options:
-        - label: I searched existing issues and current extension surfaces.
+        - label: I searched existing issues for a similar request.
           required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: Problem
-      description: What recurring task, failure, or missing capability creates the need?
+      label: What problem are you trying to solve?
+      description: Describe the recurring task, failure, or missing capability.
+      placeholder: I often need to ... but Better Harness currently ...
     validations:
       required: true
 
   - type: textarea
     id: outcome
     attributes:
-      label: Desired outcome
-      description: State observable acceptance conditions without prescribing unnecessary implementation detail.
-    validations:
-      required: true
-
-  - type: dropdown
-    id: surface
-    attributes:
-      label: Likely extension surface
-      options:
-        - Existing Skill guidance or references
-        - New or extended Skill workflow
-        - Model, detector, or analysis capability
-        - Hook or lifecycle enforcement
-        - Host adapter or packaging
-        - Report mode, template, or visual style
-        - Documentation or community process
-        - Unsure
-    validations:
-      required: true
-
-  - type: dropdown
-    id: host
-    attributes:
-      label: Host scope
-      options:
-        - Host-neutral
-        - Claude Code
-        - Codex
-        - Qoder
-        - Cursor
-        - Multiple hosts
-        - Other or unsure
+      label: What would success look like?
+      description: Describe the visible result without needing to design the implementation.
+      placeholder: I would be able to ...
     validations:
       required: true
 
   - type: textarea
-    id: evidence
+    id: scope
     attributes:
-      label: Evidence and frequency
-      description: Provide bounded examples, issue links, or a synthetic fixture showing why this should become a durable project capability.
-
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed approach
-      description: Name the canonical owner, activation path, validation evidence, and compatibility boundary if known.
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Explain why existing guidance, a one-off command, or another extension surface is insufficient.
-
-  - type: textarea
-    id: risk
-    attributes:
-      label: Compatibility and delivery impact
-      description: Note host coupling, generated-artifact changes, migration needs, or breaking behavior. Write "None known" only after considering each boundary.
+      label: Where would this be used?
+      description: Name any affected host, command, Skill, report, docs page, or workflow if you know it.
+      placeholder: Qoder, Cursor, standalone CLI, reports, docs, unsure...
     validations:
       required: true
 
   - type: textarea
-    id: validation
+    id: examples
     attributes:
-      label: Validation plan
-      description: What fixture, test, preview, package check, or cross-platform evidence would prove the outcome?
+      label: Examples or evidence
+      description: Add links, screenshots, repeated cases, or a short scenario if available.
 
-  - type: checkboxes
-    id: contribution
+  - type: textarea
+    id: notes
     attributes:
-      label: Contribution
-      options:
-        - label: I am willing to help refine a spec or acceptance scenarios.
-        - label: I am willing to submit a focused implementation after maintainers confirm the owner and scope.
+      label: Anything else?
+      description: Add constraints, compatibility concerns, alternatives, or willingness to contribute if helpful.

--- a/test/docs-dx.test.mjs
+++ b/test/docs-dx.test.mjs
@@ -112,7 +112,7 @@ test("first-report guidance no longer claims one invocation works for every host
   assert.match(firstReportZh, /\[示例报告\]\(pathname:\/\/\/demo\/better-harness-report\/\)/u);
 });
 
-test("bug report intake does not hard-code a release and covers current host paths", () => {
+test("bug report intake stays lightweight and covers current host paths", () => {
   const issueForm = readUtf8(".github", "ISSUE_TEMPLATE", "bug_report.yml");
 
   assert.doesNotMatch(issueForm, /current repository baseline|placeholder:\s*0\.3\.0/u);
@@ -127,7 +127,21 @@ test("bug report intake does not hard-code a release and covers current host pat
   ]) {
     assert.match(issueForm, new RegExp(`- ${host.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}`));
   }
-  assert.match(issueForm, /Host marketplace or plugin manager/u);
-  assert.match(issueForm, /Cursor source-local --plugin-dir/u);
-  assert.match(issueForm, /npm package or standalone CLI/u);
+  assert.match(issueForm, /id: environment/u);
+  assert.doesNotMatch(issueForm, /id: operating-system|id: installation|id: command/u);
+  assert.doesNotMatch(issueForm, /Host marketplace or plugin manager|Cursor source-local --plugin-dir|npm package or standalone CLI/u);
+  assert.equal(countMatches(issueForm, /required: true/gu), 6);
+});
+
+test("feature request intake stays outcome-focused", () => {
+  const issueForm = readUtf8(".github", "ISSUE_TEMPLATE", "feature_request.yml");
+
+  assert.match(issueForm, /What problem are you trying to solve\?/u);
+  assert.match(issueForm, /What would success look like\?/u);
+  assert.match(issueForm, /id: scope/u);
+  assert.doesNotMatch(
+    issueForm,
+    /Likely extension surface|Proposed approach|Validation plan|Compatibility and delivery impact|canonical owner|activation path/u,
+  );
+  assert.equal(countMatches(issueForm, /required: true/gu), 4);
 });


### PR DESCRIPTION
## Summary
- simplify the bug report form around summary, host, environment, reproduction, and result
- simplify the feature request form around problem, outcome, scope, and optional examples
- update docs DX assertions so issue intake stays lightweight while preserving host coverage

## Validation
- node --test test/docs-dx.test.mjs

## Traceability
- Request: simplify the GitHub issue templates
- Risk: GitHub issue intake copy/forms only; no runtime behavior changes