### PR TITLE
chore(release): prepare 0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Better Harness plugins for AI delivery readiness.",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/",
   "interface": {

--- a/.qoder-plugin/plugin.json
+++ b/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "descriptionZh": "构建面向 AI 的工程体系，让编码智能体安全地理解、变更、评审、报告并持续改进软件。",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 This file records notable public changes to Better Harness. Entries describe
 observable behavior and compatibility, not every internal refactor.
 
+## 0.6.1 - 2026-08-13
+
+### Added
+
+- Harness Inspector now includes a read-only Session Replay that advances
+  through retained prompts, intermediate responses, normalized tool calls,
+  assistant responses, and observed commit events without rerunning tools or
+  resuming the coding-agent session.
+
+- The GitHub Pages site has a first-class Inspector tab with an interactive,
+  deterministic English sample. The bilingual wrapper explains the Workbench,
+  its three evidence lanes, usage flow, evidence labels, and the command for
+  generating a private self-contained report from a local repository.
+
+### Changed
+
+- Session View places the elapsed-time activity chart beside the retained Turn
+  trace, links chart selections into the corresponding calls, and shows a
+  continuous ribbon that distinguishes observed tool execution from
+  unattributed time.
+
+- Capability navigation opens the declared Delivery Tree by default and keeps
+  scope navigation separate from evidence selection. Short sessions expose
+  their tool calls by default while repeated call runs remain compact.
+
+### Fixed
+
+- Story-to-session candidate matching filters generic stop words before scoring
+  overlap, reducing incorrect associations caused by broad terms such as
+  `project`, `session`, or `harness`.
+
+- Session View filters now keep visible tool-call totals and collapsed run
+  groups aligned with the current selection.
+
 ## 0.6.0 - 2026-08-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ compatibility boundaries, or more than one canonical owner.
 
 ## Development Setup
 
-Better Harness 0.6.0 supports Node.js `>=22.20.0 <25.0.0` and npm
+Better Harness 0.6.1 supports Node.js `>=22.20.0 <25.0.0` and npm
 `>=10.9.3 <12.0.0`. The supported project targets are Windows, macOS, and Linux.
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qoder-ai/better-harness",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "license": "MIT",
   "author": {

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "displayName": "Better Harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/"


### PR DESCRIPTION
## Summary

- bump the npm package, lockfile, and all public host manifests to 0.6.1
- document the Inspector Replay, linked trace, navigation, matching, and public GitHub Pages demo changes since 0.6.0
- keep the Node, npm, and platform support range unchanged

## Validation

- `npm ci`
- `npm test` — 92 files, 1,309 tests
- `npm run pack:verify` — 511 npm entries, 533 runtime zip entries
- `npm run publish:dry-run` — 511-file 0.6.1 tarball, 2.5 MB packed / 6.4 MB unpacked, npmjs latest target
- `git diff --check`

## Release gate

Do not merge until the exact PR head passes Linux Node 22.20.0, macOS Node 22.20.0, Windows Node 22.20.0, and Linux Node 24.x. After merge, tag that exact main commit as `v0.6.1`, publish from the tag/main commit through the trusted release workflow, and verify registry metadata plus a cold CLI invocation.