### PR TITLE
fix(reporting): use canonical Session population in HTML

### DIFF
--- a/scripts/harness-analysis/renderers/html.mjs
+++ b/scripts/harness-analysis/renderers/html.mjs
@@ -50,6 +50,29 @@ function formatNumber(value, locale) {
   }).format(number(value));
 }
 
+function reviewedSessionPopulation(summary, language) {
+  // Usage efficiency is a separate all-eligible activity census. The visible
+  // reviewed-Session metric follows the evidence selection used by findings.
+  const selection = summary?.evidenceBoundary?.manifest?.selection
+    ?? summary?.atAGlance?.coverage?.selection;
+  const hasCounts = selection
+    && Object.hasOwn(selection, "analyzedCount")
+    && Object.hasOwn(selection, "eligibleCount");
+  const analyzed = Number(selection?.analyzedCount);
+  const eligible = Number(selection?.eligibleCount);
+  const available = hasCounts
+    && Number.isInteger(analyzed)
+    && analyzed >= 0
+    && Number.isInteger(eligible)
+    && eligible >= 0;
+  return {
+    value: available
+      ? `${formatNumber(analyzed, language)} / ${formatNumber(eligible, language)}`
+      : "N/A",
+    confidence: available ? selection.confidence ?? "" : "",
+  };
+}
+
 function copy(language, en, zh) {
   return language === "zh-CN" ? zh : en;
 }
