### PR TITLE
chore(release): prepare 0.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "author": {
     "name": "Qoder",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Better Harness plugins for AI delivery readiness.",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "plugins": [
     {
       "name": "better-harness",
       "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "source": "./",
       "author": {
         "name": "Qoder",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Qoder",
     "email": "dev@qoder.com",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/",
   "interface": {

--- a/.qoder-plugin/plugin.json
+++ b/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-harness",
   "displayName": "Better Harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "descriptionZh": "构建面向 AI 的工程体系，让编码智能体安全地理解、变更、评审、报告并持续改进软件。",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 This file records notable public changes to Better Harness. Entries describe
 observable behavior and compatibility, not every internal refactor.
 
+## 0.6.2 - 2026-08-14
+
+### Added
+
+- Harness Inspector now documents its local evidence pipeline, relationship
+  strengths, privacy boundaries, and CLI workflow in a bilingual concept guide
+  with a source-backed architecture diagram.
+
+- The Inspector renderer accepts `--open` so a generated self-contained report
+  can be opened in the default browser after it is written.
+
+### Changed
+
+- Session View uses denser activity and commit presentation, compresses long
+  idle windows, and keeps expanded activity focused while preserving access to
+  the full retained trace.
+
+- Inspector chrome now uses one workspace identity, clearer breadcrumbs, and
+  the visible `Capability` label consistently across navigation and docs.
+
+- Qoder CLI installation guidance now distinguishes the Desktop-bundled path
+  from standalone marketplace and Git installation.
+
+### Fixed
+
+- The Inspector sticky header is isolated from trace content so scrolling and
+  focused expansion do not create overlap.
+
 ## 0.6.1 - 2026-08-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ compatibility boundaries, or more than one canonical owner.
 
 ## Development Setup
 
-Better Harness 0.6.1 supports Node.js `>=22.20.0 <25.0.0` and npm
+Better Harness 0.6.2 supports Node.js `>=22.20.0 <25.0.0` and npm
 `>=10.9.3 <12.0.0`. The supported project targets are Windows, macOS, and Linux.
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qoder-ai/better-harness",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoder-ai/better-harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "license": "MIT",
   "author": {

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "better-harness",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "displayName": "Better Harness",
   "description": "Build an AI-ready engineering system for safe coding-agent delivery and continuous software improvement.",
   "skills": "./skills/"


### PR DESCRIPTION
## Summary

- align the npm package, lockfile, and public host manifests on 0.6.2
- add the 0.6.2 changelog entry for Inspector and Qoder CLI changes since 0.6.1
- keep the release metadata isolated from unrelated source changes

## Validation

- 34 focused manifest and Inspector tests
- full suite: 94 files, 1,321 tests
- package verification: 519 npm entries, 541 runtime ZIP entries
- npm publish dry-run: 2.5 MB tarball, 519 files

## Post-merge

Tag the verified main revision as `v0.6.2`, run the protected npm publish workflow against that tag, and verify a cold-cache `npx @qoder-ai/better-harness@0.6.2 inspector render` creates a self-contained report.