### PR TITLE
docs(hosts): fix stale installation adapter count

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -61,7 +61,7 @@ does not establish a supported installation route.
 :::tip Don't see your Coding Agent?
 
 The six tabs below are the verified Quickstart paths, while the project tracks
-nine host adapters in total. [Compare all adapter support boundaries](./hosts/adapter-matrix),
+ten host adapters in total. [Compare all adapter support boundaries](./hosts/adapter-matrix),
 then [follow the new-host contribution workflow and worked pull requests](./hosts/contributing-new-coding-agent)
 if you want to add or complete an integration. You can also
 [browse current repository pull requests](https://github.com/QoderAI/better-harness/pulls)

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation.mdx
@@ -54,7 +54,7 @@ Codex Desktop 返回手工 UI 步骤；Cursor 在原生命令合同完成核对�
 
 :::tip 没有找到你的 Coding Agent？
 
-下方六个标签页是已验证的快速开始路径，项目当前共跟踪九个宿主适配器。
+下方六个标签页是已验证的快速开始路径，项目当前共跟踪十个宿主适配器。
 请先[比较全部适配器的支持边界](./hosts/adapter-matrix)；如果希望新增或补全
 一个集成，再[按照新增宿主贡献流程与 PR 示例操作](./hosts/contributing-new-coding-agent)。
 开始重复工作前，也可以先[查看仓库当前的 Pull Requests](https://github.com/QoderAI/better-harness/pulls)。


### PR DESCRIPTION
## Summary

Kimi support increased the capability-level host adapter count from nine to ten, but the English and Chinese installation pages still referenced the previous count.

This PR updates those two stale references to match the current host adapter catalog.

## Changes

- Update the English installation page from `nine` to `ten` host adapters.
- Update the Chinese installation page from `九个` to `十个` host adapters.

## Validation

- `npm test` — 94 test files / 1324 tests passed
- `npx vitest run test/skills-docs/doc-link-graph.test.mjs` — 6 tests passed
- `git diff --check` — passed

## Impact

Documentation-only change. No runtime, CLI, packaging, schema, API, or compatibility behavior is affected.

## AI Assistance

AI tools were used to help investigate the documentation drift, review the change, and verify the contribution scope. The final diff was reviewed and validated before submission.
