### PR TITLE
docs(hosts): fix broken contributing-new-coding-agent link

### DIFF
--- a/docs/docs/hosts/adapter-matrix.md
+++ b/docs/docs/hosts/adapter-matrix.md
@@ -125,6 +125,6 @@ The canonical matrix, discovery rules, and split triggers live in
 
 ## Contributing another host
 
-Start with [Contributing a Coding Agent Host](./contributing-new-coding-agent).
+Start with [Contributing a Coding Agent Host](./contributing-new-coding-agent.md).
 It separates native shell, configured-asset, session, output, and packaging
 claims and links Qwen Code and GitHub Copilot pull requests as worked examples.


### PR DESCRIPTION
## Summary

The "Contributing another host" link in `docs/docs/hosts/adapter-matrix.md` pointed to `./contributing-new-coding-agent` (missing the `.md` extension). The target file exists; agent-lint's `missing-local-reference` check resolves references with `pathExists` and does not auto-append the extension, so the link was reported as a broken local reference although Docusaurus would resolve it.

Link now points to `./contributing-new-coding-agent.md`.

## Why

Maintenance. The broken link surfaces as an **error**-level finding from `agent-lint` / `review-trigger` (`missing-local-reference`), which blocks/poisons the harness's own review tooling on this repository.

## Traceability and Scope

- Spec/ADR, if applicable: none
- Acceptance criteria addressed: link resolves to an existing file
- Canonical owners changed: none
- Explicit non-goals: none

## Change Type

- [x] Documentation/community

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `node scripts/review-trigger/cli.mjs --mode=stop --json` (cwd=repo) | errors dropped 1 → 0; remaining findings are warnings/advisories |

Manual or visual evidence: link now points to existing `contributing-new-coding-agent.md` in the same directory.

## Risk and Recovery

- Compatibility and cross-platform impact: none (docs-only)
- Package, plugin, schema, or generated-file impact: none
- Rollback or recovery path: revert the single-line change
- Residual risk or unverified boundary: none

## AI Involvement

- Level: Assisted (change authored and verified with the help of Qwen Code; reviewed by human)
- Human review and validation: user reviewed the diff before submission