### PR TITLE
fix(reporting): use host-neutral portable HTML copy

### DIFF
--- a/scripts/harness-analysis/renderers/html-interactions.mjs
+++ b/scripts/harness-analysis/renderers/html-interactions.mjs
@@ -265,14 +265,14 @@ export function renderHtmlInteractionScript(language) {
     ? {
         copy: "复制 AI 修复",
         copied: "已复制",
-        copySuccess: "已复制，请粘贴到 Codex 输入框。",
+        copySuccess: "已复制，请粘贴到当前 Coding Agent 输入框。",
         manualCopy: "自动复制被阻止，请手动复制已选中的提示词。",
         missingPrompt: "这个问题没有可用的 AI 修复提示词。",
       }
     : {
         copy: "Copy AI Fix",
         copied: "Copied",
-        copySuccess: "Copied. Paste into the Codex input.",
+        copySuccess: "Copied. Paste into your coding agent input.",
         manualCopy: "Automatic copy was blocked. Copy the selected prompt manually.",
         missingPrompt: "No AI Fix prompt is available for this finding.",
       };

--- a/scripts/harness-analysis/renderers/html.mjs
+++ b/scripts/harness-analysis/renderers/html.mjs
@@ -580,7 +580,7 @@ function renderHtmlBody(reportData) {
 
   return `<header class="hero" data-section="overview">
     <div class="hero-copy">
-      <span class="eyebrow">${renderVisibleText(copy(language, "Harness Insights · Codex HTML", "Harness 洞察 · Codex HTML"), language)}</span>
+      <span class="eyebrow">${renderVisibleText(copy(language, "Harness Insights · Portable HTML", "Harness 洞察 · 便携式 HTML"), language)}</span>
       <h1>${renderVisibleText(projectName, language)}</h1>
       <p>${renderVisibleText(overview, language)}</p>
       <div class="hero-tags"><span class="pill accent">${renderVisibleText(summary.modelId ?? "Harness", language)}</span><span class="pill muted">${renderVisibleText(copy(language, "Evidence-bound", "证据有界"), language)}</span></div>
@@ -656,7 +656,7 @@ export function renderHtml(reportData, actionContext) {
 <div id="copy-status" class="sr-only" role="status" aria-live="polite"></div>
 <main id="harness-report" data-report-mode="codex-html">
 ${renderHtmlBody(reportData)}
-<footer>${renderVisibleText(copy(reportData.language, "Generated from one reviewed Harness source · self-contained Codex HTML", "由同一份已复核 Harness source 生成 · 自包含 Codex HTML"), language)}</footer>
+<footer>${renderVisibleText(copy(reportData.language, "Generated from one reviewed Harness source · self-contained portable HTML", "由同一份已复核 Harness source 生成 · 自包含便携式 HTML"), language)}</footer>
 </main>
 <dialog id="manual-copy-dialog" class="manual-copy-dialog" aria-labelledby="manual-copy-title" aria-describedby="manual-copy-description">
   <div class="dialog-heading">

--- a/test/reporting/harness-report-render-cli.test.mjs
+++ b/test/reporting/harness-report-render-cli.test.mjs
@@ -202,6 +202,14 @@ function embeddedJson(html, id) {
   return JSON.parse(payload);
 }
 
+function visibleHtmlText(html) {
+  return String(html)
+    .replace(/<(?:script|style)\b[^>]*>[\s\S]*?<\/(?:script|style)>/giu, " ")
+    .replace(/<[^>]+>/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
 function reviewedTaskLoopSource() {
   const source = buildTaskLoopSourceCandidate({
     scope: { platform: "qoder", workspace: "/tmp/render-source-project" },
@@ -1224,6 +1232,49 @@ test("DSH reuses portable HTML report data, target root, and exact artifact cont
   });
 });
 
+test("generated DSH HTML uses host-neutral visible copy in both locales", async () => {
+  await withTempDir("better-harness-dsh-portable-copy-", async (root) => {
+    const findingsPath = path.join(root, "reviewed.findings.json");
+    await writeJson(findingsPath, dshReviewedFindings());
+
+    for (const row of [{
+      language: "en",
+      eyebrow: "Harness Insights · Portable HTML",
+      footer: "Generated from one reviewed Harness source · self-contained portable HTML",
+      copySuccess: "Copied. Paste into your coding agent input.",
+      oldCopySuccess: "Copied. Paste into the Codex input.",
+    }, {
+      language: "zh-CN",
+      eyebrow: "Harness 洞察 · 便携式 HTML",
+      footer: "由同一份已复核 Harness source 生成 · 自包含便携式 HTML",
+      copySuccess: "已复制，请粘贴到当前 Coding Agent 输入框。",
+      oldCopySuccess: "已复制，请粘贴到 Codex 输入框。",
+    }]) {
+      const result = runNode([
+        renderPath,
+        "--findings", findingsPath,
+        "--mode", "html",
+        "--platform", "dsh",
+        "--target", root,
+        "--run-dir", `copy-${row.language}`,
+        "--language", row.language,
+        "--validate",
+        "--json",
+      ], { cwd: root });
+
+      assert.equal(result.status, 0, `${row.language}: ${result.stderr || result.stdout}`);
+      const payload = parseRun(result.stdout);
+      const html = readFileSync(path.join(payload.runDir, "report.html"), "utf8");
+      const visibleText = visibleHtmlText(html);
+      assert.equal(visibleText.includes(row.eyebrow), true, row.language);
+      assert.equal(visibleText.includes(row.footer), true, row.language);
+      assert.equal(visibleText.includes("Codex"), false, row.language);
+      assert.equal(html.includes(row.copySuccess), true, row.language);
+      assert.equal(html.includes(row.oldCopySuccess), false, row.language);
+    }
+  });
+});
+
 test("render routes html output by host id and fails closed on unknown platforms", async () => {
   await withTempDir("better-harness-render-platform-", async (root) => {
     const findingsPath = path.join(root, "input.findings.json");
@@ -1238,6 +1289,11 @@ test("render routes html output by host id and fails closed on unknown platforms
       const payload = parseRun(routed.stdout);
       assert.equal(payload.outputLocation.requestedOut, `.${platform}/better-harness`);
       assert.equal(payload.runDir.includes(path.join(`.${platform}`, "better-harness")), true);
+      const html = readFileSync(path.join(payload.runDir, "report.html"), "utf8");
+      const visibleText = visibleHtmlText(html);
+      assert.equal(visibleText.includes("Harness Insights · Portable HTML"), true, platform);
+      assert.equal(visibleText.includes("Codex HTML"), false, platform);
+      assert.equal(html.includes("Paste into the Codex input"), false, platform);
     }
 
     const rejected = runNode(

--- a/test/reporting/html-report-interactions.test.mjs
+++ b/test/reporting/html-report-interactions.test.mjs
@@ -49,7 +49,7 @@ const ACTION_PROMPT = actionPrompt();
 const LABELS = {
   copy: "Copy AI Fix",
   copied: "Copied",
-  copySuccess: "Copied. Paste into the Codex input.",
+  copySuccess: "Copied. Paste into your coding agent input.",
   manualCopy: "Automatic copy was blocked. Copy the selected prompt manually.",
   missingPrompt: "No AI Fix prompt is available for this finding.",
 };
@@ -421,6 +421,6 @@ test("rendered interaction controller localizes labels without host coupling", (
 
   assert.match(script, /id="harness-report-interactions"/u);
   assert.match(script, /复制 AI 修复/u);
-  assert.match(script, /已复制，请粘贴到 Codex 输入框。/u);
+  assert.match(script, /已复制，请粘贴到当前 Coding Agent 输入框。/u);
   assert.doesNotMatch(script, /window\.openai|codex:\/\/|chatgpt:\/\//iu);
 });


### PR DESCRIPTION
## Summary

Replace legacy Codex-specific visible text in the shared portable HTML renderer with host-neutral English and Chinese copy. Generated DSH HTML now identifies the format as Portable HTML, and copied fixes direct users to their coding agent rather than Codex.

## Why

- Issue/Story: Closes #115
- User or maintainer outcome: every supported portable host receives semantically correct shared report branding while Codex remains one valid portable host.

Independent DSH P0 qualification exposed the shared-renderer bug after #112 / #113 completed. This PR does not reopen or rewrite that historical scope.

## Traceability and Scope

- Spec/ADR, if applicable: No new spec required; Bug #115 is sufficient for this narrow presentation-only correction. The completed #112 spec remains unchanged at AC-1 through AC-16.
- Acceptance criteria addressed: host-neutral visible branding and copy; no Codex-directed instruction in non-Codex generated HTML; aligned English/Chinese output; generated HTML regression; Codex and current portable hosts remain valid without per-host renderers.
- Canonical owners changed: `scripts/harness-analysis/renderers/html.mjs`, `scripts/harness-analysis/renderers/html-interactions.mjs`, and their focused generated-output/interaction tests.
- Explicit non-goals: no layout redesign, renderer architecture rewrite, schema, routing, capability, publication, artifact, Canvas, Studio, dependency, package, version, timeout, or configuration change.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| Literal default `npm run check` in a clean detached `upstream/main` worktree with the exact four-file patch, Node 24.15.0/npm 11.12.1 | PASS in 198.87s: root 1,543 passed/2 skipped; Harness 167; Harness UI 30; Harness Studio 270; pack verification 587 npm/849 runtime entries |
| `volta run --node 22.20.0 npx vitest run test/reporting/harness-report-render-cli.test.mjs test/reporting/html-report-interactions.test.mjs` (npm 10.9.3) | PASS: 2 files, 49 passed, 1 Windows-only skipped |
| `npx vitest run test/reporting/harness-report-render-cli.test.mjs test/reporting/html-report-interactions.test.mjs` on Node 24.15.0/npm 11.12.1 | PASS: 2 files, 49 passed, 1 Windows-only skipped |
| Generated validated DSH `report.html`, English and Chinese | PASS: Portable HTML eyebrow/footer and neutral copy-success payload present; legacy Codex-directed visible strings absent |
| Existing Grok/Kimi/WorkBuddy/Codex HTML routing control | PASS: generated artifacts share Portable HTML branding and retain valid routes |
| `git diff upstream/main...HEAD --check` | PASS |
| Cobb04 attribution guard before commit, before push, and against the pushed fork range | PASS: one Cobb04-authored commit with the required Codex co-author trailer; GitHub resolves the primary author to Cobb04 |

Manual or visual evidence: temporary English and Chinese DSH reports were generated and passed the self-contained HTML validator. Direct in-app visual capture from `file://` was attempted but blocked by the browser's local-file security policy; no bypass or screenshot artifact was used. Generated-output tests exercise header, footer, copy-success text, both locales, non-Codex controls, and Codex validity.

## Risk and Recovery

- Compatibility and cross-platform impact: visible wording changes intentionally for every portable HTML host; no filesystem or platform behavior changes.
- Package, plugin, schema, or generated-file impact: none. Existing package contents were verified unchanged apart from the two renderer source files.
- Rollback or recovery path: revert commit `7e82ca3`.
- Residual risk or unverified boundary: direct local-file screenshot capture is unavailable under the browser security policy; deterministic generated HTML and interaction coverage passed on Node 22 and 24.

## AI Involvement

- Level: Assisted
- Human review and validation: Cobb04 owns the contribution, directed the independent traceability correction and delivery requirements, and required Issue-first ownership, exact-patch validation, cross-version coverage, skeptical diff review, and attribution verification. AI assistance covered diagnosis, implementation, tests, source/duplicate audit, validation execution, and PR preparation.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed. No documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md`. Not applicable: `AGENTS.md` prohibits task-external changelog edits without explicit authorization, and Bug #115 requires no release metadata change.
- [x] I have the right to contribute this work under the repository's MIT License.
