### PR TITLE
chore(deps): bump fast-uri from 3.1.4 to 3.1.5 in docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9026,9 +9026,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Bumps the transitive `fast-uri` pin in `docs/package-lock.json` from 3.1.4 to 3.1.5. Lockfile-only change (3 lines: version, resolved, integrity); no `package.json` edits are needed because the existing `^3.0.1` range already admits the patched release.

## Why

Resolves Dependabot alert https://github.com/QoderAI/better-harness/security/dependabot/5 — GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446 (high, CWE-436). `fast-uri` before 3.1.5 only recognizes a literal `//` authority introducer, so a reference using `\\`, `/\`, or `\/` folds the host into the path while Node's WHATWG `URL` (used by `fetch`/`undici`) reads it as a host — a host-confusion desync for any allowlist or SSRF filter built on `fast-uri`.

Dependency path: `@docusaurus/core -> webpack-dev-server -> schema-utils -> ajv -> fast-uri`. Impact here is limited to the docs build toolchain, but the alert is on the default branch, so it stays open until the patched pin lands.

Note: this closes a Dependabot **alert**, not issue #5 (an unrelated, already-closed adapters issue), so no `Closes` trailer is used. GitHub resolves the alert automatically once the lockfile fix is on `main`.

## Validation

- `npm ls fast-uri` in `docs/` resolves 3.1.5, and the installed tree on disk is 3.1.5 (a `--package-lock-only` update alone leaves the old copy in `node_modules`, so it was reinstalled and re-verified).
- `npm run build` in `docs/` succeeds for both `en` and `zh-Hans`.
- `node --test test/dependency-governance.test.mjs test/docs-site.test.mjs test/docs-dx.test.mjs` → 16/16 pass.

## Risk

Low. Patch-level bump of a build-time transitive dependency, verified by a full docs production build.
