### PR TITLE
chore(release): prepare 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Better Harness plugins for AI delivery readiness.",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "plugins": [
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/",
   "interface": {

--- a/.qoder-plugin/plugin.json
+++ b/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "descriptionZh": "构建面向 AI 的工程体系，让编码智能体安全地理解、变更、评审、报告并持续改进软件。",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 This file records notable public changes to Better Harness. Entries describe
 observable behavior and compatibility, not every internal refactor.
 
+## 0.6.0 - 2026-08-13
+
+### Added
+
+- Harness Inspector is now available from the published CLI through
+  `better-harness harness-inspector` and the `better-harness inspector`
+  shortcut. `inspector render` creates a self-contained, read-only HTML
+  workbench that relates Feature Tree stages, Stories, prompts, sessions,
+  tool calls, files, and commits across the supported session providers. Its
+  synchronized Evidence Drawer explains why evidence is linked, states known
+  limitations, and distinguishes commits created during a session from files
+  merely present in those commits.
+
+- `better-harness commit-session-link` correlates bounded Git history with
+  coding-agent sessions and renders commit-oriented provenance evidence.
+  Long-session reports can now retain privacy-safe tool activity and file
+  evidence for trace inspection instead of reducing execution to aggregate
+  counts.
+
+- A new Harness Component Snapshot contract and direct CLI captures, compares,
+  and resolves non-authorizing rollback references for bounded project-owned
+  Harness component state. Standard report analysis can also surface
+  evidence-bound native Learning Capture candidates without requiring adapters
+  to assign pattern labels.
+
+### Changed
+
+- The repository test suite now runs on Vitest with human-readable failures in
+  the main GitHub Actions log, source annotations, a Job Summary, and JUnit
+  output. Existing Node assertions remain intact, while Windows, macOS, Linux,
+  Node 22.20.0, and Node 24.x remain release gates.
+
+- Test ownership is organized by capability, and contributor commands now use
+  the same Vitest discovery contract locally and in CI.
+
+### Fixed
+
+- Claude session discovery resolves underscore-based transcript directories,
+  component snapshot failures retain bounded diagnostics, and review-trigger
+  stop-hook results use a structured cross-platform output contract.
+
+- CI test module paths remain valid on Windows drive-letter workspaces, and
+  failure output identifies the owning test instead of reporting only a failed
+  capability group.
+
 ## 0.5.0 - 2026-08-04
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ compatibility boundaries, or more than one canonical owner.
 
 ## Development Setup
 
-Better Harness 0.5.0 supports Node.js `>=22.20.0 <25.0.0` and npm
+Better Harness 0.6.0 supports Node.js `>=22.20.0 <25.0.0` and npm
 `>=10.9.3 <12.0.0`. The supported project targets are Windows, macOS, and Linux.
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qoder-ai/better-harness",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "license": "MIT",
   "author": {

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "displayName": "Better Harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/"


### PR DESCRIPTION
## Summary

- bump the npm package, lockfile, and all public host manifests to 0.6.0
- add reader-facing release notes for Harness Inspector, commit/session provenance, component snapshots, native learning review, and Vitest CI reporting
- keep the Node/npm/platform support range unchanged

## Validation

- `npm ci`
- focused manifest and CLI suites — 52 tests
- `npm run pack:verify` — 508 npm entries, 530 runtime zip entries
- `npm run publish:dry-run` — 91 files, 1,305 tests; 508-file 0.6.0 tarball; npmjs latest target
- `git diff --check`

## Release gate

Do not merge until the exact PR head passes Linux Node 22.20.0, macOS Node 22.20.0, Windows Node 22.20.0, and Linux Node 24.x. After merge, tag that exact main commit as `v0.6.0`, publish from the tag, and verify a cold `npx @qoder-ai/better-harness@0.6.0 inspector` invocation.