@@ -541,14 +564,14 @@ function renderCustomize(summary, language) {
 function renderEvidence(summary, language) {
   const boundary = summary?.evidenceBoundary ?? {};
   const coverage = boundary?.episodeCoverage ?? summary?.atAGlance?.coverage ?? {};
-  const selection = boundary?.manifest?.selection ?? coverage?.selection ?? {};
+  const population = reviewedSessionPopulation(summary, language);
   const learning = summary?.learningCapture ?? {};
   const facts = [
     [copy(language, "Evidence mode", "证据模式"), summary?.evidenceMode ?? "—"],
     [copy(language, "Task episodes", "任务 Episode"), coverage.episodeCount ?? 0],
     [copy(language, "Edited episodes", "含编辑 Episode"), coverage.editedEpisodeCount ?? 0],
-    [copy(language, "Sampling", "抽样"), `${selection.analyzedCount ?? 0} / ${selection.eligibleCount ?? 0}`],
-    [copy(language, "Confidence", "可信度"), selection.confidence ?? "—"],
+    [copy(language, "Sampling", "抽样"), population.value],
+    [copy(language, "Confidence", "可信度"), population.confidence || "—"],
     [copy(language, "Learning state", "学习状态"), learning.state ?? "—"],
   ];
   const gaps = textLines(boundary.sourceGaps);
@@ -570,10 +593,7 @@ function renderHtmlBody(reportData) {
   const high = findings.filter((row) => ["Critical", "High"].includes(row.severity)).length;
   const medium = findings.filter((row) => row.severity === "Medium").length;
   const overview = summary.overview ?? summary.strengths?.[0] ?? copy(language, "Reviewed Harness evidence is ready for inspection.", "已复核的 Harness 证据可供检查。" );
-  const coverage = summary.atAGlance?.coverage ?? {};
-  const selection = summary.usageEfficiency?.selection ?? coverage.selection ?? {};
-  const analyzed = selection.analyzedSessionCount ?? selection.analyzedCount ?? 0;
-  const eligible = selection.eligibleSessionCount ?? selection.eligibleCount ?? summary.usageActivity?.sessions?.total ?? 0;
+  const population = reviewedSessionPopulation(summary, language);
   const hasUsage = summary.usageActivity !== undefined || summary.usageEfficiency !== undefined;
   const effectiveness = loopEffectiveness(dimensions);
   const progress = repairProgress(findings);
@@ -590,7 +610,7 @@ function renderHtmlBody(reportData) {
   <div class="metrics">
     ${metric(evidenceScoreLabel(summary, language), `${effectiveness} / 100`, copy(language, "Changes after later task outcomes", "等待后续任务结果后更新"), language)}
     ${metric(copy(language, "Asset Health / Repair Progress", "资产健康 / 修复进度"), `${progress.score} / 100`, copy(language, `${progress.verified} verified · ${progress.partial} partial · ${progress.pending} pending`, `${progress.verified} 项已验证 · ${progress.partial} 项部分完成 · ${progress.pending} 项待处理`), language)}
-    ${metric(copy(language, "Sessions analyzed", "会话样本"), `${formatNumber(analyzed, language)} / ${formatNumber(eligible, language)}`, selection.confidence ?? "", language)}
+    ${metric(copy(language, "Sessions analyzed", "会话样本"), population.value, population.confidence, language)}
     ${metric(copy(language, "Findings", "待处理 Finding"), findings.length, `${high} High · ${medium} Medium`, language)}
   </div>
   ${section("fluency", copy(language, "01 · Readiness", "01 · 就绪度"), copy(language, "Five-dimension fluency", "五维流畅度"), renderDimensionGrid(summary, language), copy(language, "Scores and states come from the reviewed source.", "分数与状态来自已复核 source。"), language)}

--- a/test/reporting/harness-report-render-cli.test.mjs
+++ b/test/reporting/harness-report-render-cli.test.mjs
@@ -1184,6 +1184,68 @@ test("portable publication and restoration failure reports PUBLISH_ROLLBACK_FAIL
   });
 });
 
+test("portable HTML Session population stays consistent across generated artifacts", async () => {
+  await withTempDir("better-harness-portable-session-population-", async (root) => {
+    // Given: reviewed portable data with a canonical 2/2 Session population and
+    // no optional usage census or legacy at-a-glance projection.
+    const reviewed = projectTaskLoopFindings(reviewedTaskLoopSource(), {
+      projectName: "render-source-project",
+      direct: true,
+    });
+    reviewed.summary.evidenceBoundary.manifest.platform = "dsh";
+    reviewed.summary.evidenceBoundary.manifest.selection = {
+      strategy: "all-eligible",
+      eligibleCount: 2,
+      analyzedCount: 2,
+      confidence: "High",
+    };
+    reviewed.summary.dimensions = reviewed.summary.dimensions.map((dimension) => {
+      const compact = { ...dimension };
+      delete compact.subdimensions;
+      return compact;
+    });
+    delete reviewed.summary.atAGlance;
+    delete reviewed.summary.usageActivity;
+    delete reviewed.summary.usageEfficiency;
+
+    const findingsPath = path.join(root, "reviewed.findings.json");
+    await writeJson(findingsPath, reviewed);
+
+    // When: every affected portable host routes the same reviewed input through
+    // the public renderer.
+    for (const host of ["dsh", "codex", "grok", "kimi", "workbuddy"]) {
+      const runDir = path.join(root, `run-${host}`);
+      const result = runNode([
+        renderPath,
+        "--findings", findingsPath,
+        "--mode", "html",
+        "--platform", host,
+        "--target", root,
+        "--run-dir", runDir,
+        "--validate",
+        "--json",
+      ], { cwd: root });
+
+      // Then: JSON, Markdown, and both visible HTML surfaces use the same
+      // canonical reviewed population without a host-specific renderer branch.
+      assert.equal(result.status, 0, `${host}: ${result.stderr || result.stdout}`);
+      const findings = JSON.parse(readFileSync(path.join(runDir, "findings.json"), "utf8"));
+      const markdown = readFileSync(path.join(runDir, "report.md"), "utf8");
+      const html = readFileSync(path.join(runDir, "report.html"), "utf8");
+      assert.deepEqual(findings.summary.evidenceBoundary.manifest.selection, {
+        strategy: "all-eligible",
+        eligibleCount: 2,
+        analyzedCount: 2,
+        confidence: "High",
+      }, host);
+      assert.match(markdown, /Session selection: all-eligible; 2 sessions analyzed of 2 eligible sessions; High confidence/u, host);
+      assert.match(html, /<span>Sessions analyzed<\/span>\s*<strong>2 \/ 2<\/strong>\s*<small>High<\/small>/u, host);
+      assert.match(html, /<span>Sampling<\/span><strong>2 \/ 2<\/strong>/u, host);
+      assert.match(html, /<span>Confidence<\/span><strong>High<\/strong>/u, host);
+    }
+  });
+});
+
 test("DSH reuses portable HTML report data, target root, and exact artifact contract", async () => {
   await withTempDir("better-harness-dsh-portable-", async (root) => {
     const target = path.join(root, "DSH target with 空格");
@@ -1620,6 +1682,38 @@ test("HTML evidence episode coverage preserves canonical summary facts and legac
   assert.match(canonicalHtml, /<span>Edited episodes<\/span><strong>12<\/strong>/u);
   assert.match(legacyHtml, /<span>Task episodes<\/span><strong>7<\/strong>/u);
   assert.match(legacyHtml, /<span>Edited episodes<\/span><strong>5<\/strong>/u);
+});
+
+test("portable HTML Session population distinguishes valid zero from unavailable data", () => {
+  const fixture = sampleFindings();
+  const reportData = {
+    ...fixture,
+    language: "en",
+    target: { name: "render-fixture", path: "/tmp/render-fixture" },
+  };
+
+  const zeroHtml = renderHtml({
+    ...reportData,
+    summary: {
+      ...reportData.summary,
+      evidenceBoundary: {
+        manifest: {
+          selection: {
+            strategy: "all-eligible",
+            eligibleCount: 0,
+            analyzedCount: 0,
+            confidence: "Low",
+          },
+        },
+      },
+    },
+  });
+  const unavailableHtml = renderHtml(reportData);
+
+  assert.match(zeroHtml, /<span>Sessions analyzed<\/span>\s*<strong>0 \/ 0<\/strong>\s*<small>Low<\/small>/u);
+  assert.match(zeroHtml, /<span>Sampling<\/span><strong>0 \/ 0<\/strong>/u);
+  assert.match(unavailableHtml, /<span>Sessions analyzed<\/span>\s*<strong>N\/A<\/strong>/u);
+  assert.match(unavailableHtml, /<span>Sampling<\/span><strong>N\/A<\/strong>/u);
 });
 
 test("HTML CJK phrase breaking emits bounded deterministic markup without changing report data", () => {


### PR DESCRIPTION
## Summary

Make the shared portable HTML hero and Evidence section derive their Session population from the canonical reviewed evidence selection. Missing population data now renders as `N/A`, while an explicit zero population remains `0 / 0`.

## Why

- Issue/Story: Closes #117
- User or maintainer outcome: generated JSON, Markdown, and HTML no longer contradict one another about the reviewed Session population.

## Traceability and Scope

- Spec/ADR, if applicable: No new spec required. Bug #117 owns this narrow repair; the implemented summary-facts rendering contract and current report guidance already establish canonical machine-fact precedence, legacy compatibility, and the separation between reviewed sampling and the optional usage census.
- Acceptance criteria addressed: canonical reviewed Session counts on both HTML surfaces; JSON/Markdown/HTML consistency; `N/A` for unavailable data; valid `0 / 0` retained; generated cross-host regression.
- Canonical owners changed: `scripts/harness-analysis/renderers/html.mjs` and `test/reporting/harness-report-render-cli.test.mjs`.
- Explicit non-goals: no layout redesign, DSH routing or capability change, Evidence Bundle or Session adapter change, model/lead change, schema expansion, dependency/configuration change, or installation-document cleanup.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| Literal default `npm run check` in the exact-patch worktree, Node 24.15.0/npm 11.12.1 | PASS in about 234s: root 1,545 passed/2 skipped; Harness 167; Harness UI 30; Harness Studio 270; pack verification 587 npm/849 runtime entries |
| `npx vitest run test/reporting/harness-report-render-cli.test.mjs` on Node 24.15.0 | PASS: 42 passed, 1 Windows-only skipped |
| Node 22.20.0 focused portable renderer/privacy/host controls | PASS: 7 passed, 36 filtered; includes generated artifacts, DSH privacy/temporal boundaries, both locales, five-host consistency, output routing, and allowlist control |
| RED before production edit | Public DSH pipeline generated JSON/Markdown/Evidence `2 / 2 High` while the HTML hero assertion observed `0 / 0`; missing-data assertion also failed on the silent zero fallback |
| Generated validated DSH `report.html` | PASS: Portable HTML branding; hero and Evidence both `2 / 2 High`; no visible Codex-directed text or host deep link |
| `git diff upstream/main...HEAD --check` | PASS |
| Cobb04 attribution guard before commit, before push, and against the pushed fork range | PASS: one Cobb04-authored commit with the required Codex co-author trailer; GitHub resolves the primary author to Cobb04 |

Manual or visual evidence: a temporary post-fix DSH report passed the self-contained HTML validator and visible-text structural audit. Direct `file://` automation remains blocked by the known browser policy, so no bypass or screenshot artifact was added; a later manual direct-disk visual receipt remains appropriate.

## Risk and Recovery

- Compatibility and cross-platform impact: canonical `evidenceBoundary.manifest.selection` now wins, with legacy `atAGlance.coverage.selection` retained as fallback. The optional all-eligible usage census no longer masquerades as the reviewed evidence sample.
- Package, plugin, schema, or generated-file impact: none.
- Rollback or recovery path: revert commit `7147969`.
- Residual risk or unverified boundary: manual direct-disk visual inspection was not automated because local-file browser navigation is unavailable in the qualification environment.

## AI Involvement

- Level: Assisted
- Human review and validation: Cobb04 owns the contribution and required Issue-first traceability, semantic diagnosis before mapping, deterministic RED→GREEN evidence, exact-patch validation, cross-version coverage, skeptical diff review, and attribution verification. AI assistance covered repository inspection, diagnosis, implementation, tests, validation execution, and PR preparation.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered. Existing contracts already describe the corrected semantics; no documentation change is needed.
- [x] Markdown links were checked when documentation moved or changed. No documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md`. Not applicable: repository task-scope policy prohibits unrelated changelog edits, and Bug #117 does not require release metadata.
- [x] I have the right to contribute this work under the repository MIT License.