### PR TITLE
feat(studio): ship AgentReact and a project-first workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ dev/terminal-demo/*.cast
 /harness-qoder-profile-evidence/
 design-qa.md
 
+# Linked AgentReact bundles written by the Artifact Runtime tests.
+packages/harness-studio/test/.artifacts/
+
 # Local Artifact View scratch decks and their inspection dumps.
 /*.pptx
 /*.pptx.inspect.ndjson

--- a/docs/specs/2026-08-27-agent-react-artifact-runtime-poc.md
+++ b/docs/specs/2026-08-27-agent-react-artifact-runtime-poc.md
@@ -1,0 +1,630 @@
+# AgentReact Artifact Runtime production foundation
+
+## Traceability
+
+- Spec ID: agent-react-artifact-runtime-poc
+- Status: Implemented locally; cross-platform CI and publication pending
+- ADR: [Harness Studio Artifact runtime and provider architecture](../adrs/studio-artifact-runtime-and-providers.md)
+- Related spec: [Stabilize the Artifact View host lifecycle](2026-08-23-studio-artifact-view-host-lifecycle.md)
+
+## Intent
+
+Prove that a React Artifact can travel the whole AgentReact pipeline as an
+addressable, verifiable, transactionally committed build:
+
+```text
+Agent Source Stream
+→ Artifact Revision
+→ Oxc Semantic Compile
+→ esbuild Link
+→ Immutable Build Snapshot
+→ Opaque Sandbox Staging
+→ Atomic View Commit
+→ Observation
+```
+
+The proof of concept only strengthens the existing ADR-0007 Code-backed
+lifecycle. It does not add a third lifecycle, and it does not touch the
+Data-backed adapter path.
+
+The value being proved is not "TSX can be bundled" — Studio already bundles TSX
+through `artifact-compile-runtime.ts`. The new claims are:
+
+1. a compile stage can *refuse* code that leaves the AgentReact language
+   profile, before any bundle exists;
+2. a default export can declare its state and capability requests as static
+   data, and the Host can grant strictly less than the code asked for;
+3. every rendered DOM node can carry a deterministic address back to its source
+   span; and
+4. a new build can be verified in a separate staging frame and committed
+   atomically, so a failing revision never replaces a working view.
+
+The pipeline above is the target architecture. The first increment established
+the production-eligible data and Host foundations. The production increment
+continues in this same spec: it registers an explicit AgentReact format, moves
+Oxc behind a restartable deadline-enforced Worker, and binds the build to
+Studio's existing opaque-origin iframe/CSP/MessageChannel security surface.
+
+## Production Readiness
+
+Production readiness is assessed per boundary rather than inherited from a
+passing end-to-end POC:
+
+| Boundary | Readiness in this increment | Production rule |
+| --- | --- | --- |
+| Revision, compile/link contracts, Build Snapshot identity | Production-eligible foundation | Identity-owned records are deeply immutable and every effective compiler/runtime policy participates in the build identity |
+| Oxc Node compiler | Implemented; macOS arm64 runtime and extracted-install verified; Intel macOS dependency closure checked | Native parsing may process untrusted source only inside a restartable Worker with an enforceable per-request deadline; direct in-process use remains verification-only |
+| Profile validator | Advisory production diagnostic | It improves refusal quality but is never a security boundary; execution isolation and Host Action validation remain mandatory |
+| State, capability, Action, and observation Host services | Production-eligible foundation | The Host owns immutable state copies, tokens are unguessable, approval revocation is effective immediately, and Actions are revalidated per dispatch |
+| Transaction controller | Production-eligible only with an isolated FrameFactory | Concurrent stages are generation-fenced; a rejected, superseded, timed-out, or disposed frame can never act on newer controller state |
+| `LocalFrameFactory` | Verification-only | It may prove compile/link/address wiring with explicit opt-in, but it is not an origin boundary and cannot support a production execution claim |
+| Opaque iframe transport and Studio registration | Implemented; Chromium wide/compact/narrow verified | Reuse the existing Studio sandbox only after AgentReact adds transferred-port identity, two-frame commit, state/Action validation, cancellation, browser mount/error evidence, and responsive browser QA |
+
+The controller therefore rejects an in-process `FrameFactory` by default.
+Tests and local experiments must opt in explicitly, making it impossible to
+register the verification transport accidentally as a production runtime.
+
+## Terminology
+
+The document under implementation renames several overloaded words. This spec
+uses the same vocabulary, and the code uses it verbatim:
+
+| Term | Meaning |
+| --- | --- |
+| `Artifact Revision` | Digest-addressed, immutable set of module sources |
+| `Build Generation` | One monotonically numbered build attempt |
+| `Build Snapshot` | Frozen, replayable compile+link result |
+| `Artifact View Definition` | The `defineArtifactView` default export |
+| `Artifact Surface` | Unchanged ADR-0007 presentation kind |
+
+## Decisions
+
+### D-1: Four layers, one narrow compiler port
+
+The POC keeps the four-layer split from the source document, and each layer is one
+directory whose barrel is its public face:
+
+| Directory | Layer | Owns |
+| --- | --- | --- |
+| `contracts/` | (shared) | Layer-crossing types, plus the addressing algorithm |
+| `kernel/` | Oxc Semantic Kernel | Parse, admit, extract ABI, index, erase types |
+| `linker/` | esbuild Linker | Resolve modules, externalize Bootstrap, emit one bundle |
+| `runtime/` | React Artifact Runtime | Render, state/action hooks, node addressing |
+| `host/` | Artifact Host | Revision, state, grants, actions, commit, observation |
+
+Dependencies point one way: `host → {kernel, linker, runtime} → contracts`. Two of
+those edges are load-bearing rather than tidy:
+
+- **`runtime` may not reach the kernel.** The runtime layer is what loads inside
+  the sandbox frame. One import of `kernel/` pulls `oxc-parser`'s native binding
+  into a browser bundle, which then fails to load at all.
+- **`contracts` may not use Node built-ins or any package.** The runtime
+  re-exports contracts into the frame, so a single `node:crypto` there breaks the
+  same load. This is why hashing enters the pipeline as an injected `DigestFn`,
+  and why `contracts/addressing.ts` inlines a 64-bit FNV-1a instead of importing
+  one.
+
+`contracts/addressing.ts` is the only contract module with executable code, and
+that is the point: the kernel computes a JSX element's id at compile time and the
+sandbox `jsxDEV` computes it again at render time. Two copies of "the same" hash
+in two layers is exactly how those drift, so both layers import this one.
+
+Business code never sees an Oxc AST; it depends only on `OxcCompilerPort`:
+
+```ts
+interface OxcCompilerPort {
+  readonly compilerVersion: string;
+  readonly profileVersion: string;
+  compileModule(input: CompileModuleInput): Promise<CompileModuleOutput>;
+}
+```
+
+Oxc answers *what the code is and whether it obeys the contract*. The Host
+answers *what the code is allowed to do*. The Profile validator is therefore
+documented and tested as a Semantic Firewall, not as the security authority: the
+Action Gateway re-validates every single call at runtime even if a bundle
+forged its declaration.
+
+### D-2: Oxc runs through the Node bindings only behind the compiler port
+
+The direct `createOxcCompiler()` adapter remains the deterministic test and
+fixture implementation. Production uses the same port through a Node
+`worker_threads` adapter because Studio's server owns the confined source root,
+the exact revision route, and the immutable build cache. Moving compilation to
+the browser would duplicate that authority and transfer the whole source graph
+over a second protocol without improving the iframe execution boundary.
+
+The Worker has a per-request deadline. Timeout, crash, invalid response, or
+disposal terminates it; the next request starts a clean Worker. The compiler
+policy fingerprint includes the deadline and Oxc limits. The stable
+`limit/compile-timeout` diagnostic is produced without caching a partial build.
+
+### D-3: The Profile is a closed list of refusals
+
+`AGENT_REACT_PROFILE_VERSION = "1"` refuses, with a stable diagnostic code:
+
+| Code | Refusal |
+| --- | --- |
+| `profile/commonjs` | `require`, `module.exports`, `exports.x` |
+| `profile/node-builtin` | `node:*` and bare Node built-in imports |
+| `profile/dynamic-import` | any `import()` |
+| `profile/package-not-allowed` | any bare import outside the allowlist |
+| `profile/react-dom-root` | `createRoot`, `ReactDOM.render`, `hydrateRoot` |
+| `profile/dynamic-eval` | `eval`, `new Function` |
+| `profile/worker` | `Worker`, `SharedWorker`, `ServiceWorker`, `navigator.serviceWorker` |
+| `profile/network` | `fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `sendBeacon` |
+| `profile/class-component` | `class X extends React.Component/PureComponent` |
+| `profile/top-level-effect` | a top-level statement that is not a declaration, an import/export, or a directive |
+
+`profile/top-level-effect` is deliberately a hard rule rather than a budget: a
+top-level `VariableDeclaration`, `FunctionDeclaration`, type declaration, import,
+export, or string directive is allowed, and every other top-level statement —
+expression statements, loops, conditionals, `try`, `throw` — is refused. "Some
+side effects allowed" has no test that separates pass from fail, and violations
+inside an allowed declaration's initializer are still caught by the other rules.
+
+A refusal is reported as a diagnostic with module path, line, and column, and no
+code is emitted for that module.
+
+### D-4: The ABI is extracted, never inferred
+
+`extractArtifactViewDeclaration` accepts exactly one shape:
+
+```tsx
+export default defineArtifactView({ id, state, capabilities, component });
+```
+
+- `id` must be a static string literal;
+- `state` must be an object literal whose keys are `/`-rooted paths and whose
+  values are `{ schema: string, version: integer }` literals;
+- `capabilities` must be an array literal of string literals;
+- `component` must be an identifier bound to a module-local function declaration
+  or function-valued `const`, or a named/default import from another module in
+  the same Revision. Package and namespace imports cannot be the root component.
+
+Anything else — a spread, a computed key, an identifier reference for `id`, a
+capability built by `.map()` — is `abi/not-static`. The validator never derives a
+capability from a call the code happens to make, because a permission inferred
+from behaviour would grant exactly what an attacker writes.
+
+### D-4b: The linker re-applies the allowlist and externalizes the Bootstrap
+
+`AllowedPackageResolver` answers three questions: is this an internal Revision
+module, is it a trusted runtime package, or is it refused. A trusted package
+resolves to an **external** Bootstrap specifier in the validation bundle. That
+keeps the source-owned link step independent of installed package layout and
+makes every trusted mapping part of `buildPolicyDigest`; the production packager
+owns the later resolution into the self-contained iframe bundle.
+
+The resolver also maps the TypeScript `./panel.js` → `./panel.tsx` convention,
+since that is what a TS-aware agent writes.
+
+The linker refuses a non-allowlisted package independently of the Profile, so
+defeating one check does not produce a bundle. Note that Oxc elides an unused
+import the way TypeScript does, so only a *used* forbidden import reaches the
+linker at all. The production packager then resolves those trusted externals
+from Studio's installed dependency closure and emits one self-contained iframe
+bundle; Artifact source never controls that resolution step.
+
+### D-5: Grants are an intersection, and the frame token carries them
+
+```text
+Granted = Declared Requests ∩ Host Policy ∩ Session Approval
+```
+
+`CapabilityBroker.computeGrant()` returns the intersection plus the two reasons a
+request was dropped (`not-in-policy`, `awaiting-approval`), so the UI can explain
+a missing control instead of silently omitting it. The broker issues a
+frame-scoped token; `ActionGateway.dispatch()` validates the token, the
+capability, and the frame's action mode on *every* call and revokes on frame
+disposal. A revoked token denies even a previously granted capability.
+
+### D-6: Addresses are deterministic within a Revision, and only within it
+
+`@studio/agent-react/jsx-dev-runtime` accepts Oxc's development-shaped JSX call
+for its source span, then delegates element creation to React's production-safe
+`jsx`/`jsxs`. The automatic development transform supplies `fileName`,
+`lineNumber`, and `columnNumber`, so:
+
+```text
+SourceNodeId  = fnv1a64(modulePath | line | column | elementType) → 16 hex chars
+InstanceAddress = artifactDigest | SourceNodeId | React key | parent instance
+```
+
+Intrinsic elements receive `data-artifact-node`; catalog components receive the
+reserved `artifactNode` prop and are expected to forward it. The runtime never
+reads React internals or Fiber fields.
+
+Cross-Revision continuity is *not* claimed from spans. The `ReactSemanticIndex`
+exists for that purpose and is explicitly excluded from authorization.
+
+### D-7: Observations reuse the AG-UI CUSTOM envelope, under their own name
+
+The source document routes observations through `HARNESS_PROTOCOL_EVENT`. That
+constant's payload type is `HarnessProtocolEvidence` with `protocol: "acp"`, and
+an artifact render is not ACP traffic. The POC therefore keeps the AG-UI
+`CUSTOM` envelope but introduces `HARNESS_ARTIFACT_OBSERVATION_EVENT`
+(`"harness.artifact-observation"`) so a consumer cannot mistake a render failure
+for a protocol receipt. Recorded kinds are the ten versioned values exported by
+the AgentReact Host contract.
+
+### D-8: Commit is transactional, and staging cannot act
+
+`SandboxFrameController` holds at most one Current and one Staging frame.
+Staging is created with `actionMode: "dry-run"` and a frozen state snapshot;
+`activate()` promotes it only after `renderCompleted`. On `renderFailed`, on
+timeout, or on a blocking dry-run attempt under a `blockOnDeniedAction` policy,
+the Staging frame is disposed and Current is untouched.
+
+Verification performs module load, mount, error boundary, a post-mount paint
+boundary with a bounded visibility-independent fallback, and the timeout — it
+never synthesizes clicks and never runs a real Action.
+Promotion is a Host act, not a frame act: `activate()` revokes the dry-run token,
+issues a `live` token for the same build digest, and hands it to the frame. A
+frame therefore cannot grant itself live mode.
+
+### D-8b: The transport is a port; verification and production have distinct implementations
+
+`SandboxFrameController` depends on a `FrameFactory`, and the POC ships two
+implementations of the frame side:
+
+- `host/frames/frame-protocol.ts` — the transport-free handshake: the init message,
+  identity matching, and the render reports. A frame must match protocol version,
+  artifact digest, build digest, and frame token before mounting, because an
+  opaque origin cannot serve as an identity and a superseded build racing a stage
+  is the common case.
+- `host/frames/local-frame-factory.ts` — an in-process frame that **really
+  executes** the linked bundle: it loads the module, installs the runtime bridge
+  into that bundle's own runtime instance, renders the component, and returns
+  resolvable node addresses.
+
+Production reuses the existing Studio sandbox response and host invariants:
+`<iframe sandbox="allow-scripts">` without `allow-same-origin`,
+`referrerpolicy="no-referrer"`, a no-network CSP, a transferred `MessagePort`,
+parent/source and full build-identity checks, and bounded handshake time. A
+dedicated AgentReact Surface owns Current and Staging iframe instances. Only a
+matching `renderCompleted` report promotes Staging; compile, handshake, render,
+or protocol failure removes Staging and leaves Current visible.
+
+The opaque frame announces `runtime.ready` only after installing its message
+listener and repeats that announcement until the Host transfers the one accepted
+port. The Host validates the frame window and full build identity and creates at
+most one session per build. Generated preview HTML is served as immutable, so
+the compile runtime version participates in the build URL and must change with
+the frame document or Host protocol; a new Studio release cannot reuse a
+year-cached document from an incompatible protocol version.
+
+Because the in-process factory shares a process and runtime modules with the
+Host, it proves compile/link/address wiring only. It does not prove browser
+mount behavior, effects, error boundaries, origin isolation, CSP, or concurrent
+frame realms. Its type and controller admission policy expose that limitation.
+
+### D-9: Registration is explicit and additive
+
+Existing `*.canvas.tsx` keeps the current `studio.react-source` runtime. The new
+compound suffix `*.agent.canvas.tsx` is the only built-in selector for
+`studio.agent-react`; ordinary TSX/JSX remains source-only. This prevents
+production admission from being inferred from file contents and prevents an
+existing Canvas artifact from being silently reinterpreted under the stricter
+ABI. The view id is the portable basename before `.agent.canvas.tsx` and must
+match the static `defineArtifactView()` id.
+
+### D-10: Production Host services are bounded and deny by default
+
+The browser Host publishes three versioned state schemas: `json@1`, `list@1`,
+and `record@1`. State is structured-cloned, validated, and retained only for the
+same authority, Artifact id, path, schema, and version. Staging reads a snapshot
+and cannot write. A promoted frame receives live state updates over its bound
+port.
+
+The initial Action policy grants only `studio.show-source`, a Host-owned command
+that selects the existing Source tab. Every other declared capability remains
+visible as refused and every dispatch is revalidated against the live port,
+frame token, build identity, action mode, and current policy. Staging dispatches
+return `dry-run` and never invoke a handler.
+
+## Acceptance Scenarios
+
+- **AR-AC-1:** `AgentStreamAssembler` only commits sealed modules; the same
+  module bytes under any patch ordering produce the same `Artifact Revision`
+  digest, and different bytes produce a different one. `abortGeneration()`
+  discards unsealed work.
+- **AR-AC-2:** For each Profile rule in D-3, a module violating it compiles to
+  `code === undefined` and a diagnostic carrying that rule's code, module path,
+  and a positive line number. A conforming module compiles with no error
+  diagnostics.
+- **AR-AC-3:** A conforming entry module yields an `ArtifactViewDeclaration`
+  whose `id`, `state` schemas/versions, and sorted `capabilities` equal the
+  source literals. Non-static `id`, `state`, `capabilities`, or `component`
+  produce `abi/not-static` and no declaration. A module with no
+  `defineArtifactView` default export produces `abi/missing-view`.
+- **AR-AC-4:** `build()` on a multi-module revision returns a frozen
+  `BuildSnapshot` whose `buildDigest` is stable across repeated builds of the
+  same revision and compiler/profile/runtime versions, and changes when the
+  revision or any of those versions changes. A superseded generation's result is
+  discarded rather than returned to its caller.
+- **AR-AC-5:** The linked bundle executes: loading it with a bootstrap providing
+  `react` and `@studio/agent-react` yields the declared view definition, and
+  server-rendering its component emits `data-artifact-node` attributes whose
+  values resolve through `NodeAddressRegistry` back to the correct module path,
+  element type, line, and column. Two elements of the same type on different
+  lines get different `SourceNodeId`s; the same element in a re-linked build of
+  the same revision keeps its `SourceNodeId`.
+- **AR-AC-6:** A bare import outside the allowlist fails the *link* stage as
+  well as the Profile stage, so a bypass of one check does not produce a bundle.
+- **AR-AC-7:** `computeGrant()` equals the three-way intersection. A capability
+  in the policy but awaiting approval is reported `awaiting-approval` and is not
+  granted. `dispatch()` denies an unknown capability, an ungranted capability, a
+  revoked token, and a stale frame token; a `dry-run` frame records
+  `actionAttempted` without invoking the handler; a `live` frame invokes it once.
+- **AR-AC-8:** `ArtifactStateStore.snapshot()` returns a frozen value that later
+  `set()` calls do not mutate. A `set()` failing schema validation is rejected,
+  emits `stateValidationFailed`, and leaves the previous value in place.
+  `migrate()` moves a path to a new schema version and notifies subscribers.
+- **AR-AC-9:** A successful stage/activate replaces Current and disposes the old
+  Current exactly once. A `renderFailed`, a verification timeout, and a blocked
+  dry-run attempt each leave the original Current mounted and dispose only
+  Staging. `rollback()` after an activation restores the previous snapshot.
+- **AR-AC-10:** Every recorded observation encodes to an AG-UI `CUSTOM` event
+  named `harness.artifact-observation` carrying artifact digest, build digest
+  when known, kind, and sequence; sequences are strictly increasing.
+- **AR-AC-11:** The parsed import graph of `src/agent-react/**` obeys D-1: every
+  relative import resolves, no cycle exists, every cross-layer edge is allowed and
+  goes through the target layer's barrel (`contracts` excepted, being addressable
+  file by file), `contracts` and `runtime` use no Node built-in, `oxc-*` appears
+  only in `kernel`, `esbuild-wasm` only in `linker`, and `stableHash`,
+  `sourceNodeId`, and `instanceAddress` are each defined in exactly one module
+  that both the kernel and the runtime import.
+- **AR-AC-12:** A committed Revision owns frozen copies of its descriptor and
+  every module. Mutating caller-owned inputs or attempting to mutate returned
+  nested records cannot change the entry, module bytes, or metadata named by its
+  digest. Non-normalized descriptor and module paths fail before streaming.
+- **AR-AC-13:** If two stages overlap, only the newest generation may become
+  Staging. Completion or failure of the older generation cannot dispose, reject,
+  activate, or return the newer frame.
+- **AR-AC-14:** A render timeout or disposal aborts bundle loading where the
+  loader supports cancellation and fences every post-await side effect. A late
+  loader completion cannot install a runtime bridge, render, emit success, or
+  mutate controller state.
+- **AR-AC-15:** Artifact state stores Host-owned, deeply frozen, structured-clone
+  data. A caller retaining the original object, including a shallow-frozen outer
+  object, cannot mutate stored or staged state; unsupported state shapes fail
+  validation without replacing the previous value.
+- **AR-AC-16:** Frame tokens use cryptographic entropy by default. Revoking an
+  approval immediately denies subsequent dispatches through already-issued
+  tokens, and a token generator collision fails closed.
+- **AR-AC-17:** A controller rejects an in-process FrameFactory unless the caller
+  explicitly opts into verification-only execution. No test using
+  `LocalFrameFactory` is reported as opaque-origin, browser-mount, CSP, or
+  production execution evidence.
+- **AR-AC-18:** The Build Coordinator owns and validates its Revision input,
+  refuses non-normalized or duplicate modules, recomputes the Revision digest,
+  requires the static view id to match the descriptor id, and deeply freezes all
+  identity-bearing Build Snapshot data. Caller mutation cannot change bytes or
+  evidence after either digest is computed.
+- **AR-AC-19:** `buildPolicyDigest` changes when compiler limits, Host module or
+  output limits, or any trusted Bootstrap specifier/external mapping changes,
+  even when the emitted bundle bytes happen to remain identical. `buildDigest`
+  includes that policy identity, so cache reuse cannot cross a permission or
+  admission-policy change.
+- **AR-AC-20:** Production compilation executes Oxc through a Worker. A normal
+  multi-module build returns the same ABI and semantic evidence as the direct
+  adapter. A deadline terminates the Worker, returns
+  `limit/compile-timeout`, retains no partial result, and a later valid request
+  succeeds through a fresh Worker.
+- **AR-AC-21:** Only `*.agent.canvas.tsx` selects the
+  `studio.agent-react` build runtime and `studio.agent-react-preview` Surface.
+  Existing `*.canvas.tsx` keeps `studio.react-source`; ordinary TSX/JSX remains
+  source-only. The catalog binding and build identity include the AgentReact
+  runtime/profile/policy versions.
+- **AR-AC-22:** The production frame has an opaque origin, `sandbox` contains
+  only `allow-scripts`, referrer policy is `no-referrer`, CSP denies network,
+  and initialization requires the parent window, a transferred port, the full
+  build identity, action mode, and frame token. Wrong-source, stale, malformed,
+  and late messages cannot commit UI or invoke Host services.
+- **AR-AC-23:** A valid AgentReact build renders real browser DOM with resolvable
+  `data-artifact-node` addresses. During a live revision update Current stays
+  visible until Staging reports success. Compile, handshake, and render failure
+  leave Current visible; a successful successor atomically replaces it.
+- **AR-AC-24:** `json@1`, `list@1`, and `record@1` state survive a compatible
+  successful revision, invalid values and staging writes are rejected, and a
+  live write rerenders the Artifact. A staging `studio.show-source` dispatch is
+  `dry-run`; after promotion the same declared and granted Action selects Source
+  exactly once. Unknown, undeclared, stale-token, and refused Actions fail
+  closed.
+- **AR-AC-25:** Browser observations use the AG-UI `CUSTOM` envelope named
+  `harness.artifact-observation`, carry strictly increasing sequence and exact
+  Artifact/build identity, and cover staging render, commit, rejection, state
+  validation, Action attempt/denial/completion, and runtime failure.
+- **AR-AC-26:** Focused contract/Worker/server/Surface tests, a real Chromium E2E
+  at wide/compact/narrow widths, Studio build/typecheck/package tests, repository
+  tests, documentation links, package verification, and `git diff --check`
+  pass. Windows and Linux are claimed only from their corresponding CI jobs.
+- **AR-AC-27:** AgentReact initialization is frame-ready-driven rather than a
+  one-shot iframe load callback, accepts only the matching frame/build, and is
+  idempotent under repeated readiness. Promotion completes when paint callbacks
+  are suspended, and a generated-preview protocol change advances the runtime
+  version that addresses its immutable preview URL.
+- **AR-AC-28:** Static module discovery follows relative sources declared by
+  `ImportDeclaration`, `ExportNamedDeclaration`, and `ExportAllDeclaration`.
+  A production project whose entry imports through a barrel re-export loads the
+  complete Revision and links successfully.
+- **AR-AC-29:** An artifact catalog invalidation that recompiles to Current's
+  existing `buildId` is a no-op for the Current/Staging transaction. Repeated
+  unrelated artifact changes leave the verified frame ready, preserve Host
+  state, and keep its MessageChannel Actions usable.
+- **AR-AC-30:** The root lockfile contains a package record for every optional
+  native binding declared by the pinned `oxc-parser` and `oxc-transform`
+  packages. A clean Intel macOS npm install plan includes the parser and
+  transform x64 bindings; runtime execution on that platform remains unclaimed
+  until exercised there.
+
+## Non-goals
+
+- No browser-side source compiler or browser Wasm compiler. Production compile
+  authority stays in the restartable Studio server Worker; see D-2.
+- No React Refresh; production updates use transactional frame replacement.
+- No Oxc Semantic Diff, component-level partial rebuild, or `<Activity>`
+  branch pre-render (v3 in the source document).
+- No `SurfaceSpec` Data-backed adapter and no Component Catalog (v2).
+- No Draft Lane, no retained Artifact history, no persisted state across reloads.
+- No behavior change to the existing `*.canvas.tsx` preview lane. The shared
+  compile route now dispatches the explicit AgentReact build runtime when the
+  registry selects `*.agent.canvas.tsx`.
+- No CSS/asset linking beyond what esbuild already does for imported CSS; the
+  POC's fixtures do not exercise it.
+- No cross-Revision address continuity. `InstanceAddress` accepts a parent
+  instance for callers that hold one, but JSX elements are created inner-first so
+  the creation-time stamp is `artifact digest + SourceNodeId + React key` only.
+
+## Plan and Tasks
+
+All modules live under `packages/harness-studio/src/agent-react/`:
+
+| Increment | Modules |
+| --- | --- |
+| v1.1 | `contracts/{versions,revision,diagnostics,compile,build,host,index}.ts`, `host/digest.ts`, `host/stream-assembler.ts`, `kernel/ast.ts`, `kernel/profile.ts`, `kernel/compiler.ts` |
+| v1.2 | `kernel/abi.ts`, `host/capability.ts` |
+| v1.3 | `contracts/addressing.ts`, `runtime/address-registry.ts`, `runtime/bridge.ts`, `runtime/jsx-dev-runtime.ts`, `runtime/index.ts` |
+| v1.4 | `kernel/semantic-index.ts`, `linker/allowed-packages.ts`, `linker/esbuild-linker.ts`, `host/build-coordinator.ts` |
+| v1.5 | `host/frames/frame-protocol.ts`, `host/frames/local-frame-factory.ts`, `host/frames/frame-controller.ts` |
+| v1.6 | `host/data-ownership.ts`, `host/observation-bridge.ts`, `host/state-store.ts`, `host/action-gateway.ts` |
+| production compile | Worker compiler adapter, confined project loader, explicit AgentReact build runtime and build metadata |
+| production Surface | `AgentReactPreviewHost`, opaque frame protocol, bounded browser state/Action services, transactional Current/Staging commit |
+| production maintenance | re-export dependency discovery, same-build invalidation no-op, complete Oxc optional-binding lock records |
+
+Each layer directory also carries an `index.ts` barrel that documents the layer's
+job and is the only entry other layers may import.
+
+New dependencies: `oxc-parser` and `oxc-transform`, both pinned exact, added to
+`packages/harness-studio`. `esbuild-wasm` and `react` were already present.
+
+## Test and Review Evidence
+
+Tests live in `packages/harness-studio/test/agent-react/` and run under the
+package's existing `vitest` project:
+
+| File | Covers |
+| --- | --- |
+| `stream-assembler.test.ts` | AR-AC-1, AR-AC-12 |
+| `oxc-compiler.test.ts` | AR-AC-2, AR-AC-3 |
+| `build-coordinator.test.ts` | AR-AC-4, AR-AC-6, AR-AC-18, AR-AC-19 |
+| `runtime-addressing.test.ts` | AR-AC-5, AR-AC-14, AR-AC-17; one-chain E2E for AR-AC-1, AR-AC-4, AR-AC-5, AR-AC-7 through AR-AC-10 |
+| `capability-and-actions.test.ts` | AR-AC-7, AR-AC-16 |
+| `state-store.test.ts` | AR-AC-8, AR-AC-15 |
+| `frame-controller.test.ts` | AR-AC-9, AR-AC-13, AR-AC-17 |
+| `frame-protocol.test.ts` | AR-AC-13, AR-AC-14, AR-AC-17 |
+| `observation-bridge.test.ts` | AR-AC-10 |
+| `layering.test.ts` | AR-AC-11 |
+| `worker-oxc-compiler.test.ts` | AR-AC-20 normal, timeout, restart, and close behavior |
+| `host-services.test.ts` | AR-AC-24 state schemas, grant policy, and frame-message admission |
+| `artifact-compile-runtime.test.ts`, registry tests | AR-AC-20, AR-AC-21, AR-AC-27 production project compilation, explicit selection, and immutable preview runtime version |
+| `browser/artifact-host.spec.mjs` AgentReact scenarios | AR-AC-22 through AR-AC-27, including CSP/sandbox, ready-driven initialization, paint-callback suspension, state, Action, observations, rejected staging, committed-runtime failure, recovery, and responsive screenshots |
+| `artifact-compile-runtime.test.ts`, `oxc-compiler.test.ts` | AR-AC-28 semantic dependency discovery and production barrel re-export compilation |
+| `browser/artifact-host.spec.mjs` same-build invalidation scenario | AR-AC-29 repeated unrelated changes retain Current state and Action transport |
+| `worker-oxc-compiler.test.ts`, npm platform dry-run | AR-AC-30 parsed lockfile completeness and Intel macOS install-plan closure |
+
+`pipeline-fixture.ts` holds the shared Revision fixtures, the test Trusted
+Bootstrap, and the bundle loader. Linked bundles are written under
+`packages/harness-studio/test/.artifacts/` because the Bootstrap externals are
+relative specifiers that must resolve from the bundle's own location; the
+directory is removed after the run and git-ignored.
+
+AR-AC-5 is the load-bearing compile/link/address agreement test: it evaluates
+the linked ESM bundle through the verification-only local transport, renders it
+with `react-dom/server`, and asserts that each `data-artifact-node` value resolves
+through `NodeAddressRegistry` to the module, line, column, and element type the
+compiler indexed — not that a substring exists in the emitted code. It is not
+browser mount or production execution evidence.
+
+The original-POC E2E scenario in the same file streams and seals both modules,
+builds and links them with the real Oxc/esbuild adapters, stages and activates
+the linked bundle, drives state and a capability-gated Action through the active
+Artifact runtime, proves a render-failing Revision leaves Current intact,
+activates a valid successor, and rolls back to the first Build Snapshot. This is
+one continuous in-process verification chain; it does not expand the evidence
+to browser isolation or Studio registration.
+
+AR-AC-11 is a fitness function over the real import graph: `layering.test.ts`
+parses every module in `src/agent-react/**` with `oxc-parser` and asserts on the
+resolved edges and exported names, not on source text. A passing architecture test
+proves nothing on its own, so each rule was verified by mutation — the violation
+was introduced, the suite was run, and the failure was confirmed before the
+violation was reverted:
+
+| Injected violation | Caught by |
+| --- | --- |
+| `runtime/bridge.ts` imports `kernel/index.js` | layer direction, runtime browser-loadability |
+| `contracts/addressing.ts` imports `node:crypto` | contracts package ban, per-layer packages |
+| `host/build-coordinator.ts` imports `kernel/ast.js` | barrel-only crossing |
+| `linker/esbuild-linker.ts` imports `host/index.js` | layer direction |
+| `kernel/ast.ts` also exports `stableHash` | single addressing definition |
+| `host/digest.ts` ↔ `host/state-store.ts` | cycle detection |
+
+Baseline before the production-hardening pass: 132 tests across the nine files;
+the package suite is 423 passing across 56 files, and the repository suite 1545
+passing with 2 skipped across 104 files. These results prove the checked
+behaviors only; they do not satisfy AR-AC-12 through AR-AC-17 until the focused
+regressions are present and passing. `tsc --noEmit` is clean for the package.
+The baseline was recorded on macOS arm64 with Node 24; no Windows or Linux CI receipt
+exists for this increment yet.
+
+Production implementation evidence recorded on macOS arm64 with Node 24:
+
+- AgentReact and production compile focused suite: 207 passing across 14 files,
+  including the original-POC one-chain E2E, real emitted Worker compilation,
+  deadline/restart, barrel re-export compilation, Oxc lock closure, and bounded
+  Host-service scenarios.
+- Harness Studio build and package suite: 466 passing across 59 files.
+- Chromium production Surface suite: 47 passing, including real AgentReact DOM,
+  resolvable node addresses, CSP and sandbox headers/attributes, Host state and
+  Action round trips, Current/Staging commit, rejected staging retention,
+  committed-runtime failure and recovery, ready-driven initialization with
+  suspended paint callbacks, observation envelopes, keyboard focus,
+  console/page-error inspection, and wide/compact/narrow screenshots.
+- The original timeout was reproduced in the Codex in-app Browser against an
+  immutable, stale preview URL. Runtime version 5 produced a new build/preview
+  URL; the repaired frame committed in the same Browser with no console warning
+  or error. This is enabled-host evidence for the local in-app Browser only.
+- Repository `npm run check`: root 1545 passing with 2 skipped across 104 files;
+  Harness 173, Harness UI 31, Studio 466; generated sources and pack verification
+  passed (`npm 593 entries`, `runtime zip 863 entries`).
+- `npm ci --dry-run --ignore-scripts --os=darwin --cpu=x64` selects both
+  `@oxc-parser/binding-darwin-x64@0.147.0` and
+  `@oxc-transform/binding-darwin-x64@0.147.0`; the parsed lockfile test confirms
+  every optional binding declared by both pinned Oxc packages has a package
+  record. This is install-plan evidence, not Intel macOS runtime evidence.
+- `git diff --check` is clean. Existing preview regression smoke returned HTTP
+  200 and `ok` from `/health`, and HTTP 200 with 100449 JavaScript bytes from
+  `/canvas-module.js`.
+- Studio's dry-run tarball contains the emitted Worker entry, Worker protocol,
+  and production compiler route. Installing locally packed Harness, Harness UI,
+  and Studio tarballs into a clean directory loaded
+  `oxc-node-0.147.0+worker` and compiled a module with no diagnostics.
+
+These receipts satisfy the local production acceptance boundary. Windows and
+Linux remain unclaimed until the corresponding CI jobs pass. Publication is a
+separate release action: a Studio-only install against the currently configured
+npm mirror is blocked because that mirror does not contain
+`@qoder-ai/harness-ui@0.1.1`; the three-package local tarball closure passes.
+
+Risks:
+
+- `oxc-parser` / `oxc-transform` ship platform-specific native bindings, so the
+  new dependency adds optional binaries to the install graph. Both are pinned
+  exact and kept behind `OxcCompilerPort` so the browser Wasm build can replace
+  them without touching callers.
+- Node addresses depend on the automatic development JSX transform's `__source`.
+  The semantic index and the runtime compute the span independently and are
+  asserted to agree; if a future Oxc release changes `columnNumber` semantics,
+  that assertion fails rather than silently splitting one element into two
+  identities.
+- React 19's production `react/jsx-dev-runtime` deliberately exports no
+  `jsxDEV` function. The trusted AgentReact JSX wrapper therefore accepts Oxc's
+  development-shaped call for its source span, then creates elements through
+  production-safe `react/jsx-runtime` `jsx`/`jsxs`. Unit and browser tests cover
+  this exact packaged path.
+- Opaque origin, no-network CSP, referrer policy, direct-open non-execution, and
+  transferred-port initialization are re-proved in the production browser E2E;
+  they remain sensitive to changes in the shared preview response or iframe
+  attributes.

--- a/docs/specs/2026-08-27-studio-project-first-workbench.md
+++ b/docs/specs/2026-08-27-studio-project-first-workbench.md
@@ -1,0 +1,155 @@
+# Make projects the Studio workbench scope
+
+## Traceability
+
+- Spec ID: studio-project-first-workbench
+- Status: Implemented
+- Related decision: [Developer Experience System](../adrs/developer-experience-system.md)
+- Design contract: [Harness Studio visual system](../../DESIGN.md)
+
+## Intent
+
+Make Harness Studio project-first: a persistent left sidebar selects the active
+project, and one shared workbench shell hosts every project-scoped View. Project
+selection must be fast and explicit without forcing Sessions, Inputs, Commits,
+Artifacts, Debugger, Compare, or Customizations to duplicate project chrome or
+adopt one shared domain model.
+
+The UI term **Project** identifies a remembered local or imported project entry.
+The server term **workspace** remains the materialized filesystem and execution
+authority for the active Project. Configured Inspector, experiment, evidence,
+and compatibility Artifact inputs remain independent **Sources** and must not be
+presented as if they belong to the selected Project.
+
+## Acceptance Scenarios
+
+- **AC-1:** At wide layout, Studio shows a persistent Projects sidebar and one
+  adjacent workbench. The active Project expands one shared View navigation for
+  Overview, Customizations, Inputs, Sessions, Commits, Artifacts, Debugger, and
+  Compare; inactive Projects remain compact rows and do not duplicate the View
+  navigation.
+- **AC-2:** Opening a local directory registers an opaque Project descriptor,
+  activates its freshly discovered workspace snapshot, and exposes only the
+  Project id, label, revision, availability, and bounded counts to the browser.
+  Native absolute paths remain server-only.
+- **AC-3:** Activating a remembered Project re-runs workspace discovery, replaces
+  the active workspace atomically, increments a monotonic Project revision, and
+  refreshes project-scoped configuration, Sessions, Inputs, Git, Artifacts,
+  Customizations, Compare, and default Debugger context. A cancelled or failed
+  activation leaves the previous active Project usable.
+- **AC-4:** Project routes encode the opaque Project id and View. Reload,
+  browser back, and browser forward restore the active Project and View when the
+  Project is still registered. Selecting another Project preserves the current
+  View when possible and otherwise renders that View's honest unavailable state.
+- **AC-5:** The shared shell owns product identity, Project/View context, theme,
+  source selection, Project opening, and Project removal. Feature Views may own
+  one local toolbar and their internal panes, but they do not repeat the active
+  Project title or workspace change/disconnect controls.
+- **AC-6:** Compare distinguishes current-Project Session comparison from
+  configured experiment and frozen evidence Sources. A fixed experiment
+  checkpoint is labelled as read-only context and is not rendered as a fake
+  Project selector.
+- **AC-7:** A live run captures the active Project id and revision at request
+  start. Switching the UI Project cannot silently retarget an already-started
+  run; the visible run context continues to identify its bound Project.
+- **AC-8:** At 1440x900, 1024x768, and 390x844, the primary Project and active
+  View remain obvious, the sidebar becomes a keyboard-operable overlay when
+  compact or narrow, focus is visible, document-level horizontal overflow is
+  absent, and browser console/page errors are empty in populated states.
+- **AC-9:** Existing feature behavior remains reachable: Session inspection and
+  comparison, Input trace and Intent analysis, Git history and patches, Artifact
+  browsing and preview, customization analysis, Debugger runs, ACP permissions,
+  Compare Simple/Advanced paths, and frozen evidence rendering.
+
+## Non-goals
+
+- Loading every remembered Project's full Session, Git, Artifact, or Inspector
+  model into memory simultaneously.
+- Merging feature-specific evidence, run, Artifact, Git, or experiment models
+  into a universal Project or View IR.
+- Claiming that configured experiment, evidence, Inspector, or compatibility
+  Artifact Sources belong to the active Project without explicit binding.
+- Adding a remote project service, authentication, collaboration, cloud sync,
+  host adapter, or repository mutation workflow.
+- Persisting remembered Projects across Studio server restarts in this change;
+  the Project catalog is process-local and can gain a server-private durable
+  store under a separately reviewed contract.
+
+## Plan and Tasks
+
+1. Add browser-safe Project descriptor and snapshot contracts with opaque ids,
+   monotonic revisions, and pure route/view models.
+2. Replace the single open-workspace route flow with a process-local Project
+   catalog that registers local/imported workspaces, activates one materialized
+   workspace at a time, preserves the previous Project on failure, and retains
+   compatibility aliases for current workspace clients.
+3. Split the React application shell into Project sidebar, context bar, View
+   viewport, shared states, and a pure View registry. Key project-scoped Views
+   by Project id and revision rather than an unlabelled workspace counter.
+4. Move Project opening/removal and Project identity out of Sessions and other
+   feature components. Keep feature-specific filters, tabs, actions, and dense
+   workbench panes local.
+5. Make Compare scope explicit and replace its one-option Current Project
+   select with a read-only checkpoint context.
+6. Add model, server, and Playwright coverage for registration, A/B activation,
+   failure preservation, path privacy, routes, keyboard behavior, responsive
+   layout, stale UI state, and existing feature reachability.
+7. Run package build/typecheck/tests, focused browser suites, preview health and
+   module smoke, console/error inspection, three-width screenshots, document
+   link validation, and a Review Readiness Check.
+
+## Test and Review Evidence
+
+- **AC-1/AC-4/AC-5/AC-8:** pure shell/route tests plus Playwright Project A to
+  Project B switching at 1440x900, 1024x768, and 390x844; assert one visible View
+  navigation, focus restoration, no document overflow, and screenshots.
+- **AC-2/AC-3:** server tests for Project listing/opening/activation/removal,
+  cancelled and failed discovery, revision increments, same-origin mutation,
+  imported-directory lifetime, and responses that never serialize native paths.
+- **AC-6:** Compare model/browser checks distinguish Sessions, Bench, and frozen
+  results and assert the checkpoint context is not an interactive Project select.
+- **AC-7:** server and browser checks record the Project binding used by a live
+  default-workspace run and prove later Project selection does not change it.
+- **AC-9:** existing Harness Studio package and browser suites remain green,
+  with selector updates limited to the shared chrome contract.
+- Required commands:
+  - `npm run build -w @qoder-ai/harness-studio`
+  - `npm run typecheck -w @qoder-ai/harness-studio`
+  - `npm test -w @qoder-ai/harness-studio`
+  - `npm run test:browser -w @qoder-ai/harness-studio`
+  - `npx vitest run test/skills-docs/doc-link-graph.test.mjs`
+  - `node scripts/doc-link-graph/cli.mjs skills/better-harness`
+  - `npm run preview`, then smoke `/health` and `/canvas-module.js`
+- Risk: Project switching can cross-contaminate in-flight client reads. Mitigate
+  with Project id/revision keys, effect cancellation, atomic activation, and
+  response binding checks.
+- Risk: a live run could execute in a different directory than the visible
+  Project. Mitigate by capturing Project id/revision/cwd once at run start and
+  retaining that binding in the run projection.
+- Risk: configured Sources can be mistaken for Project evidence. Mitigate with
+  explicit scope labels and independent source selection.
+- Risk: the additional sidebar can squeeze dense workbenches. Mitigate with the
+  existing wide/compact/narrow boundaries, overlay navigation below 1080px, and
+  locally scrolling panes.
+
+## Review Evidence
+
+- `npm run build -w @qoder-ai/harness-studio` passed.
+- `npm run typecheck -w @qoder-ai/harness-studio` passed.
+- `npm test -w @qoder-ai/harness-studio` passed: 61 files, 472 tests.
+- `npm run test:browser -w @qoder-ai/harness-studio` passed: 50 Playwright
+  scenarios, including Project A/B switching, browser back/forward restoration,
+  live-run Project binding, keyboard traversal, clean browser errors, and
+  screenshots at 1440x900, 1024x768, and 390x844.
+- `npm run check` passed under the repository-supported Node 24 runtime: 104
+  root test files (1545 passed, 2 skipped), generated language sources, 173
+  Harness tests, 31 Harness UI tests, 472 Harness Studio tests, and npm/runtime
+  package verification. The host's default Node 26 is outside the declared
+  `>=22.20.0 <25.0.0` engine range and cannot run Langium generation.
+- `npx vitest run test/skills-docs/doc-link-graph.test.mjs` passed: 8 tests.
+- `node scripts/doc-link-graph/cli.mjs skills/better-harness` regenerated the
+  graph with no resulting tracked diff.
+- `npm run preview` failed fast before binding a port because this machine has
+  no Canvas SDK runtime and neither `CANVAS_SDK_MEDIA_DIR` nor
+  `CANVAS_SDK_ROOT` is configured. Consequently `/health` and
+  `/canvas-module.js` could not be claimed as live Preview evidence.

--- a/docs/specs/2026-08-28-studio-published-first-run.md
+++ b/docs/specs/2026-08-28-studio-published-first-run.md
@@ -1,0 +1,133 @@
+# Make the published Studio first run actionable
+
+## Traceability
+
+- Spec ID: studio-published-first-run
+- Status: Implemented
+- Design contract: [Harness Studio visual system](../../DESIGN.md)
+- Related Project shell: [Make projects the Studio workbench scope](2026-08-27-studio-project-first-workbench.md)
+
+## Intent
+
+Make the installed `@qoder-ai/harness-studio` CLI behave like the Project-first
+Studio shown by the repository launcher. A user starting the published package
+must be able to open a local Project, analyze supported Host customizations, and
+recover from ordinary input, port, and browser-loading failures without reading
+source code. Unavailable capabilities must remain honest and actionable.
+
+## Acceptance Scenarios
+
+- **AC-1:** The packed npm artifact contains a bundled workspace Session
+  provider. Starting `harness-studio` without repository-only scripts reports
+  Project discovery as enabled, and the Projects add command can discover a
+  selected local directory without exposing its native path to the browser.
+- **AC-2:** The packed ESM CLI loads the bundled customization runtime under a
+  supported Node release. An Analyze request returns independent Host results
+  instead of failing because a CommonJS dependency attempted a dynamic
+  `require` from ESM.
+- **AC-3:** A Host collection failure retains a bounded, privacy-safe reason and
+  the Customizations View keeps an enabled retry action. Native paths,
+  environment values, commands, arguments, and authorization data never cross
+  the browser boundary.
+- **AC-4:** `--version` succeeds. Unknown options preserve the first offending
+  token; value options reject a missing value without consuming the following
+  known flag; missing input files and occupied ports produce concise recovery
+  guidance, including `--port <n>` for address conflicts.
+- **AC-5:** A Studio configuration-load failure presents a keyboard-operable
+  Retry command that re-runs the coherent config/source/Project fetch without a
+  full page refresh.
+- **AC-6:** Empty Views offer a relevant shell-owned action when one exists,
+  unavailable status is rendered as status rather than button-like chrome, and
+  launchers without a prerequisite state the actual missing capability.
+- **AC-7:** Before a live run starts, Debugger uses ordinary state language such
+  as Ready and Waiting. Advanced retained-history terminology appears only on
+  recorded evidence surfaces; the live inspector explanation follows actual
+  running, finished, error, or permission state.
+- **AC-8:** At 390x844, the active View title remains readable, Source controls
+  collapse to an icon/count affordance, toolbars do not consume the primary
+  vertical decision area, document overflow stays zero, and focus remains
+  visible.
+- **AC-9:** The package README starts with an actionable Project-first command
+  and accurately distinguishes packaged CLI behavior from repository
+  development launchers.
+
+## Non-goals
+
+- Persisting the process-local Project catalog across server restarts.
+- Adding a new Coding Agent host, remote Project service, authentication layer,
+  or browser-exposed native path picker.
+- Replacing the Debugger evidence model or removing precise retained-history
+  terms from the recorded Session surface.
+- Publishing the package or changing its version, release notes, or changelog.
+
+## Plan and Tasks
+
+1. Bundle the existing Inspector workspace provider and its repository-owned
+   dependencies into `dist/server/runtime`, and load it lazily from the CLI.
+2. Give Node-targeted ESM runtimes a `createRequire(import.meta.url)` bridge so
+   bundled CommonJS dependencies work on supported Node releases.
+3. Preserve safe collector failure reasons through the customization contract
+   and keep Analyze retryable.
+4. Refactor CLI value parsing around explicit option contracts, add version and
+   friendly filesystem/listen diagnostics, and cover the actual compiled CLI.
+5. Add a retryable Studio bootstrap function and action-aware empty states;
+   simplify live Debugger status copy and narrow layout priorities.
+6. Update the package README and verify the tarball contents, installed CLI,
+   HTTP config, Project open flow, customization analysis, and browser layouts.
+
+## Test and Review Evidence
+
+- **AC-1/AC-2:** build and pack the workspace, install or execute the tarball in
+  an isolated temporary directory, start the compiled CLI, inspect `/api/config`,
+  open a fixture Project through the server seam, and call customization Analyze.
+- **AC-3/AC-4:** focused Vitest behavior tests for redacted failure reasons,
+  first-error parsing, missing values, version, missing files, and `EADDRINUSE`.
+- **AC-5/AC-6/AC-8:** Playwright scenarios for failed-then-successful bootstrap,
+  actionable empty states, semantic status, keyboard focus, 390x844 layout,
+  zero document overflow, and empty console/page errors.
+- **AC-7:** component/model and browser assertions for Ready, Running,
+  Permission required, Finished, and Failed labels without claiming a pause.
+- **AC-9:** inspect the packed README and `npm pack --dry-run` file list.
+- Required commands:
+  - `npm run build -w @qoder-ai/harness-studio`
+  - `npm run typecheck -w @qoder-ai/harness-studio`
+  - `npm test -w @qoder-ai/harness-studio`
+  - `npm run test:browser -w @qoder-ai/harness-studio`
+  - `npm pack -w @qoder-ai/harness-studio --dry-run`
+  - `npx vitest run test/skills-docs/doc-link-graph.test.mjs`
+- Risk: bundling repository discovery can capture unsupported files or native
+  paths. Keep it in one Node-only runtime entry and verify the tarball plus the
+  browser-safe Project contract.
+- Risk: reporting collector exceptions can leak secrets. Normalize to a small
+  allowlist of reason categories and never serialize raw messages, stacks, or
+  filesystem paths.
+- Risk: denser narrow-screen changes can hide commands. Retain accessible names,
+  one primary action, visible focus, and desktop labels while collapsing only
+  secondary copy.
+
+### Implementation receipt
+
+- **AC-1/AC-2:** The extracted `0.1.1` tarball reported
+  `workspaceDiscoveryEnabled: true`, opened a non-Git temporary Project through
+  the bundled Session provider, and analyzed all three customization Hosts.
+  The real bundled runtime returned 288 definitions with no Host failure.
+- **AC-3/AC-4:** Focused server and collector coverage passed as part of 76
+  targeted tests. The extracted CLI returned `0.1.1`, preserved
+  `Unknown option '--evidenc'.`, and the server test exercised missing values,
+  missing Harness files, and occupied-port recovery.
+- **AC-5/AC-6/AC-7/AC-8:** The Project shell browser suite exercised bootstrap
+  Retry, action-owned empty states, Ready/Running live states, a Project switch
+  during a live run, compact Source controls, focus, zero document overflow,
+  and 1440x900, 1024x768, and 390x844 screenshots. The complete browser suite
+  passed 51 scenarios without console or page errors in the changed surfaces.
+- **AC-9:** `npm pack --dry-run --ignore-scripts` included the package README,
+  both bundled runtimes, and the Inspector runtime's HTML, CSS, and JavaScript
+  assets. The package contained 1,142 files (6.9 MB compressed).
+- `npm run typecheck -w @qoder-ai/harness-studio` passed.
+- `npm test -w @qoder-ai/harness-studio` passed 61 files / 483 tests.
+- `npm run test:browser -w @qoder-ai/harness-studio` passed 51 tests.
+- `npx vitest run test/skills-docs/doc-link-graph.test.mjs` passed 8 tests after
+  regenerating the routing graph.
+- The required repository Canvas preview remains independently blocked before
+  binding a port because no Canvas SDK runtime is configured; `/health` and
+  `/canvas-module.js` therefore could not be smoked in this checkout.

--- a/docs/specs/2026-08-28-studio-published-first-run.md
+++ b/docs/specs/2026-08-28-studio-published-first-run.md
@@ -50,6 +50,27 @@ source code. Unavailable capabilities must remain honest and actionable.
 - **AC-9:** The package README starts with an actionable Project-first command
   and accurately distinguishes packaged CLI behavior from repository
   development launchers.
+- **AC-10:** A comparison whose checkpoint source is unavailable is blocked by
+  one shared readiness predicate in Setup, Simple Compare, Advanced Workbench,
+  and the server execution route. No surface calls it Ready, enables entry or
+  Run, or claims that fresh runs share a valid checkpoint.
+- **AC-11:** A Qoder experiment never receives or renders an ACP Agent
+  selection. Simple and Advanced surfaces identify Qoder execution from the
+  manifest runtime, while ACP manifests retain their registered Agent chooser
+  and server-side selection validation.
+- **AC-12:** Session comparison exposes explicit Metric, Left, and Right column
+  headers. At 390x844 both values remain visible and associated with their lane
+  without document-level or table-level horizontal scrolling.
+- **AC-13:** Every Session comparison checkbox has a unique accessible name
+  containing the Session identity, and Up/Down/Home/End move one roving row
+  focus through the Session catalog.
+- **AC-14:** An exact zero Artifact count is unavailable evidence rather than a
+  ready catalog. Overview does not recommend the empty View, and Project-backed
+  evidence empty states offer the shell-owned command for opening another
+  Project when discovery is available.
+- **AC-15:** The Compare destination status follows the active Compare surface,
+  so an open Bench is labelled Harness Bench even when Session comparison is
+  also available.
 
 ## Non-goals
 
@@ -74,6 +95,14 @@ source code. Unavailable capabilities must remain honest and actionable.
    simplify live Debugger status copy and narrow layout priorities.
 6. Update the package README and verify the tarball contents, installed CLI,
    HTTP config, Project open flow, customization analysis, and browser layouts.
+7. Reuse the checkpoint readiness contract across all experiment surfaces and
+   reject direct execution when the server observes an unavailable source.
+8. Project runtime identity from the manifest host and expose ACP Agent catalogs
+   only for ACP-hosted experiments.
+9. Add semantic Session comparison headers, narrow columns, unique checkbox
+   names, and roving Session-row focus.
+10. Derive navigation and Overview actions from usable evidence counts and the
+    active Compare surface rather than only source presence.
 
 ## Test and Review Evidence
 
@@ -88,6 +117,13 @@ source code. Unavailable capabilities must remain honest and actionable.
 - **AC-7:** component/model and browser assertions for Ready, Running,
   Permission required, Finished, and Failed labels without claiming a pause.
 - **AC-9:** inspect the packed README and `npm pack --dry-run` file list.
+- **AC-10/AC-11:** focused contract and server tests plus Playwright against one
+  unavailable Qoder manifest and one ready ACP manifest. Assert disabled actions,
+  a 409 direct-run boundary, truthful Qoder labels, and an ACP-only catalog.
+- **AC-12/AC-13:** Playwright at 390x844 with explicit column-header assertions,
+  bounded cell rectangles, unique checkbox names, and arrow-key row focus.
+- **AC-14/AC-15:** pure shell-model tests for zero evidence, Overview actions,
+  Project recovery actions, and active Bench status.
 - Required commands:
   - `npm run build -w @qoder-ai/harness-studio`
   - `npm run typecheck -w @qoder-ai/harness-studio`
@@ -104,6 +140,11 @@ source code. Unavailable capabilities must remain honest and actionable.
 - Risk: denser narrow-screen changes can hide commands. Retain accessible names,
   one primary action, visible focus, and desktop labels while collapsing only
   secondary copy.
+- Risk: UI-only experiment gating can be bypassed by a direct request. Apply the
+  same readiness contract at the server route before allocating a run.
+- Risk: runtime identity can drift if it is inferred from an installed catalog.
+  Use the loaded manifest host as authority and treat Agent selection as an
+  ACP-only refinement.
 
 ### Implementation receipt
 
@@ -123,9 +164,23 @@ source code. Unavailable capabilities must remain honest and actionable.
 - **AC-9:** `npm pack --dry-run --ignore-scripts` included the package README,
   both bundled runtimes, and the Inspector runtime's HTML, CSS, and JavaScript
   assets. The package contained 1,142 files (6.9 MB compressed).
+- **AC-10/AC-11:** One shared checkpoint predicate now controls Setup, Simple,
+  Advanced, `/api/config`, and the run route. Focused server and browser checks
+  proved that an unavailable Qoder experiment reports Blocked, returns 409
+  without calling its runner, omits the ACP catalog and selector, and continues
+  to identify ready ACP manifests through their registered Agent selection.
+- **AC-12/AC-13:** Session comparison now exposes semantic Metric, Left, and
+  Right headers. Playwright verified bounded 390x844 cells, unique comparison
+  checkbox names, and Up/Down roving row focus; wide, compact, and narrow
+  screenshots were visually reviewed.
+- **AC-14/AC-15:** Shell-model coverage proved that zero Artifacts are partial
+  evidence and are not recommended by Overview, Project recovery actions retain
+  their shell-owned labels, and Compare status follows Sessions, Bench, or
+  frozen Results. The configured Overview also reports a blocked checkpoint as
+  needing attention rather than ready.
 - `npm run typecheck -w @qoder-ai/harness-studio` passed.
-- `npm test -w @qoder-ai/harness-studio` passed 61 files / 483 tests.
-- `npm run test:browser -w @qoder-ai/harness-studio` passed 51 tests.
+- `npm test -w @qoder-ai/harness-studio` passed 61 files / 487 tests.
+- `npm run test:browser -w @qoder-ai/harness-studio` passed 52 tests.
 - `npx vitest run test/skills-docs/doc-link-graph.test.mjs` passed 8 tests after
   regenerating the routing graph.
 - The required repository Canvas preview remains independently blocked before

--- a/package-lock.json
+++ b/package-lock.json
@@ -2437,6 +2437,334 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.147.0.tgz",
+      "integrity": "sha512-fOtoGvIoirkvxQVw9J1WJPxz571XPgLsPf9uhRD+PJteUnvrJHMDmK9pw2yZEGGyismtRoEsp+JcXUdF/JDMDw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.147.0.tgz",
+      "integrity": "sha512-emjQHOYJaomo4ykaXQ1EItunr/I94Nk01oqBmU4dSkKSTupIDx6OysVDf2e8Eytm77rb+4ZxzgElyWP7rcEX7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.147.0.tgz",
+      "integrity": "sha512-kXvBPJL7RmDPJ2mze/vXPPVQimCDtFr9OFLjf7dyhV5Dx64cgcXh9KKrA1sMWvCObvJll9CZZUO0FBlFwD0l6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.147.0.tgz",
+      "integrity": "sha512-mgFF8pLU6R64LbT27lSrtVRspVC/3IcZ0qyIikzmi78Y3Ik2OPnlAHHI0UEBRcC3qmNgtjaef7zkFt7/uPxIcw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.147.0.tgz",
+      "integrity": "sha512-v38aiF11qufOTBcCAKL4skgQf0zJ4NEvRlivq7B5kHrlyvjCLjvNrMtNWDTz1SDUL6/xVsJRmLDxv2e+Cp4oWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.147.0.tgz",
+      "integrity": "sha512-AeIiBbwUaP0H1+4/qGW9l5qHecS/+XA5iMuieVcGb1T+tyc2dVGspFW13BWk/XrLsiGP/CiDJTJqAPLLCzZHkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.147.0.tgz",
+      "integrity": "sha512-/41MKPW4RgPY4DJco0NCF0RYX3IMZaVlRNMNzvhaxRavc7tN3Txm+qllZbh0aMRs0VHdgUlbI8TcAOiTai4TKg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.147.0.tgz",
+      "integrity": "sha512-bmpw/RPhVXgZbtb3xBDuwW5s8+LvZYdqcDSX/sP2ltL77aTio3DP/B5ZTwwgoJ6Mr9vJs4RrmgEKW9XkLNUU1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.147.0.tgz",
+      "integrity": "sha512-gd7VX/FDVOw6mjQcu45iIcp4QkgybgJwh3a0OFG2NxmPCj628mQWD96QGu1kK8+mZF9qK4b/gIEyC63vQoB7+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.147.0.tgz",
+      "integrity": "sha512-HnAzcfki7dSUNHf510Q2NmbJlz8Ys7rn8l9l588Pkx0tYe1BHLZnmELIgqizJ4WPhHGSwN8Ce+B/menVxS3odA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.147.0.tgz",
+      "integrity": "sha512-qlkOL6wT44U+fT5s/+sR6Shx0OdwvQF83JyIPZUxG/ovqZF5/7atOtjH+JPZ5/7ATQLbFBBSmghcy/+2NVB/ew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.147.0.tgz",
+      "integrity": "sha512-DlefD7L7sMXs/3hIBH23Egk0phj8kG0SA81dVGOQ3S1ekjOlmTLH2E+F2Thwfh1slKx6aH+lNc5fQYAw0GU7/g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.147.0.tgz",
+      "integrity": "sha512-Xqpagk/031IvZ4svrk2FF01YEqM/iN3MJV3SVZadKg/CsGlDCGoREqKHXYnoV5+8SfGe/m6RM1szXFLusTu/Uw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.147.0.tgz",
+      "integrity": "sha512-QioQOeUbI4ATUr0S2z88uA3Cds2R3Mm5Ge7U8XNYtlTb2GJF3rWlcj70z0AJhhOlbdm0YgVjqPBldUNbFylDIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.147.0.tgz",
+      "integrity": "sha512-NXy1tv/OdC+pPTwf9RiCZWPK53V/Xq/2cjSnjOSyKopajdaDqMIkgtDY+jXZemp2e8px5FeWfY2L2LwhKZQovg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.147.0.tgz",
+      "integrity": "sha512-GpGWZ6oKz4bjCWW9Mz5pCaGPyk2Aaze6zEoaslIQqpSLtpx5pXj/ap5gUNb5Jn2LIbqWyjkGLX9yv3NMuNcBVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.147.0.tgz",
+      "integrity": "sha512-a8mlt7CC8z7LUdCfaxhff4kCd+vSjE+NEFL0cxA8ukfuSnvAto/pWTjytW4BuVLnQGcCVdHJwcRKOfs++H+tjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.147.0.tgz",
+      "integrity": "sha512-M5ViVDBcFLnl2632AuuWuP35zEL5oikK1jTx8r3+902VEDeSNHxFZAB6RZyfZ7MU6Oi5QTOG8MmMkIeHsudSaw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.147.0.tgz",
+      "integrity": "sha512-DUaE13OwnUSlHpLZNcC/nuT10ivlWqc5EZgsfgXuAmWYw0r3nDxGeLD1zlGwYwIgVk1/ZMAxoXpV+05stvbHaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",
       "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.146.0.tgz",
@@ -2445,6 +2773,334 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-transform/binding-android-arm-eabi": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.147.0.tgz",
+      "integrity": "sha512-nXKEO0K20Px6CmGl2PVqVKgkct56QRtGBtW36kEmUOpTofHZ7DdxoYrM9POLd5nIoier0gKqNQVmP1xn8KfGBA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-android-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.147.0.tgz",
+      "integrity": "sha512-HVdPZeXzBs9BXKUdQaa1PvyN96nGAOk6xPbhkBuJRyLvj35ia+YGWlY8evWAEmHZLFAmd1tEjrsHrwL3ySxWww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.147.0.tgz",
+      "integrity": "sha512-1S52DkH9HHTpMfQPKuTMTc9ge35N69OGTg2Ex9EEqvMmK7YayAxQWhOeqKBSRbGVkSumqcpx0K/t5aejv/05zA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.147.0.tgz",
+      "integrity": "sha512-j/Bi0u604qsn4pi/jCMoXXAVGL13vjF4UqFg65lIbwGZH+S1dtm8u9yCvtwvxTgyucfkVCviq3OBo3EojHEKPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-freebsd-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.147.0.tgz",
+      "integrity": "sha512-oFWm18B23ZUEZ705VGCQlb0naWNyZXQXRYa3RByiDW5AgAgY089DUM2QGNjWU/2FHYe93SZGk0LRddr+2/yw8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.147.0.tgz",
+      "integrity": "sha512-G0tPdWMEFQLa2xqWu7rUmeET9hpr7c/MDi0fE2W6fOGmGhn4/RJMF0ywR01fHGYyq7xmBzpcKCm3xoSlQXiVOA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.147.0.tgz",
+      "integrity": "sha512-JvVu2FqGO+fogVSdVMggIR7Q5zQLNrdVTjUoWM7GOH79GkmiDTdWSrPVHNnOfmbAdRlRsRcBKA2NOYbato3qxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.147.0.tgz",
+      "integrity": "sha512-iBJSWOdb9NYYq0XH1afo+7kD+Mh3vEQvP4u/r1hWqePTZY1u5eG03jWi28l7phpPyRQU7+4FXEDn7G+g9k58Xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.147.0.tgz",
+      "integrity": "sha512-1SDvUsgZETvXXYdADr1bLxtjonh5uBSZLbCYYeJKvVEWbDrnpfvnwDzfossV2JVn6ZLuEov16ZzLiuaByK8fAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.147.0.tgz",
+      "integrity": "sha512-VnLNBMZvqIwh4p1f4jHcTdcvB9eiYnyLe43HWxO08G6sAE32eRzeiP3Kca3eTDfJQyKwYMk5JywlGstmKB5uNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.147.0.tgz",
+      "integrity": "sha512-HHd5ENuYymXe0LGgCzcKQ85D+p8fIhH+R9oSbh5K/45dt9uPFv+yjp3jwM6V5+T62VVjhAeepyYGo6qNpiAUdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.147.0.tgz",
+      "integrity": "sha512-OVgHgc6fjN5MaM+ruU0pB3+OpRBd5UlKycmWNpPuJgOkN8RPqywDcZ5rrVWw8ydj1LZPVdYsZqDtzeBAsaFH9A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.147.0.tgz",
+      "integrity": "sha512-qDFdcfZjlVfdKWECGch+RzzY/LzueSXoKNfM+MA4DW0gYyUlKtXMwkDtJTnf1AJ9WYBZ1n3AoIoBMZ8PvVDYeQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.147.0.tgz",
+      "integrity": "sha512-ZAmvqUs+IrXQkxMGiDu0KAblhqQAa/utszB5HhRPbwcTcyegfthllxsR7EW8i5ZUXp+kEcv5KW2OXVJTbmDKmA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.147.0.tgz",
+      "integrity": "sha512-mBvjsBtI3oVXLx+9LpsAB422lRJOPWqGJsXUFt5ThgVihnDsmHzWs1nRab8MaB2B7emJ0+O1sE8fvvLxfJxo4w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-openharmony-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.147.0.tgz",
+      "integrity": "sha512-qy08slHzOZb5IVxa7RPkIeKJjzKO4VuINlLvrxt3+eiT9DobeHryN84HZ0Kdde5NLr2jZIC+fkmJksAuQ83TRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.147.0.tgz",
+      "integrity": "sha512-5cyVdptM9GIZavwrOHaQeJdrWWeEv3pS0nQcTIS1DM998TyZ0B4IZTB5Va3OHs2oh0QCcCDFYTYwMS8nlyfyCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.147.0.tgz",
+      "integrity": "sha512-6Tf6tzMSrk+aQvcaC9CBFly7l1gEH5ErTAH9AxJfCb8VI3fwWLa1E96YpO8NKSqN1i5pbL9atQryHhwoJO5fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-x64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.147.0.tgz",
+      "integrity": "sha512-rpaJY9I+0vOy0MA4HPzK4XqvG1ydec1yoXJIsOceYanCFX5vDmJtwOjpiFUieYSYM9KKrv8r2hCMgBrQ9sdhIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@phosphor-icons/react": {
@@ -5781,6 +6437,84 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/oxc-parser/-/oxc-parser-0.147.0.tgz",
+      "integrity": "sha512-5xaug6t7GfV3BO5Iv+xHW1rmQkDEQ3BEu3L8g3InsvWO5i8CYGc4tCZ2X985QcwWNycFJam+aOns6Nr2XAThTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.147.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.147.0",
+        "@oxc-parser/binding-android-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-x64": "0.147.0",
+        "@oxc-parser/binding-freebsd-x64": "0.147.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.147.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.147.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.147.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/oxc-transform": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/oxc-transform/-/oxc-transform-0.147.0.tgz",
+      "integrity": "sha512-FkGVLTM83USPtu7Oa8iWKuLygto+gQRz7Kvb2SZsoVjFrJ0VJFQvIOHWW02GBN/8MzwT5G5hC9HM8HsWY72ufg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-transform/binding-android-arm-eabi": "0.147.0",
+        "@oxc-transform/binding-android-arm64": "0.147.0",
+        "@oxc-transform/binding-darwin-arm64": "0.147.0",
+        "@oxc-transform/binding-darwin-x64": "0.147.0",
+        "@oxc-transform/binding-freebsd-x64": "0.147.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.147.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.147.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.147.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.147.0",
+        "@oxc-transform/binding-linux-ppc64-gnu": "0.147.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.147.0",
+        "@oxc-transform/binding-linux-riscv64-musl": "0.147.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.147.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.147.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.147.0",
+        "@oxc-transform/binding-openharmony-arm64": "0.147.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.147.0",
+        "@oxc-transform/binding-win32-ia32-msvc": "0.147.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.147.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "8.3.0",
       "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-8.3.0.tgz",
@@ -7356,6 +8090,8 @@
         "esbuild-wasm": "0.28.2",
         "fast-xml-parser": "^5.11.0",
         "fflate": "^0.8.3",
+        "oxc-parser": "0.147.0",
+        "oxc-transform": "0.147.0",
         "pdfjs-dist": "^6.2.108",
         "react": "19.2.8",
         "react-arborist": "^3.16.0",

--- a/packages/harness-studio/README.md
+++ b/packages/harness-studio/README.md
@@ -117,6 +117,47 @@ The module must export `createArtifactProvider()`. Contributions remain inactive
 until `harness-studio artifact-provider activate` records the exact Provider
 fingerprint and matcher.
 
+### AgentReact artifacts
+
+Studio selects the production AgentReact runtime only for the explicit compound
+suffix `*.agent.canvas.tsx`; existing `*.canvas.tsx` keeps the general React
+preview, and ordinary TSX remains source-only. The static view id must equal the
+portable filename stem before `.agent.canvas.tsx`:
+
+```tsx
+import {
+  defineArtifactView,
+  useArtifactAction,
+  useArtifactState,
+} from "@studio/agent-react";
+
+function Orders() {
+  const [orders, setOrders] = useArtifactState<readonly string[]>("/orders");
+  const showSource = useArtifactAction("studio.show-source");
+  return <main>
+    <h1>Orders</h1>
+    <output>{orders.length}</output>
+    <button onClick={() => setOrders([...orders, "next"])}>Add</button>
+    <button onClick={() => void showSource()}>Show source</button>
+  </main>;
+}
+
+export default defineArtifactView({
+  id: "orders", // orders.agent.canvas.tsx
+  state: { "/orders": { schema: "list", version: 1 } },
+  capabilities: ["studio.show-source"],
+  component: Orders,
+});
+```
+
+The built-in Host provides `json@1`, `list@1`, and `record@1` state and grants
+only `studio.show-source`; other requested actions fail closed. Source is
+compiled by a deadline-enforced Worker and runs only after an opaque, no-network
+staging frame verifies the build. A failed replacement leaves the last verified
+Current frame visible. See the
+[AgentReact production foundation spec](../../docs/specs/2026-08-27-agent-react-artifact-runtime-poc.md)
+for the exact language profile, ABI, and evidence boundary.
+
 ## Architecture
 
 ```text

--- a/packages/harness-studio/README.md
+++ b/packages/harness-studio/README.md
@@ -1,13 +1,12 @@
 # @qoder-ai/harness-studio
 
-A local React control plane for [`@qoder-ai/harness`](../harness/README.md):
-durable Harness objects organize the evidence, inspection, live-run, and
-experiment surfaces the Harness toolchain produces.
+A local React workbench for [`@qoder-ai/harness`](../harness/README.md): Projects
+provide one shared scope for retained inputs, Sessions, commits, artifacts,
+live runs, and comparisons.
 
-- **Harness control plane** — organizes work as `Overview`, `Inspector`,
-  `Harnesses`, `Task Suites`, `Experiments`, and `Registry`. Unimplemented
-  source, suite, and promotion capabilities stay visibly marked as foundations
-  instead of appearing as working controls.
+- **Project-first workbench** — open and switch local Projects from the left
+  navigation while `Overview`, `Inputs`, `Sessions`, `Commits`, `Artifacts`,
+  `Debugger`, and `Compare` stay in one stable View shell.
 
 - **Inspector workspace** — embeds an explicitly supplied, self-contained
   Harness Inspector report behind a sandboxed, read-only document boundary.
@@ -29,6 +28,9 @@ studio reads the same evidence and adds interactivity on top.
 ## Usage
 
 ```sh
+# Project-first Studio; choose a local Project in the app
+npx @qoder-ai/harness-studio
+
 # Inspector evidence only
 npx @qoder-ai/harness-studio --inspector ./harness-inspector.html
 
@@ -51,11 +53,15 @@ npx @qoder-ai/harness-studio \
   --experiment-locks ./.harness-studio-locks
 ```
 
-Then open the printed URL (default `http://127.0.0.1:3311`). The server binds
-to loopback; live runs execute through the same v0.2 executors and redaction
-rules as the core package. The embedded run endpoint accepts same-origin JSON
-browser requests only; use the standalone `@qoder-ai/harness-ui` server with
-an explicit `--allow-origin` when the frontend is hosted on another origin.
+Then open the printed URL (default `http://127.0.0.1:3311`). The packaged CLI
+includes local Project selection and Session discovery on Windows, macOS, and
+Linux. Native directory selection depends on the operating system's picker;
+Studio reports an actionable error when no supported picker is installed. The
+server binds to loopback; live runs execute through the same v0.2 executors and
+redaction rules as the core package. The embedded run endpoint accepts
+same-origin JSON browser requests only; use the standalone
+`@qoder-ai/harness-ui` server with an explicit `--allow-origin` when the
+frontend is hosted on another origin.
 
 A `source`-backed skill is locked and read from `--source-root`, which
 defaults to the directory containing `--harness`. Pass it explicitly when the
@@ -210,10 +216,11 @@ npm run harness-studio:test:browser   # built-app Playwright interaction
 Run the development command from the repository root. It incrementally rebuilds
 Studio browser dependencies plus its HTML and styles, then reloads open pages
 after a successful build. A browser build error leaves the server running and
-the next valid edit recovers normally. The repository's local workspace launcher
-supplies Session discovery and the default ACP Agent. Server-side source changes
-still require restarting the command; this is live reload rather than React Fast
-Refresh.
+the next valid edit recovers normally. The repository launcher and the packaged
+CLI use the same bundled Session discovery boundary; the development launcher
+also supplies the repository's default ACP Agent configuration. Server-side
+source changes still require restarting the command; this is live reload rather
+than React Fast Refresh.
 
 Publication is repository-owned: select `harness-studio` in the protected
 GitHub Actions `Publish npm` workflow. Local commands only build, test, pack,

--- a/packages/harness-studio/package.json
+++ b/packages/harness-studio/package.json
@@ -56,6 +56,8 @@
     "esbuild-wasm": "0.28.2",
     "fast-xml-parser": "^5.11.0",
     "fflate": "^0.8.3",
+    "oxc-parser": "0.147.0",
+    "oxc-transform": "0.147.0",
     "pdfjs-dist": "^6.2.108",
     "react": "19.2.8",
     "react-arborist": "^3.16.0",

--- a/packages/harness-studio/scripts/app-build.mjs
+++ b/packages/harness-studio/scripts/app-build.mjs
@@ -95,15 +95,33 @@ export async function buildStudioApp() {
 }
 
 export async function buildStudioServerRuntime() {
-  await build({
-    entryPoints: [join(repositoryRoot, "scripts", "agent-customize", "index.mjs")],
-    outfile: join(packageRoot, "dist", "server", "runtime", "agent-customize-runtime.mjs"),
+  const runtimeAssetRoot = join(packageRoot, "dist", "server", "runtime", "ui");
+  await mkdir(runtimeAssetRoot, { recursive: true });
+  const nodeRuntime = {
     bundle: true,
     format: "esm",
     platform: "node",
     target: "node22",
     logLevel: "warning",
-  });
+    banner: {
+      js: "import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);",
+    },
+  };
+  await Promise.all([
+    build({
+      ...nodeRuntime,
+      entryPoints: [join(repositoryRoot, "scripts", "agent-customize", "index.mjs")],
+      outfile: join(packageRoot, "dist", "server", "runtime", "agent-customize-runtime.mjs"),
+    }),
+    build({
+      ...nodeRuntime,
+      entryPoints: [join(packageRoot, "scripts", "inspector-workspace-provider.mjs")],
+      outfile: join(packageRoot, "dist", "server", "runtime", "inspector-workspace-runtime.mjs"),
+    }),
+    ...["workbench.html", "workbench.css", "workbench.js"].map((file) =>
+      copyFile(join(inspectorAssetRoot, file), join(runtimeAssetRoot, file)),
+    ),
+  ]);
 }
 
 export function createStudioDevReloadPlugin({

--- a/packages/harness-studio/scripts/inspector-workspace-provider.mjs
+++ b/packages/harness-studio/scripts/inspector-workspace-provider.mjs
@@ -33,7 +33,25 @@ export function createInspectorWorkspaceSessionProvider({
 } = {}) {
   return {
     async discover(workspacePath) {
-      const repoRoot = repoRootFor(workspacePath);
+      let repoRoot = workspacePath;
+      let commits = [];
+      let gitHistoryAvailable = false;
+      let checkpointResolution = { checkpoints: [], unresolved: [] };
+      const discoveryDiagnostics = [];
+      try {
+        repoRoot = repoRootFor(workspacePath);
+        ({ commits } = collectCommits({ workspace: repoRoot, limit: MAX_COMMITS }));
+        gitHistoryAvailable = true;
+      } catch {
+        discoveryDiagnostics.push("Git history is unavailable for this Project; Session evidence remains available.");
+      }
+      if (gitHistoryAvailable) {
+        try {
+          checkpointResolution = collectCheckpoints({ repoRoot, commits });
+        } catch {
+          discoveryDiagnostics.push("Entire checkpoint evidence is unavailable; Git history remains available.");
+        }
+      }
       const { sessions, providers } = await collect({
         workspace: workspacePath,
         repoRoot,
@@ -42,8 +60,6 @@ export function createInspectorWorkspaceSessionProvider({
         includeToolTrace: true,
         includeDialogue: true,
       });
-      const { commits } = collectCommits({ workspace: repoRoot, limit: MAX_COMMITS });
-      const checkpointResolution = collectCheckpoints({ repoRoot, commits });
       const sessionsWithCheckpoints = attachCheckpointFactsToSessions(sessions, checkpointResolution.checkpoints);
       const correlated = correlate(commits, sessionsWithCheckpoints);
       const filesByCommit = new Map(commits.map((commit) => [commit.hash, commit.files]));
@@ -70,6 +86,7 @@ export function createInspectorWorkspaceSessionProvider({
           sessionLimit: MAX_SESSIONS,
         },
         diagnostics: [
+          ...discoveryDiagnostics,
           ...diagnostics,
           ...(checkpointResolution.unresolved.length > 0
             ? [`${checkpointResolution.unresolved.length} Entire checkpoint link(s) could not be resolved locally.`]

--- a/packages/harness-studio/src/agent-react/contracts/addressing.ts
+++ b/packages/harness-studio/src/agent-react/contracts/addressing.ts
@@ -1,0 +1,70 @@
+/**
+ * The addressing algorithm shared by the compiler and the runtime.
+ *
+ * This is the one contract module with executable code, and that is the point:
+ * the Oxc semantic index computes a JSX element's id at compile time while the
+ * sandbox-side `jsxDEV` computes it again at render time, and the two must agree
+ * exactly or a resolved DOM node points at unrelated source. Two copies of "the
+ * same" hash in two layers is precisely how that drifts, so both layers import
+ * this one.
+ *
+ * That constraint also fixes the implementation: this module runs inside the
+ * sandbox, so it may not use `node:crypto`, the DOM, or any dependency — hence
+ * the inlined 64-bit FNV-1a below.
+ */
+
+const FNV_OFFSET = 0xcbf29ce484222325n;
+const FNV_PRIME = 0x100000001b3n;
+const MASK_64 = 0xffffffffffffffffn;
+
+export function stableHash(input: string): string {
+  let hash = FNV_OFFSET;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash ^ BigInt(input.charCodeAt(index) & 0xffff)) * FNV_PRIME & MASK_64;
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+export interface SourceSpan {
+  readonly modulePath: string;
+  readonly line: number;
+  readonly column: number;
+  readonly elementType: string;
+}
+
+/**
+ * Identity of a JSX element *in the source*, stable for one Artifact Revision.
+ *
+ * Line and column come from the automatic development transform's `__source`, so
+ * any edit above an element changes its id. That is intentional: cross-Revision
+ * continuity is the semantic index's job, and pretending a span survives an edit
+ * would let a stale annotation point at unrelated code.
+ */
+export function sourceNodeId(span: SourceSpan): string {
+  return stableHash(`${span.modulePath}\u0000${span.line}\u0000${span.column}\u0000${span.elementType}`);
+}
+
+/**
+ * Identity of a rendered element. `parentInstance` is optional because JSX
+ * elements are created inner-first, so the creation-time stamp cannot know its
+ * parent; a caller that already holds a parent instance (a tree walk, a
+ * selection event) passes it to disambiguate repeated keys.
+ */
+export function instanceAddress(parts: {
+  readonly artifactDigest: string;
+  readonly sourceNodeId: string;
+  readonly key?: string | null;
+  readonly parentInstance?: string | null;
+}): string {
+  return stableHash([
+    parts.artifactDigest,
+    parts.sourceNodeId,
+    parts.key ?? "",
+    parts.parentInstance ?? "",
+  ].join("\u0000"));
+}
+
+/** Attribute an intrinsic DOM element carries. */
+export const ARTIFACT_NODE_ATTRIBUTE = "data-artifact-node";
+/** Reserved prop a catalog component must forward to its root DOM element. */
+export const ARTIFACT_NODE_PROP = "artifactNode";

--- a/packages/harness-studio/src/agent-react/contracts/build.ts
+++ b/packages/harness-studio/src/agent-react/contracts/build.ts
@@ -1,0 +1,47 @@
+import type { ArtifactViewDeclaration, ReactSemanticIndex } from "./compile.js";
+import type { Diagnostic } from "./diagnostics.js";
+import type { Digest } from "./revision.js";
+
+export interface SourceMapChainEntry {
+  readonly module: string;
+  readonly map: string;
+}
+
+/**
+ * A frozen, replayable compile+link result.
+ *
+ * The three version fields are part of the identity, not metadata: a snapshot can
+ * only be replayed if the Revision *and* the rules that translated it are pinned.
+ */
+export interface BuildSnapshot {
+  readonly buildDigest: Digest;
+  readonly artifactDigest: Digest;
+  readonly artifactId: string;
+  readonly buildGeneration: number;
+  readonly compilerVersion: string;
+  readonly profileVersion: string;
+  readonly runtimeVersion: string;
+  /** Effective compiler, linker, limit, and Bootstrap policy identity. */
+  readonly buildPolicyDigest: Digest;
+  readonly status: "ready" | "failed";
+  /** UTF-8 ESM bundle; empty when `status === "failed"`. */
+  readonly bundle: string;
+  readonly sourceMaps: readonly SourceMapChainEntry[];
+  readonly semanticIndex: readonly ReactSemanticIndex[];
+  readonly viewDeclaration?: ArtifactViewDeclaration;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/**
+ * Raised instead of returning a stale bundle.
+ *
+ * A streaming agent commits Revisions faster than a build finishes. Resolving a
+ * superseded generation would let an older bundle win the race and get staged over
+ * the newer one.
+ */
+export class BuildGenerationSuperseded extends Error {
+  constructor(readonly generation: number) {
+    super(`Build generation ${generation} was superseded before it completed.`);
+    this.name = "BuildGenerationSuperseded";
+  }
+}

--- a/packages/harness-studio/src/agent-react/contracts/compile.ts
+++ b/packages/harness-studio/src/agent-react/contracts/compile.ts
@@ -1,0 +1,91 @@
+import type { Diagnostic } from "./diagnostics.js";
+import type { ModuleSource } from "./revision.js";
+
+/**
+ * What the Oxc Semantic Kernel promises the rest of the system.
+ *
+ * Everything here is data. Business code never receives an Oxc AST, which is what
+ * lets the kernel move behind a Wasm Worker later: shipping a full AST across that
+ * boundary would dominate compile cost.
+ */
+
+// ---------------------------------------------------------------------------
+// Artifact View ABI
+// ---------------------------------------------------------------------------
+
+export interface ArtifactStateDeclaration {
+  readonly path: string;
+  readonly schema: string;
+  readonly version: number;
+}
+
+export interface ArtifactViewDeclaration {
+  readonly id: string;
+  /** Sorted by `path`, so two extractions of the same source compare equal. */
+  readonly state: readonly ArtifactStateDeclaration[];
+  /** Sorted, duplicate-free capability requests. */
+  readonly capabilities: readonly string[];
+  readonly componentName: string;
+  readonly module: string;
+}
+
+// ---------------------------------------------------------------------------
+// Semantic index
+// ---------------------------------------------------------------------------
+
+export interface SemanticComponentEntry {
+  readonly name: string;
+  readonly exported: boolean;
+  readonly line: number;
+}
+
+export interface SemanticJsxNodeEntry {
+  /** Computed by `contracts/addressing.ts`, so the runtime derives the same id. */
+  readonly sourceNodeId: string;
+  readonly elementType: string;
+  readonly intrinsic: boolean;
+  readonly line: number;
+  readonly column: number;
+  /** JSX ancestry inside the module, outermost first. */
+  readonly structurePath: readonly string[];
+  readonly staticAttributes: readonly string[];
+}
+
+export interface ReactSemanticIndex {
+  readonly module: string;
+  readonly components: readonly SemanticComponentEntry[];
+  readonly imports: readonly string[];
+  readonly exports: readonly string[];
+  readonly jsxNodes: readonly SemanticJsxNodeEntry[];
+  readonly stateReferences: readonly string[];
+  readonly actionReferences: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Compiler port
+// ---------------------------------------------------------------------------
+
+export interface CompileModuleInput {
+  readonly module: ModuleSource;
+  /** Extract the Artifact View ABI from this module only. */
+  readonly entry: boolean;
+  readonly allowedPackages: readonly string[];
+}
+
+export interface CompileModuleOutput {
+  readonly module: string;
+  readonly code?: string;
+  readonly sourceMap?: string;
+  readonly diagnostics: readonly Diagnostic[];
+  readonly semanticIndex?: ReactSemanticIndex;
+  readonly viewDeclaration?: ArtifactViewDeclaration;
+}
+
+/** The single seam business code may depend on. */
+export interface OxcCompilerPort {
+  readonly compilerVersion: string;
+  readonly profileVersion: string;
+  /** Stable identity of effective compile limits and other admission policy. */
+  readonly policyFingerprint: string;
+  compileModule(input: CompileModuleInput): Promise<CompileModuleOutput>;
+}

--- a/packages/harness-studio/src/agent-react/contracts/diagnostics.ts
+++ b/packages/harness-studio/src/agent-react/contracts/diagnostics.ts
@@ -1,0 +1,46 @@
+/**
+ * Diagnostics are the pipeline's only channel back to the agent, so their codes
+ * are a stable enumeration rather than free text: an agent that must fix its own
+ * output needs to branch on the reason, not parse a sentence.
+ */
+
+export const PROFILE_DIAGNOSTIC_CODES = [
+  "profile/commonjs",
+  "profile/node-builtin",
+  "profile/dynamic-import",
+  "profile/package-not-allowed",
+  "profile/react-dom-root",
+  "profile/dynamic-eval",
+  "profile/worker",
+  "profile/network",
+  "profile/class-component",
+  "profile/top-level-effect",
+] as const;
+
+export type ProfileDiagnosticCode = (typeof PROFILE_DIAGNOSTIC_CODES)[number];
+
+export type DiagnosticCode =
+  | ProfileDiagnosticCode
+  | "syntax/parse-failed"
+  | "abi/missing-view"
+  | "abi/not-static"
+  | "abi/duplicate-state-path"
+  | "abi/view-id-mismatch"
+  | "revision/digest-mismatch"
+  | "revision/duplicate-module"
+  | "revision/path-invalid"
+  | "limit/module-count"
+  | "limit/module-bytes"
+  | "limit/output-bytes"
+  | "limit/compile-timeout"
+  | "link/failed"
+  | "link/package-not-allowed";
+
+export interface Diagnostic {
+  readonly level: "error" | "warning";
+  readonly code: DiagnosticCode;
+  readonly message: string;
+  readonly module?: string;
+  readonly line?: number;
+  readonly column?: number;
+}

--- a/packages/harness-studio/src/agent-react/contracts/host.ts
+++ b/packages/harness-studio/src/agent-react/contracts/host.ts
@@ -1,0 +1,115 @@
+import type { BuildSnapshot } from "./build.js";
+import type { ArtifactViewDeclaration } from "./compile.js";
+import type { Digest } from "./revision.js";
+
+/**
+ * What the Artifact Host owes a frame: a grant, a state view, and a channel to
+ * report what happened. Every type here is transport-free, so the same contract
+ * serves an in-process frame and an opaque-origin iframe.
+ */
+
+// ---------------------------------------------------------------------------
+// Capabilities and actions
+// ---------------------------------------------------------------------------
+
+export type ActionMode = "live" | "dry-run" | "denied";
+
+export type CapabilityRefusal = "not-in-policy" | "awaiting-approval";
+
+export interface CapabilityGrant {
+  readonly granted: readonly string[];
+  /** Kept rather than dropped so a Surface can explain a missing control. */
+  readonly refused: readonly { readonly capability: string; readonly reason: CapabilityRefusal }[];
+}
+
+export interface FrameToken {
+  readonly token: string;
+  readonly buildDigest: Digest;
+  readonly actionMode: ActionMode;
+  readonly granted: readonly string[];
+}
+
+export type ActionOutcome =
+  | { readonly status: "completed"; readonly result: unknown }
+  | { readonly status: "dry-run" }
+  | { readonly status: "denied"; readonly reason: string };
+
+export interface ActionRequest {
+  readonly frameToken: string;
+  readonly capability: string;
+  readonly payload?: unknown;
+}
+
+/** Requests the Host may grant; the code's declaration is only the left operand. */
+export type CapabilityRequests = Pick<ArtifactViewDeclaration, "capabilities">;
+
+// ---------------------------------------------------------------------------
+// Observations
+// ---------------------------------------------------------------------------
+
+export const OBSERVATION_KINDS = [
+  "compileDiagnostic",
+  "profileViolation",
+  "renderCompleted",
+  "renderFailed",
+  "actionAttempted",
+  "actionDenied",
+  "stateValidationFailed",
+  "nodeSelected",
+  "annotationCreated",
+  "runtimeException",
+] as const;
+
+export type ObservationKind = (typeof OBSERVATION_KINDS)[number];
+
+export interface ObservationInput {
+  readonly kind: ObservationKind;
+  readonly artifactDigest?: Digest;
+  readonly buildDigest?: Digest;
+  readonly detail?: Record<string, unknown>;
+}
+
+export interface ObservationEvent extends ObservationInput {
+  readonly sequence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Frames
+// ---------------------------------------------------------------------------
+
+export interface FrameMountOptions {
+  readonly actionMode: ActionMode;
+  readonly frameToken: FrameToken;
+  /** Frozen state snapshot handed to a staging frame; live frames subscribe instead. */
+  readonly state: Readonly<Record<string, unknown>>;
+}
+
+export type FrameVerification =
+  | { readonly status: "renderCompleted" }
+  | { readonly status: "renderFailed"; readonly message: string }
+  | { readonly status: "timedOut" };
+
+export interface FrameHandle {
+  readonly snapshot: BuildSnapshot;
+  /** Reflects the token the frame currently holds, so promotion is observable. */
+  readonly actionMode: ActionMode;
+  readonly frameToken: FrameToken;
+  mount(): Promise<void>;
+  /** Resolves with the first terminal render outcome, or `timedOut`. */
+  waitForRenderCompleted(timeoutMs: number): Promise<FrameVerification>;
+  /**
+   * Promotes a verified staging frame by handing it a live token. The frame's
+   * action mode is decided by the token the Host issues, never by the frame.
+   */
+  activate(token: FrameToken): void;
+  dispose(): void;
+  readonly disposed: boolean;
+}
+
+export type FrameIsolation = "opaque-origin" | "in-process";
+
+export interface FrameFactory {
+  /** Production controllers admit only an opaque-origin transport by default. */
+  readonly isolation: FrameIsolation;
+  create(snapshot: BuildSnapshot, options: FrameMountOptions): FrameHandle;
+}

--- a/packages/harness-studio/src/agent-react/contracts/index.ts
+++ b/packages/harness-studio/src/agent-react/contracts/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Layer-crossing contracts for the AgentReact Artifact Runtime.
+ *
+ * Every other layer may import this one; this one imports nothing outside itself.
+ * It also stays free of Node built-ins and third-party packages, because the
+ * sandbox-side runtime layer loads it in a browser.
+ *
+ * Enforced by `test/agent-react/layering.test.ts`.
+ */
+
+export * from "./addressing.js";
+export * from "./build.js";
+export * from "./compile.js";
+export * from "./diagnostics.js";
+export * from "./host.js";
+export * from "./revision.js";
+export * from "./versions.js";

--- a/packages/harness-studio/src/agent-react/contracts/revision.ts
+++ b/packages/harness-studio/src/agent-react/contracts/revision.ts
@@ -1,0 +1,29 @@
+/** Digest-addressed identity, always `sha256:<hex>`. */
+export type Digest = `sha256:${string}`;
+
+/**
+ * Hashing is injected rather than imported.
+ *
+ * The Host hashes with `node:crypto`; a browser Compiler Worker would use
+ * `crypto.subtle`. Neither belongs in a contract that the sandbox-side runtime
+ * also has to load.
+ */
+export type DigestFn = (parts: readonly unknown[]) => Digest;
+
+export interface ModuleSource {
+  /** Revision-relative POSIX path, always starting with `/`. */
+  readonly path: string;
+  readonly text: string;
+}
+
+export interface ArtifactDescriptor {
+  readonly id: string;
+  /** Revision-relative path of the module carrying the default export. */
+  readonly entry: string;
+}
+
+export interface ArtifactRevision {
+  readonly digest: Digest;
+  readonly modules: readonly ModuleSource[];
+  readonly descriptor: ArtifactDescriptor;
+}

--- a/packages/harness-studio/src/agent-react/contracts/versions.ts
+++ b/packages/harness-studio/src/agent-react/contracts/versions.ts
@@ -1,0 +1,12 @@
+/**
+ * Versions that make a Build Snapshot replayable.
+ *
+ * These are separate from the package version on purpose: a snapshot is only
+ * reproducible if the Profile rules, the runtime ABI, and the compiler that
+ * translated it are all pinned, and those three move independently.
+ */
+
+export const AGENT_REACT_PROFILE_VERSION = "1";
+export const AGENT_REACT_RUNTIME_VERSION = "1";
+export const AGENT_REACT_RUNTIME_PACKAGE = "@studio/agent-react";
+export const AGENT_REACT_JSX_DEV_PACKAGE = "@studio/agent-react/jsx-dev-runtime";

--- a/packages/harness-studio/src/agent-react/host/action-gateway.ts
+++ b/packages/harness-studio/src/agent-react/host/action-gateway.ts
@@ -1,0 +1,92 @@
+import type { ActionOutcome, ActionRequest, Digest } from "../contracts/index.js";
+import type { CapabilityBroker, CapabilityPolicy } from "./capability.js";
+import type { ObservationBridge } from "./observation-bridge.js";
+
+export type ActionHandler = (payload: unknown) => Promise<unknown> | unknown;
+
+export interface ActionGateway {
+  dispatch(request: ActionRequest): Promise<ActionOutcome>;
+  /** Registers the Host-side effect for one capability. */
+  register(capability: string, handler: ActionHandler): void;
+}
+
+export interface ActionGatewayOptions {
+  readonly broker: CapabilityBroker;
+  readonly policy: CapabilityPolicy;
+  readonly observations: ObservationBridge;
+  readonly artifactDigest?: Digest;
+  readonly handlers?: Readonly<Record<string, ActionHandler>>;
+}
+
+/**
+ * The single point where an Artifact's intent becomes a side effect.
+ *
+ * Every dispatch is re-validated against the live token, the live grant, and the
+ * policy. The compile-time Profile and the ABI are advisory by comparison: a
+ * bundle that forged its own manifest, or kept a token after its frame was
+ * discarded, is refused right here.
+ */
+export function createActionGateway(options: ActionGatewayOptions): ActionGateway {
+  const handlers = new Map<string, ActionHandler>(Object.entries(options.handlers ?? {}));
+
+  const deny = (reason: string, capability: string, buildDigest?: Digest): ActionOutcome => {
+    options.observations.record({
+      kind: "actionDenied",
+      ...(options.artifactDigest === undefined ? {} : { artifactDigest: options.artifactDigest }),
+      ...(buildDigest === undefined ? {} : { buildDigest }),
+      detail: { capability, reason },
+    });
+    return { status: "denied", reason };
+  };
+
+  return {
+    register(capability, handler) {
+      handlers.set(capability, handler);
+    },
+    async dispatch(request) {
+      const frame = options.broker.resolveFrameToken(request.frameToken);
+      if (frame === undefined) {
+        return deny("Frame token is unknown or has been revoked.", request.capability);
+      }
+
+      options.observations.record({
+        kind: "actionAttempted",
+        ...(options.artifactDigest === undefined ? {} : { artifactDigest: options.artifactDigest }),
+        buildDigest: frame.buildDigest,
+        detail: { capability: request.capability, actionMode: frame.actionMode },
+      });
+
+      if (frame.actionMode === "denied") {
+        return deny("Frame is not permitted to run Actions.", request.capability, frame.buildDigest);
+      }
+      if (!options.broker.isFrameCapabilityGranted(request.frameToken, request.capability)) {
+        return deny(`Capability '${request.capability}' is not currently granted to this frame.`, request.capability, frame.buildDigest);
+      }
+      const verdict = options.policy.validateAction(request.capability, request.payload);
+      if (verdict !== true) {
+        return deny(verdict, request.capability, frame.buildDigest);
+      }
+      if (frame.actionMode === "dry-run") {
+        // A staging frame must reach this line and stop: running the handler to
+        // "see if it works" is indistinguishable from committing the effect.
+        return { status: "dry-run" };
+      }
+
+      const handler = handlers.get(request.capability);
+      if (handler === undefined) {
+        return deny(`No Host handler is registered for '${request.capability}'.`, request.capability, frame.buildDigest);
+      }
+      try {
+        return { status: "completed", result: await handler(request.payload) };
+      } catch (error) {
+        options.observations.record({
+          kind: "runtimeException",
+          ...(options.artifactDigest === undefined ? {} : { artifactDigest: options.artifactDigest }),
+          buildDigest: frame.buildDigest,
+          detail: { capability: request.capability, message: error instanceof Error ? error.message : String(error) },
+        });
+        return { status: "denied", reason: `Action '${request.capability}' failed in the Host.` };
+      }
+    },
+  };
+}

--- a/packages/harness-studio/src/agent-react/host/build-coordinator.ts
+++ b/packages/harness-studio/src/agent-react/host/build-coordinator.ts
@@ -1,0 +1,301 @@
+import {
+  AGENT_REACT_RUNTIME_VERSION,
+  type ArtifactRevision,
+  BuildGenerationSuperseded,
+  type BuildSnapshot,
+  type Diagnostic,
+  type DigestFn,
+  type ObservationInput,
+  type OxcCompilerPort,
+  type ReactSemanticIndex,
+  type SourceMapChainEntry,
+} from "../contracts/index.js";
+import { digestParts } from "./digest.js";
+import { digestArtifactRevision } from "./digest.js";
+import { cloneAndFreezePlainData } from "./data-ownership.js";
+import { isNormalizedRevisionPath } from "./stream-assembler.js";
+import {
+  type AllowedPackageResolver,
+  createAllowedPackageResolver,
+  linkArtifactBundle,
+  type TrustedRuntimePackage,
+} from "../linker/index.js";
+
+export interface BuildCoordinatorOptions {
+  readonly compiler: OxcCompilerPort;
+  readonly runtimePackages: readonly TrustedRuntimePackage[];
+  readonly runtimeVersion?: string;
+  readonly maxModules?: number;
+  readonly maxOutputBytes?: number;
+  readonly digest?: DigestFn;
+  readonly onObservation?: (observation: ObservationInput) => void;
+}
+
+export interface AgentReactBuildCoordinator {
+  build(revision: ArtifactRevision): Promise<BuildSnapshot>;
+  readonly generation: number;
+}
+
+const DEFAULT_MAX_MODULES = 64;
+const DEFAULT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Drives one Build Generation from a Revision to a frozen Build Snapshot.
+ *
+ * A streaming agent commits Revisions faster than a build finishes, so the
+ * coordinator is generation-numbered: a superseded generation rejects instead of
+ * resolving. Returning its result would let an older bundle win a race and get
+ * staged over the newer one, which is exactly the flicker the transactional
+ * commit is supposed to remove.
+ */
+export function createBuildCoordinator(options: BuildCoordinatorOptions): AgentReactBuildCoordinator {
+  const digest = options.digest ?? digestParts;
+  const runtimeVersion = options.runtimeVersion ?? AGENT_REACT_RUNTIME_VERSION;
+  const maxModules = options.maxModules ?? DEFAULT_MAX_MODULES;
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const observe = options.onObservation ?? ((): void => {});
+  let generation = 0;
+
+  return {
+    get generation() {
+      return generation;
+    },
+    async build(revision: ArtifactRevision): Promise<BuildSnapshot> {
+      generation += 1;
+      const mine = generation;
+      const stillCurrent = (): boolean => generation === mine;
+      const ownedRevision = cloneAndFreezePlainData(revision, "Artifact Revision");
+
+      const snapshot = await runBuild({
+        revision: ownedRevision,
+        buildGeneration: mine,
+        compiler: options.compiler,
+        runtimePackages: options.runtimePackages,
+        runtimeVersion,
+        maxModules,
+        maxOutputBytes,
+        digest,
+        observe,
+      });
+      if (!stillCurrent()) throw new BuildGenerationSuperseded(mine);
+      return snapshot;
+    },
+  };
+}
+
+interface RunBuildOptions {
+  readonly revision: ArtifactRevision;
+  readonly buildGeneration: number;
+  readonly compiler: OxcCompilerPort;
+  readonly runtimePackages: readonly TrustedRuntimePackage[];
+  readonly runtimeVersion: string;
+  readonly maxModules: number;
+  readonly maxOutputBytes: number;
+  readonly digest: DigestFn;
+  readonly observe: (observation: ObservationInput) => void;
+}
+
+async function runBuild(options: RunBuildOptions): Promise<BuildSnapshot> {
+  const { revision, compiler, digest, observe } = options;
+  const diagnostics: Diagnostic[] = [];
+  const semanticIndex: ReactSemanticIndex[] = [];
+  const sourceMaps: SourceMapChainEntry[] = [];
+  const compiledModules = new Map<string, string>();
+  let viewDeclaration: BuildSnapshot["viewDeclaration"];
+
+  const failed = (extra: readonly Diagnostic[]): BuildSnapshot =>
+    freezeSnapshot({
+      ...options,
+      status: "failed",
+      bundle: "",
+      diagnostics: [...diagnostics, ...extra],
+      semanticIndex,
+      sourceMaps,
+      viewDeclaration,
+    });
+
+  if (!isNormalizedRevisionPath(revision.descriptor.entry)) {
+    return failed([{
+      level: "error",
+      code: "revision/path-invalid",
+      message: `Revision entry '${revision.descriptor.entry}' is not a normalized POSIX module path.`,
+      module: revision.descriptor.entry,
+    }]);
+  }
+
+  const modulePaths = new Set<string>();
+  for (const module of revision.modules) {
+    if (!isNormalizedRevisionPath(module.path)) {
+      return failed([{
+        level: "error",
+        code: "revision/path-invalid",
+        message: `Revision module '${module.path}' is not a normalized POSIX path.`,
+        module: module.path,
+      }]);
+    }
+    if (modulePaths.has(module.path)) {
+      return failed([{
+        level: "error",
+        code: "revision/duplicate-module",
+        message: `Revision contains module '${module.path}' more than once.`,
+        module: module.path,
+      }]);
+    }
+    modulePaths.add(module.path);
+  }
+
+  const computedRevisionDigest = digestArtifactRevision(revision.descriptor, revision.modules);
+  if (computedRevisionDigest !== revision.digest) {
+    return failed([{
+      level: "error",
+      code: "revision/digest-mismatch",
+      message: "Artifact Revision digest does not match its descriptor and module bytes.",
+    }]);
+  }
+
+  if (revision.modules.length > options.maxModules) {
+    return failed([{
+      level: "error",
+      code: "limit/module-count",
+      message: `Revision has ${revision.modules.length} modules, over the ${options.maxModules}-module limit.`,
+    }]);
+  }
+
+  const resolver: AllowedPackageResolver = createAllowedPackageResolver({
+    modulePaths: revision.modules.map((module) => module.path),
+    runtimePackages: options.runtimePackages,
+  });
+
+  for (const module of revision.modules) {
+    const output = await compiler.compileModule({
+      module,
+      entry: module.path === revision.descriptor.entry,
+      allowedPackages: resolver.allowedPackages,
+    });
+    diagnostics.push(...output.diagnostics);
+    for (const diagnostic of output.diagnostics) {
+      observe({
+        kind: diagnostic.code.startsWith("profile/") ? "profileViolation" : "compileDiagnostic",
+        artifactDigest: revision.digest,
+        detail: { ...diagnostic },
+      });
+    }
+    if (output.semanticIndex !== undefined) semanticIndex.push(output.semanticIndex);
+    if (output.sourceMap !== undefined) sourceMaps.push({ module: module.path, map: output.sourceMap });
+    if (output.viewDeclaration !== undefined) viewDeclaration = output.viewDeclaration;
+    if (output.code !== undefined) compiledModules.set(module.path, output.code);
+  }
+
+  if (diagnostics.some((diagnostic) => diagnostic.level === "error")) return failed([]);
+  if (viewDeclaration === undefined) {
+    return failed([{
+      level: "error",
+      code: "abi/missing-view",
+      message: `Entry module '${revision.descriptor.entry}' produced no Artifact View declaration.`,
+      module: revision.descriptor.entry,
+    }]);
+  }
+  if (viewDeclaration.id !== revision.descriptor.id) {
+    return failed([{
+      level: "error",
+      code: "abi/view-id-mismatch",
+      message: `Artifact View id '${viewDeclaration.id}' does not match descriptor id '${revision.descriptor.id}'.`,
+      module: revision.descriptor.entry,
+    }]);
+  }
+
+  const linked = await linkArtifactBundle({
+    compiledModules,
+    entryModule: revision.descriptor.entry,
+    resolver,
+    maxOutputBytes: options.maxOutputBytes,
+  });
+  if (linked.status === "failed") {
+    for (const diagnostic of linked.diagnostics) {
+      observe({ kind: "compileDiagnostic", artifactDigest: revision.digest, detail: { ...diagnostic } });
+    }
+    return failed(linked.diagnostics);
+  }
+
+  const snapshot = freezeSnapshot({
+    ...options,
+    status: "ready",
+    bundle: linked.bundle,
+    diagnostics: [...diagnostics, ...linked.diagnostics],
+    semanticIndex,
+    sourceMaps,
+    viewDeclaration,
+  });
+  return snapshot;
+}
+
+interface SnapshotParts {
+  readonly revision: ArtifactRevision;
+  readonly buildGeneration: number;
+  readonly compiler: OxcCompilerPort;
+  readonly runtimeVersion: string;
+  readonly runtimePackages: readonly TrustedRuntimePackage[];
+  readonly maxModules: number;
+  readonly maxOutputBytes: number;
+  readonly digest: DigestFn;
+  readonly status: BuildSnapshot["status"];
+  readonly bundle: string;
+  readonly diagnostics: readonly Diagnostic[];
+  readonly semanticIndex: readonly ReactSemanticIndex[];
+  readonly sourceMaps: readonly SourceMapChainEntry[];
+  readonly viewDeclaration: BuildSnapshot["viewDeclaration"];
+}
+
+function freezeSnapshot(parts: SnapshotParts): BuildSnapshot {
+  const sourceMaps = cloneAndFreezePlainData(parts.sourceMaps, "Build Snapshot source maps");
+  const semanticIndex = cloneAndFreezePlainData(parts.semanticIndex, "Build Snapshot semantic index");
+  const diagnostics = cloneAndFreezePlainData(parts.diagnostics, "Build Snapshot diagnostics");
+  const viewDeclaration = parts.viewDeclaration === undefined
+    ? undefined
+    : cloneAndFreezePlainData(parts.viewDeclaration, "Build Snapshot view declaration");
+  const runtimePackages = [...parts.runtimePackages]
+    .map((entry) => [entry.specifier, entry.external] as const)
+    .sort(([leftSpecifier, leftExternal], [rightSpecifier, rightExternal]) => {
+      const left = `${leftSpecifier}\u0000${leftExternal}`;
+      const right = `${rightSpecifier}\u0000${rightExternal}`;
+      return left < right ? -1 : left > right ? 1 : 0;
+    });
+  const buildPolicyDigest = parts.digest([
+    parts.compiler.policyFingerprint,
+    parts.maxModules,
+    parts.maxOutputBytes,
+    runtimePackages,
+  ]);
+  /**
+   * The digest covers the Revision *and* the three versions that decide how it
+   * was translated. Omitting them would let a compiler upgrade silently reuse a
+   * cached snapshot built by the previous rules, so a replay would no longer
+   * prove anything about the code that is running.
+   */
+  const buildDigest = parts.digest([
+    parts.revision.digest,
+    parts.compiler.compilerVersion,
+    parts.compiler.profileVersion,
+    parts.runtimeVersion,
+    buildPolicyDigest,
+    parts.status,
+    parts.bundle,
+    diagnostics,
+  ]);
+  return Object.freeze({
+    buildDigest,
+    artifactDigest: parts.revision.digest,
+    artifactId: parts.revision.descriptor.id,
+    buildGeneration: parts.buildGeneration,
+    compilerVersion: parts.compiler.compilerVersion,
+    profileVersion: parts.compiler.profileVersion,
+    runtimeVersion: parts.runtimeVersion,
+    buildPolicyDigest,
+    status: parts.status,
+    bundle: parts.bundle,
+    sourceMaps,
+    semanticIndex,
+    ...(viewDeclaration === undefined ? {} : { viewDeclaration }),
+    diagnostics,
+  });
+}

--- a/packages/harness-studio/src/agent-react/host/capability.ts
+++ b/packages/harness-studio/src/agent-react/host/capability.ts
@@ -1,0 +1,123 @@
+import type {
+  ActionMode,
+  ArtifactViewDeclaration,
+  CapabilityGrant,
+  CapabilityRefusal,
+  Digest,
+  FrameToken,
+} from "../contracts/index.js";
+
+export interface CapabilityPolicy {
+  /** Capabilities the Host is willing to expose for this Artifact at all. */
+  readonly allowedCapabilities: readonly string[];
+  requiresApproval(capability: string): boolean;
+  /** Re-checked on every dispatch, not only at grant time. */
+  validateAction(capability: string, payload: unknown): true | string;
+}
+
+export interface CapabilityPolicyOptions {
+  readonly allowedCapabilities: readonly string[];
+  readonly requiresApproval?: readonly string[];
+  readonly validate?: (capability: string, payload: unknown) => true | string;
+}
+
+export function createCapabilityPolicy(options: CapabilityPolicyOptions): CapabilityPolicy {
+  const allowed = new Set(options.allowedCapabilities);
+  const needsApproval = new Set(options.requiresApproval ?? []);
+  return {
+    allowedCapabilities: Object.freeze([...allowed].sort()),
+    requiresApproval(capability) {
+      return needsApproval.has(capability);
+    },
+    validateAction(capability, payload) {
+      if (!allowed.has(capability)) return `Capability '${capability}' is not allowed by Host policy.`;
+      return options.validate?.(capability, payload) ?? true;
+    },
+  };
+}
+
+export interface CapabilityBroker {
+  computeGrant(declaration: Pick<ArtifactViewDeclaration, "capabilities">): CapabilityGrant;
+  approve(capability: string): void;
+  revokeApproval(capability: string): void;
+  issueFrameToken(buildDigest: Digest, actionMode: ActionMode, grant: CapabilityGrant): FrameToken;
+  resolveFrameToken(token: string): FrameToken | undefined;
+  isFrameCapabilityGranted(token: string, capability: string): boolean;
+  revokeFrameToken(token: string): void;
+}
+
+export interface CapabilityBrokerOptions {
+  readonly policy: CapabilityPolicy;
+  readonly approvals?: readonly string[];
+  readonly newToken?: () => string;
+}
+
+/**
+ * Turns capability *requests* into a grant.
+ *
+ * The intersection is the whole point: declared capabilities are what the code
+ * asked for, and code is exactly the thing that cannot be trusted to authorize
+ * itself. The refusal reasons are returned rather than dropped so a Surface can
+ * explain a missing control instead of rendering a button that silently fails.
+ */
+export function createCapabilityBroker(options: CapabilityBrokerOptions): CapabilityBroker {
+  const approvals = new Set(options.approvals ?? []);
+  const tokens = new Map<string, FrameToken>();
+  const newToken = options.newToken ?? secureFrameToken;
+
+  return {
+    computeGrant(declaration) {
+      const granted: string[] = [];
+      const refused: { capability: string; reason: CapabilityRefusal }[] = [];
+      for (const capability of [...new Set(declaration.capabilities)].sort()) {
+        if (!options.policy.allowedCapabilities.includes(capability)) {
+          refused.push({ capability, reason: "not-in-policy" });
+          continue;
+        }
+        if (options.policy.requiresApproval(capability) && !approvals.has(capability)) {
+          refused.push({ capability, reason: "awaiting-approval" });
+          continue;
+        }
+        granted.push(capability);
+      }
+      return Object.freeze({ granted: Object.freeze(granted), refused: Object.freeze(refused) });
+    },
+    approve(capability) {
+      approvals.add(capability);
+    },
+    revokeApproval(capability) {
+      approvals.delete(capability);
+    },
+    issueFrameToken(buildDigest, actionMode, grant) {
+      const tokenValue = newToken();
+      if (tokens.has(tokenValue)) throw new Error("Frame token generator produced a duplicate token.");
+      const token: FrameToken = Object.freeze({
+        token: tokenValue,
+        buildDigest,
+        actionMode,
+        granted: Object.freeze([...grant.granted]),
+      });
+      tokens.set(token.token, token);
+      return token;
+    },
+    resolveFrameToken(token) {
+      return tokens.get(token);
+    },
+    isFrameCapabilityGranted(token, capability) {
+      const frame = tokens.get(token);
+      if (frame === undefined || !frame.granted.includes(capability)) return false;
+      if (!options.policy.allowedCapabilities.includes(capability)) return false;
+      return !options.policy.requiresApproval(capability) || approvals.has(capability);
+    },
+    revokeFrameToken(token) {
+      tokens.delete(token);
+    },
+  };
+}
+
+function secureFrameToken(): string {
+  if (typeof globalThis.crypto?.randomUUID !== "function") {
+    throw new Error("A cryptographically secure randomUUID implementation is required for frame tokens.");
+  }
+  return globalThis.crypto.randomUUID();
+}

--- a/packages/harness-studio/src/agent-react/host/compiler-worker-entry.ts
+++ b/packages/harness-studio/src/agent-react/host/compiler-worker-entry.ts
@@ -1,0 +1,23 @@
+import { parentPort } from "node:worker_threads";
+import { createOxcCompiler } from "../kernel/index.js";
+import {
+  isOxcWorkerRequest,
+  OXC_WORKER_RESPONSE,
+  type OxcWorkerResponse,
+} from "./compiler-worker-protocol.js";
+
+if (parentPort === null) throw new Error("The AgentReact compiler entry must run inside a Worker.");
+const port = parentPort;
+
+port.on("message", (value: unknown) => {
+  if (!isOxcWorkerRequest(value)) return;
+  const output = createOxcCompiler(value.limits).compileModule(value.input);
+  void Promise.resolve(output).then((compiled) => {
+    const response: OxcWorkerResponse = {
+      type: OXC_WORKER_RESPONSE,
+      requestId: value.requestId,
+      output: compiled,
+    };
+    port.postMessage(response);
+  });
+});

--- a/packages/harness-studio/src/agent-react/host/compiler-worker-protocol.ts
+++ b/packages/harness-studio/src/agent-react/host/compiler-worker-protocol.ts
@@ -1,0 +1,39 @@
+import type { CompileModuleInput, CompileModuleOutput } from "../contracts/index.js";
+import type { OxcCompileLimits } from "../kernel/index.js";
+
+export const OXC_WORKER_REQUEST = "agent-react.oxc.compile" as const;
+export const OXC_WORKER_RESPONSE = "agent-react.oxc.result" as const;
+
+export interface OxcWorkerRequest {
+  readonly type: typeof OXC_WORKER_REQUEST;
+  readonly requestId: number;
+  readonly input: CompileModuleInput;
+  readonly limits: Partial<OxcCompileLimits>;
+}
+
+export interface OxcWorkerResponse {
+  readonly type: typeof OXC_WORKER_RESPONSE;
+  readonly requestId: number;
+  readonly output: CompileModuleOutput;
+}
+
+export function isOxcWorkerRequest(value: unknown): value is OxcWorkerRequest {
+  if (typeof value !== "object" || value === null) return false;
+  const request = value as Record<string, unknown>;
+  return request.type === OXC_WORKER_REQUEST
+    && Number.isSafeInteger(request.requestId)
+    && typeof request.input === "object"
+    && request.input !== null
+    && typeof (request.input as Record<string, unknown>).module === "object"
+    && typeof request.limits === "object"
+    && request.limits !== null;
+}
+
+export function isOxcWorkerResponse(value: unknown): value is OxcWorkerResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const response = value as Record<string, unknown>;
+  return response.type === OXC_WORKER_RESPONSE
+    && Number.isSafeInteger(response.requestId)
+    && typeof response.output === "object"
+    && response.output !== null;
+}

--- a/packages/harness-studio/src/agent-react/host/data-ownership.ts
+++ b/packages/harness-studio/src/agent-react/host/data-ownership.ts
@@ -1,0 +1,40 @@
+/**
+ * Copies protocol data into Host ownership and freezes the complete plain-data
+ * graph. Functions, symbols, exotic objects, and cycles cannot cross a frame
+ * boundary with stable immutable semantics, so they fail before entering Host
+ * state, observations, or identity-bearing snapshots.
+ */
+export function cloneAndFreezePlainData<T>(value: T, label: string): T {
+  let clone: T;
+  try {
+    clone = structuredClone(value);
+  } catch (error) {
+    throw new TypeError(`${label} must be structured-cloneable: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  assertPlainData(clone, label, new WeakSet());
+  return freezeDeep(clone, new WeakSet());
+}
+
+function assertPlainData(value: unknown, label: string, ancestors: WeakSet<object>): void {
+  if (typeof value === "function" || typeof value === "symbol") {
+    throw new TypeError(`${label} may contain only primitives, arrays, and plain objects.`);
+  }
+  if (typeof value !== "object" || value === null) return;
+  if (ancestors.has(value)) throw new TypeError(`${label} may not contain cycles.`);
+  ancestors.add(value);
+  const prototype = Object.getPrototypeOf(value);
+  if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${label} may contain only primitives, arrays, and plain objects.`);
+  }
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    assertPlainData(nested, label, ancestors);
+  }
+  ancestors.delete(value);
+}
+
+function freezeDeep<T>(value: T, seen: WeakSet<object>): T {
+  if (typeof value !== "object" || value === null || seen.has(value)) return value;
+  seen.add(value);
+  for (const nested of Object.values(value as Record<string, unknown>)) freezeDeep(nested, seen);
+  return Object.freeze(value);
+}

--- a/packages/harness-studio/src/agent-react/host/digest.ts
+++ b/packages/harness-studio/src/agent-react/host/digest.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import type { ArtifactDescriptor, Digest, ModuleSource } from "../contracts/index.js";
+
+/**
+ * Content addressing for the POC.
+ *
+ * `node:crypto` keeps this synchronous, which the digest call sites rely on. A
+ * browser Compiler Worker would swap in `crypto.subtle.digest`; that is why every
+ * consumer takes a `DigestFn` rather than importing this module directly.
+ */
+export function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+export function digestParts(parts: readonly unknown[]): Digest {
+  return `sha256:${sha256Hex(JSON.stringify(parts))}`;
+}
+
+/**
+ * A Revision digest must not depend on the order in which the agent happened to
+ * stream its modules, otherwise the same source text produces a different
+ * identity per run and nothing downstream can be cached or replayed.
+ */
+export function digestArtifactRevision(
+  descriptor: ArtifactDescriptor,
+  modules: readonly ModuleSource[],
+): Digest {
+  const ordered = [...modules]
+    .map((module) => [module.path, sha256Hex(module.text)] as const)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return digestParts([descriptor.id, descriptor.entry, ordered]);
+}

--- a/packages/harness-studio/src/agent-react/host/frames/frame-controller.ts
+++ b/packages/harness-studio/src/agent-react/host/frames/frame-controller.ts
@@ -1,0 +1,222 @@
+import type {
+  BuildSnapshot,
+  CapabilityGrant,
+  FrameFactory,
+  FrameHandle,
+  FrameVerification,
+} from "../../contracts/index.js";
+import type { CapabilityBroker } from "../capability.js";
+import type { ObservationBridge } from "../observation-bridge.js";
+import type { ArtifactStateStore } from "../state-store.js";
+
+export type StageOutcome =
+  | { readonly status: "staged"; readonly frame: FrameHandle; readonly grant: CapabilityGrant }
+  | { readonly status: "rejected"; readonly reason: string; readonly verification?: FrameVerification };
+
+export interface SandboxFrameController {
+  readonly current: FrameHandle | undefined;
+  readonly staging: FrameHandle | undefined;
+  stage(snapshot: BuildSnapshot): Promise<StageOutcome>;
+  /** Atomically promotes the verified staging frame; disposes the old Current. */
+  activate(): FrameHandle;
+  discard(): void;
+  /** Re-stages and commits the snapshot Current held before the last activation. */
+  rollback(): Promise<StageOutcome>;
+}
+
+export interface SandboxFrameControllerOptions {
+  readonly frames: FrameFactory;
+  readonly broker: CapabilityBroker;
+  readonly observations: ObservationBridge;
+  readonly state: ArtifactStateStore;
+  readonly verificationTimeoutMs?: number;
+  /** Explicit test/experiment opt-in; in-process execution is never production isolation. */
+  readonly allowInProcessVerification?: boolean;
+  /**
+   * When set, a dry-run Action attempted during staging blocks the commit. Some
+   * Hosts want the attempt as information only; others treat "this build tries to
+   * act before it is trusted" as disqualifying.
+   */
+  readonly blockOnDeniedAction?: boolean;
+}
+
+const DEFAULT_VERIFICATION_TIMEOUT_MS = 5_000;
+
+/**
+ * Two-frame transactional commit.
+ *
+ * In production a new build is verified in its own opaque-origin frame while
+ * the working view keeps running, and only a frame that reported
+ * `renderCompleted` may replace it. In-process factories require explicit
+ * verification-only admission and carry no isolation claim.
+ * Mounting the new build directly into the live frame would make every failed
+ * revision visible as a blank or broken view — the agent's mistakes would become
+ * the user's outage.
+ */
+export function createSandboxFrameController(options: SandboxFrameControllerOptions): SandboxFrameController {
+  if (options.frames.isolation !== "opaque-origin" && options.allowInProcessVerification !== true) {
+    throw new Error(
+      "An in-process FrameFactory is verification-only; production controllers require opaque-origin isolation.",
+    );
+  }
+  const timeoutMs = options.verificationTimeoutMs ?? DEFAULT_VERIFICATION_TIMEOUT_MS;
+  let current: FrameHandle | undefined;
+  let staging: FrameHandle | undefined;
+  let previousSnapshot: BuildSnapshot | undefined;
+  let stageGeneration = 0;
+
+  const disposeFrame = (frame: FrameHandle): void => {
+    options.broker.revokeFrameToken(frame.frameToken.token);
+    frame.dispose();
+    if (staging === frame) staging = undefined;
+  };
+
+  const disposeStaging = (): void => {
+    if (staging !== undefined) disposeFrame(staging);
+  };
+
+  const controller: SandboxFrameController = {
+    get current() {
+      return current;
+    },
+    get staging() {
+      return staging;
+    },
+
+    async stage(snapshot) {
+      if (snapshot.status !== "ready") {
+        return { status: "rejected", reason: "Build Snapshot is not runnable." };
+      }
+      if (snapshot.viewDeclaration === undefined) {
+        return { status: "rejected", reason: "Build Snapshot carries no Artifact View declaration." };
+      }
+      stageGeneration += 1;
+      const mine = stageGeneration;
+      disposeStaging();
+
+      const grant = options.broker.computeGrant(snapshot.viewDeclaration);
+      const token = options.broker.issueFrameToken(snapshot.buildDigest, "dry-run", grant);
+      const frame = options.frames.create(snapshot, {
+        actionMode: "dry-run",
+        frameToken: token,
+        // A staging frame reads a frozen copy so verification cannot mutate what
+        // the still-live Current frame is displaying.
+        state: options.state.snapshot(),
+      });
+      staging = frame;
+      const isActiveStage = (): boolean => stageGeneration === mine && staging === frame && !frame.disposed;
+
+      let attemptedAction = false;
+      const unsubscribeObservations = options.observations.subscribe((event) => {
+        if (event.kind === "actionAttempted" && event.buildDigest === snapshot.buildDigest) attemptedAction = true;
+      });
+      let verification: FrameVerification;
+      try {
+        await frame.mount();
+        verification = await frame.waitForRenderCompleted(timeoutMs);
+      } catch (error) {
+        verification = { status: "renderFailed", message: error instanceof Error ? error.message : String(error) };
+      } finally {
+        unsubscribeObservations();
+      }
+
+      if (!isActiveStage()) {
+        disposeFrame(frame);
+        return { status: "rejected", reason: "Staging build was superseded by a newer generation." };
+      }
+
+      if (verification.status !== "renderCompleted") {
+        const reason = verification.status === "renderFailed"
+          ? verification.message
+          : `Staging render exceeded ${timeoutMs}ms.`;
+        options.observations.record({
+          kind: "renderFailed",
+          artifactDigest: snapshot.artifactDigest,
+          buildDigest: snapshot.buildDigest,
+          detail: { reason, phase: "staging" },
+        });
+        disposeFrame(frame);
+        return { status: "rejected", reason, verification };
+      }
+
+      if (options.blockOnDeniedAction === true) {
+        if (attemptedAction) {
+          options.observations.record({
+            kind: "actionDenied",
+            artifactDigest: snapshot.artifactDigest,
+            buildDigest: snapshot.buildDigest,
+            detail: { reason: "Build attempted an Action during staging verification.", phase: "staging" },
+          });
+          disposeFrame(frame);
+          return { status: "rejected", reason: "Build attempted an Action during staging verification.", verification };
+        }
+      }
+
+      options.observations.record({
+        kind: "renderCompleted",
+        artifactDigest: snapshot.artifactDigest,
+        buildDigest: snapshot.buildDigest,
+        detail: { phase: "staging", refusedCapabilities: grant.refused.map((entry) => entry.capability) },
+      });
+      return { status: "staged", frame, grant };
+    },
+
+    activate() {
+      const promoted = staging;
+      if (promoted === undefined) throw new Error("No verified staging frame is available to activate.");
+      const outgoing = current;
+      const stagingToken = promoted.frameToken.token;
+
+      const liveToken = options.broker.issueFrameToken(
+        promoted.snapshot.buildDigest,
+        "live",
+        { granted: promoted.frameToken.granted, refused: [] },
+      );
+      try {
+        promoted.activate(liveToken);
+      } catch (error) {
+        options.broker.revokeFrameToken(liveToken.token);
+        throw error;
+      }
+      options.broker.revokeFrameToken(stagingToken);
+
+      current = promoted;
+      staging = undefined;
+      if (outgoing !== undefined) {
+        previousSnapshot = outgoing.snapshot;
+        disposeFrame(outgoing);
+      }
+      options.observations.record({
+        kind: "renderCompleted",
+        artifactDigest: promoted.snapshot.artifactDigest,
+        buildDigest: promoted.snapshot.buildDigest,
+        detail: { phase: "committed" },
+      });
+      return promoted;
+    },
+
+    discard() {
+      stageGeneration += 1;
+      disposeStaging();
+    },
+
+    async rollback() {
+      if (previousSnapshot === undefined) {
+        return { status: "rejected", reason: "No previous Build Snapshot is retained to roll back to." };
+      }
+      const target = previousSnapshot;
+      const staged = await controller.stage(target);
+      if (staged.status !== "staged") return staged;
+      controller.activate();
+      options.observations.record({
+        kind: "renderCompleted",
+        artifactDigest: target.artifactDigest,
+        buildDigest: target.buildDigest,
+        detail: { phase: "rolled-back" },
+      });
+      return staged;
+    },
+  };
+
+  return controller;
+}

--- a/packages/harness-studio/src/agent-react/host/frames/frame-protocol.ts
+++ b/packages/harness-studio/src/agent-react/host/frames/frame-protocol.ts
@@ -1,0 +1,101 @@
+import type { ActionMode, BuildSnapshot } from "../../contracts/index.js";
+import { cloneAndFreezePlainData } from "../data-ownership.js";
+
+/**
+ * The frame handshake contract.
+ *
+ * The transport is intentionally not decided here. A real Studio frame is an
+ * `<iframe sandbox="allow-scripts">` without `allow-same-origin` — the browser
+ * then treats it as an opaque origin that cannot reach Studio's cookies, storage,
+ * or DOM — and the Host transfers a private `MessagePort` after the first
+ * `postMessage`. The in-process factory used by this POC speaks the same messages
+ * so the transport can be swapped without touching the Host or the controller.
+ */
+
+export const FRAME_PROTOCOL_VERSION = "agent-react/1";
+export const FRAME_INIT_MESSAGE = "artifact.runtime.init";
+export const FRAME_RENDER_COMPLETED = "renderCompleted";
+export const FRAME_RENDER_FAILED = "renderFailed";
+
+export interface FrameIdentity {
+  readonly buildDigest: string;
+  readonly artifactDigest: string;
+  readonly frameToken: string;
+  readonly actionMode: ActionMode;
+}
+
+export interface FrameInitMessage extends FrameIdentity {
+  readonly type: typeof FRAME_INIT_MESSAGE;
+  readonly protocol: typeof FRAME_PROTOCOL_VERSION;
+  readonly actionMode: ActionMode;
+  readonly state: Readonly<Record<string, unknown>>;
+}
+
+export function createFrameInitMessage(input: {
+  readonly snapshot: BuildSnapshot;
+  readonly actionMode: ActionMode;
+  readonly frameToken: string;
+  readonly state: Readonly<Record<string, unknown>>;
+}): FrameInitMessage {
+  return cloneAndFreezePlainData({
+    type: FRAME_INIT_MESSAGE,
+    protocol: FRAME_PROTOCOL_VERSION,
+    buildDigest: input.snapshot.buildDigest,
+    artifactDigest: input.snapshot.artifactDigest,
+    frameToken: input.frameToken,
+    actionMode: input.actionMode,
+    state: input.state,
+  }, "Frame init message");
+}
+
+/**
+ * A frame must reject an init it was not built for.
+ *
+ * An opaque origin cannot serve as an identity, so verifying the sender proves
+ * only "something that can reach this frame". Matching the protocol version, both
+ * digests, and the frame token is what makes a stale or crossed handshake — the
+ * common case when a build is superseded mid-stage — fail closed instead of
+ * mounting the wrong bundle.
+ */
+export function isMatchingInit(message: unknown, expected: FrameIdentity): boolean {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as Partial<FrameInitMessage>;
+  return candidate.type === FRAME_INIT_MESSAGE
+    && candidate.protocol === FRAME_PROTOCOL_VERSION
+    && candidate.buildDigest === expected.buildDigest
+    && candidate.artifactDigest === expected.artifactDigest
+    && candidate.frameToken === expected.frameToken
+    && candidate.actionMode === expected.actionMode
+    && typeof candidate.state === "object"
+    && candidate.state !== null
+    && !Array.isArray(candidate.state);
+}
+
+export type FrameReport =
+  | { readonly type: typeof FRAME_RENDER_COMPLETED; readonly protocol: string; readonly buildDigest: string }
+  | { readonly type: typeof FRAME_RENDER_FAILED; readonly protocol: string; readonly buildDigest: string; readonly message: string };
+
+export function renderCompletedReport(buildDigest: string): FrameReport {
+  return { type: FRAME_RENDER_COMPLETED, protocol: FRAME_PROTOCOL_VERSION, buildDigest };
+}
+
+export function renderFailedReport(buildDigest: string, message: string): FrameReport {
+  return {
+    type: FRAME_RENDER_FAILED,
+    protocol: FRAME_PROTOCOL_VERSION,
+    buildDigest,
+    message: message.slice(0, 600),
+  };
+}
+
+/** A report from the wrong build is not evidence about this one. */
+export function isReportFor(report: unknown, buildDigest: string): report is FrameReport {
+  if (typeof report !== "object" || report === null) return false;
+  const candidate = report as Partial<FrameReport>;
+  return candidate.protocol === FRAME_PROTOCOL_VERSION
+    && candidate.buildDigest === buildDigest
+    && (candidate.type === FRAME_RENDER_COMPLETED
+      || (candidate.type === FRAME_RENDER_FAILED
+        && typeof candidate.message === "string"
+        && candidate.message.length <= 600));
+}

--- a/packages/harness-studio/src/agent-react/host/frames/local-frame-factory.ts
+++ b/packages/harness-studio/src/agent-react/host/frames/local-frame-factory.ts
@@ -1,0 +1,249 @@
+import { createElement, type FunctionComponent, type ReactElement } from "react";
+import type {
+  BuildSnapshot,
+  FrameFactory,
+  FrameHandle,
+  FrameMountOptions,
+  FrameToken,
+  FrameVerification,
+} from "../../contracts/index.js";
+import type { ActionGateway } from "../action-gateway.js";
+import type { ObservationBridge } from "../observation-bridge.js";
+import type { ArtifactStateStore } from "../state-store.js";
+import {
+  type ArtifactRuntimeBridge,
+  createNodeAddressRegistry,
+  type NodeAddressRegistry,
+} from "../../runtime/index.js";
+import {
+  createFrameInitMessage,
+  type FrameReport,
+  isMatchingInit,
+  isReportFor,
+  renderCompletedReport,
+  renderFailedReport,
+} from "./frame-protocol.js";
+
+/**
+ * An in-process frame that really executes a Build Snapshot.
+ *
+ * This is a verification-only transport. It speaks the same init/report message
+ * shapes and proves that a linked bundle can load, render synchronously, and
+ * return resolvable addresses. It does not provide a separate realm, browser
+ * mount/effect semantics, CSP, or origin isolation, and production controllers
+ * reject it unless verification-only execution is explicitly enabled.
+ */
+
+/** What the linked bundle exposes; see `link/esbuild-linker.ts`. */
+export interface ArtifactBundleModule {
+  readonly view: { readonly id: string; readonly component: FunctionComponent };
+  activateArtifactRuntime(bridge: ArtifactRuntimeBridge): { readonly component: FunctionComponent };
+  deactivateArtifactRuntime(): void;
+}
+
+export type BundleLoader = (snapshot: BuildSnapshot, signal?: AbortSignal) => Promise<ArtifactBundleModule>;
+export type MarkupRenderer = (element: ReactElement) => string;
+
+export interface LocalFrameFactoryOptions {
+  readonly loadBundle: BundleLoader;
+  readonly state: ArtifactStateStore;
+  readonly gateway: ActionGateway;
+  readonly observations: ObservationBridge;
+  readonly renderToMarkup: MarkupRenderer;
+}
+
+export interface LocalFrameHandle extends FrameHandle {
+  /** Markup produced by the last verified render, for address resolution. */
+  markup(): string | undefined;
+  readonly registry: NodeAddressRegistry;
+}
+
+export interface LocalFrameFactory extends FrameFactory {
+  create(snapshot: BuildSnapshot, options: FrameMountOptions): LocalFrameHandle;
+}
+
+export function createLocalFrameFactory(options: LocalFrameFactoryOptions): LocalFrameFactory {
+  return {
+    isolation: "in-process",
+    create(snapshot, mountOptions) {
+      return new LocalFrame(snapshot, mountOptions, options);
+    },
+  };
+}
+
+class LocalFrame implements LocalFrameHandle {
+  readonly registry: NodeAddressRegistry;
+  #token: FrameToken;
+  #bundle: ArtifactBundleModule | undefined;
+  #markup: string | undefined;
+  #render: Promise<FrameReport> | undefined;
+  #disposed = false;
+  #abort = new AbortController();
+
+  constructor(
+    readonly snapshot: BuildSnapshot,
+    private readonly mountOptions: FrameMountOptions,
+    private readonly factory: LocalFrameFactoryOptions,
+  ) {
+    this.#token = mountOptions.frameToken;
+    this.registry = createNodeAddressRegistry(snapshot.artifactDigest);
+  }
+
+  get actionMode(): FrameToken["actionMode"] {
+    return this.#token.actionMode;
+  }
+
+  get frameToken(): FrameToken {
+    return this.#token;
+  }
+
+  get disposed(): boolean {
+    return this.#disposed;
+  }
+
+  markup(): string | undefined {
+    return this.#markup;
+  }
+
+  async mount(): Promise<void> {
+    if (this.#disposed) throw new Error("Cannot mount a disposed frame.");
+    const init = createFrameInitMessage({
+      snapshot: this.snapshot,
+      actionMode: this.mountOptions.actionMode,
+      frameToken: this.#token.token,
+      state: this.mountOptions.state,
+    });
+    if (!isMatchingInit(init, {
+      buildDigest: this.snapshot.buildDigest,
+      artifactDigest: this.snapshot.artifactDigest,
+      frameToken: this.#token.token,
+      actionMode: this.#token.actionMode,
+    })) {
+      throw new Error("Frame init message does not match this build.");
+    }
+    this.#render = this.#runRender(init.state);
+  }
+
+  async waitForRenderCompleted(timeoutMs: number): Promise<FrameVerification> {
+    if (this.#render === undefined) return { status: "renderFailed", message: "Frame was never mounted." };
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const report = await Promise.race([
+      this.#render,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]).finally(() => {
+      if (timer !== undefined) clearTimeout(timer);
+    });
+    if (report === undefined) {
+      this.#abort.abort();
+      return { status: "timedOut" };
+    }
+    // A report that names another build is not evidence about this one, so it is
+    // treated as a failure rather than quietly accepted.
+    if (!isReportFor(report, this.snapshot.buildDigest)) {
+      return { status: "renderFailed", message: "Frame reported a result for another build." };
+    }
+    return report.type === "renderCompleted"
+      ? { status: "renderCompleted" }
+      : { status: "renderFailed", message: report.message };
+  }
+
+  activate(token: FrameToken): void {
+    if (this.#disposed) throw new Error("Cannot activate a disposed frame.");
+    if (token.buildDigest !== this.snapshot.buildDigest) {
+      throw new Error("Cannot activate a frame with a token issued for a different build.");
+    }
+    if (token.actionMode !== "live") throw new Error("Frame activation requires a live token.");
+    this.#token = token;
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#abort.abort();
+    this.#bundle?.deactivateArtifactRuntime();
+    this.registry.clear();
+  }
+
+  async #runRender(stagedState: Readonly<Record<string, unknown>>): Promise<FrameReport> {
+    try {
+      const bundle = await this.factory.loadBundle(this.snapshot, this.#abort.signal);
+      if (this.#disposed || this.#abort.signal.aborted) {
+        return renderFailedReport(this.snapshot.buildDigest, "Frame was disposed before its bundle loaded.");
+      }
+      this.#bundle = bundle;
+      const view = bundle.activateArtifactRuntime(this.#createBridge(stagedState));
+      if (this.#disposed || this.#abort.signal.aborted) {
+        bundle.deactivateArtifactRuntime();
+        return renderFailedReport(this.snapshot.buildDigest, "Frame was disposed before render started.");
+      }
+      this.#markup = this.factory.renderToMarkup(createElement(view.component));
+      // Two ticks stand in for the browser's double `requestAnimationFrame`: a
+      // render that throws on its first effect must be observed before the frame
+      // may claim success.
+      await tick();
+      if (this.#disposed || this.#abort.signal.aborted) {
+        return renderFailedReport(this.snapshot.buildDigest, "Frame was disposed during render verification.");
+      }
+      await tick();
+      if (this.#disposed || this.#abort.signal.aborted) {
+        return renderFailedReport(this.snapshot.buildDigest, "Frame was disposed during render verification.");
+      }
+      return renderCompletedReport(this.snapshot.buildDigest);
+    } catch (error) {
+      if (this.#disposed || this.#abort.signal.aborted) {
+        return renderFailedReport(this.snapshot.buildDigest, "Frame was disposed during render verification.");
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      this.factory.observations.record({
+        kind: "runtimeException",
+        artifactDigest: this.snapshot.artifactDigest,
+        buildDigest: this.snapshot.buildDigest,
+        detail: { message },
+      });
+      return renderFailedReport(this.snapshot.buildDigest, message);
+    }
+  }
+
+  #createBridge(stagedState: Readonly<Record<string, unknown>>): ArtifactRuntimeBridge {
+    const frame = this;
+    return {
+      artifactDigest: this.snapshot.artifactDigest,
+      buildDigest: this.snapshot.buildDigest,
+      get actionMode() {
+        return frame.actionMode;
+      },
+      registry: this.registry,
+      getState(path) {
+        // A staging frame reads the frozen snapshot it was handed; only a promoted
+        // frame follows live Host state.
+        return frame.actionMode === "live" ? frame.factory.state.get(path) : stagedState[path];
+      },
+      setState(path, value) {
+        if (frame.actionMode !== "live") {
+          frame.factory.observations.record({
+            kind: "stateValidationFailed",
+            artifactDigest: frame.snapshot.artifactDigest,
+            buildDigest: frame.snapshot.buildDigest,
+            detail: { path, reason: "A staging frame cannot write Artifact state." },
+          });
+          return;
+        }
+        frame.factory.state.set(path, value);
+      },
+      subscribe(path, listener) {
+        return frame.actionMode === "live" ? frame.factory.state.subscribe(path, listener) : () => {};
+      },
+      dispatchAction(capability, payload) {
+        return frame.factory.gateway.dispatch({ frameToken: frame.#token.token, capability, payload });
+      },
+    };
+  }
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/packages/harness-studio/src/agent-react/host/index.ts
+++ b/packages/harness-studio/src/agent-react/host/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Layer 4 — Artifact Host.
+ *
+ * Owns everything the Artifact code is not trusted to own: the Revision, the
+ * persistent state and its schemas, the capability grant, action execution, frame
+ * staging and atomic commit, and the observation record.
+ *
+ * This is the only layer that orchestrates the others, so it is the only one
+ * permitted to import the kernel, the linker, and the runtime.
+ */
+
+export { digestArtifactRevision, digestParts, sha256Hex } from "./digest.js";
+export { AgentStreamAssembler, isNormalizedRevisionPath, type ModulePatch } from "./stream-assembler.js";
+export {
+  createBuildCoordinator,
+  type AgentReactBuildCoordinator,
+  type BuildCoordinatorOptions,
+} from "./build-coordinator.js";
+export {
+  createWorkerOxcCompiler,
+  DEFAULT_OXC_WORKER_TIMEOUT_MS,
+  type WorkerOxcCompiler,
+  type WorkerOxcCompilerOptions,
+} from "./worker-oxc-compiler.js";
+export {
+  loadAgentReactProject,
+  type AgentReactSourceStamp,
+  type LoadedAgentReactProject,
+  type LoadAgentReactProjectOptions,
+} from "./project-loader.js";
+export {
+  createArtifactStateStore,
+  type ArtifactStateStore,
+  type ArtifactStateStoreOptions,
+  type StateSchema,
+  type StateValidator,
+} from "./state-store.js";
+export {
+  createCapabilityBroker,
+  createCapabilityPolicy,
+  type CapabilityBroker,
+  type CapabilityPolicy,
+  type CapabilityPolicyOptions,
+} from "./capability.js";
+export { createActionGateway, type ActionGateway, type ActionHandler } from "./action-gateway.js";
+export {
+  createObservationBridge,
+  HARNESS_ARTIFACT_OBSERVATION_EVENT,
+  type ArtifactObservationPayload,
+  type ObservationBridge,
+} from "./observation-bridge.js";
+export {
+  createSandboxFrameController,
+  type SandboxFrameController,
+  type SandboxFrameControllerOptions,
+  type StageOutcome,
+} from "./frames/frame-controller.js";
+export {
+  createFrameInitMessage,
+  FRAME_INIT_MESSAGE,
+  FRAME_PROTOCOL_VERSION,
+  isMatchingInit,
+  isReportFor,
+  renderCompletedReport,
+  renderFailedReport,
+  type FrameInitMessage,
+  type FrameReport,
+} from "./frames/frame-protocol.js";
+export {
+  createLocalFrameFactory,
+  type ArtifactBundleModule,
+  type BundleLoader,
+  type LocalFrameFactory,
+  type LocalFrameHandle,
+} from "./frames/local-frame-factory.js";

--- a/packages/harness-studio/src/agent-react/host/observation-bridge.ts
+++ b/packages/harness-studio/src/agent-react/host/observation-bridge.ts
@@ -1,0 +1,92 @@
+import type { AguiCustomEvent } from "@qoder-ai/harness-ui/protocol";
+import type { Digest, ObservationEvent, ObservationInput } from "../contracts/index.js";
+import { cloneAndFreezePlainData } from "./data-ownership.js";
+
+/**
+ * Namespaced observation event.
+ *
+ * The source design routed these through `HARNESS_PROTOCOL_EVENT`, but that
+ * constant's payload is ACP protocol evidence (`protocol: "acp"`), and an artifact
+ * render is not ACP traffic. Reusing it would let a consumer read a render failure
+ * as a protocol receipt, so the AG-UI `CUSTOM` envelope is kept and only the name
+ * is new.
+ */
+export const HARNESS_ARTIFACT_OBSERVATION_EVENT = "harness.artifact-observation";
+
+export interface ArtifactObservationPayload {
+  readonly kind: ObservationEvent["kind"];
+  readonly sequence: number;
+  readonly artifactDigest?: Digest;
+  readonly buildDigest?: Digest;
+  readonly detail?: Record<string, unknown>;
+}
+
+export interface ObservationBridge {
+  record(observation: ObservationInput): ObservationEvent;
+  encodeHarnessEvent(observation: ObservationEvent): AguiCustomEvent;
+  /** Recorded observations in order, oldest first, bounded by `maxRetained`. */
+  recorded(): readonly ObservationEvent[];
+  /** Every recorded observation encoded for an AG-UI stream. */
+  drainToAgent(): readonly AguiCustomEvent[];
+  /** Observes live events even when the bounded retained buffer evicts them. */
+  subscribe(listener: (observation: ObservationEvent) => void): () => void;
+  clear(): void;
+}
+
+export interface ObservationBridgeOptions {
+  readonly maxRetained?: number;
+  readonly onRecord?: (observation: ObservationEvent) => void;
+}
+
+const DEFAULT_MAX_RETAINED = 512;
+
+export function createObservationBridge(options: ObservationBridgeOptions = {}): ObservationBridge {
+  const maxRetained = options.maxRetained ?? DEFAULT_MAX_RETAINED;
+  if (!Number.isSafeInteger(maxRetained) || maxRetained < 0) {
+    throw new TypeError("Observation maxRetained must be a non-negative safe integer.");
+  }
+  const events: ObservationEvent[] = [];
+  const listeners = new Set<(observation: ObservationEvent) => void>();
+  let sequence = 0;
+
+  const bridge: ObservationBridge = {
+    record(observation) {
+      sequence += 1;
+      const event = cloneAndFreezePlainData<ObservationEvent>(
+        { ...observation, sequence },
+        "Artifact observation",
+      );
+      events.push(event);
+      // Sequence numbers keep increasing after eviction: an agent that only sees
+      // the tail must still be able to tell that something was dropped.
+      while (events.length > maxRetained) events.shift();
+      options.onRecord?.(event);
+      for (const listener of listeners) listener(event);
+      return event;
+    },
+    encodeHarnessEvent(observation) {
+      const payload: ArtifactObservationPayload = {
+        kind: observation.kind,
+        sequence: observation.sequence,
+        ...(observation.artifactDigest === undefined ? {} : { artifactDigest: observation.artifactDigest }),
+        ...(observation.buildDigest === undefined ? {} : { buildDigest: observation.buildDigest }),
+        ...(observation.detail === undefined ? {} : { detail: observation.detail }),
+      };
+      return { type: "CUSTOM", name: HARNESS_ARTIFACT_OBSERVATION_EVENT, value: payload };
+    },
+    recorded() {
+      return [...events];
+    },
+    drainToAgent() {
+      return events.map((event) => bridge.encodeHarnessEvent(event));
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    clear() {
+      events.length = 0;
+    },
+  };
+  return bridge;
+}

--- a/packages/harness-studio/src/agent-react/host/project-loader.ts
+++ b/packages/harness-studio/src/agent-react/host/project-loader.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { dirname, extname, relative, resolve, sep } from "node:path";
+import type { ArtifactRevision, Diagnostic, OxcCompilerPort } from "../contracts/index.js";
+import { AgentStreamAssembler } from "./stream-assembler.js";
+
+const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs"] as const;
+
+export interface AgentReactSourceStamp {
+  readonly signature: string;
+  readonly digest: string;
+}
+
+export interface LoadedAgentReactProject {
+  readonly revision: ArtifactRevision;
+  readonly sources: ReadonlyMap<string, AgentReactSourceStamp>;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface LoadAgentReactProjectOptions {
+  readonly root: string;
+  readonly entry: string;
+  readonly artifactId: string;
+  readonly compiler: OxcCompilerPort;
+  readonly allowedPackages: readonly string[];
+  readonly maxModules?: number;
+  readonly maxSourceBytes?: number;
+}
+
+const DEFAULT_MAX_MODULES = 64;
+const DEFAULT_MAX_SOURCE_BYTES = 2 * 1024 * 1024;
+
+/** Loads only the static module graph admitted by the AgentReact compiler. */
+export async function loadAgentReactProject(
+  options: LoadAgentReactProjectOptions,
+): Promise<LoadedAgentReactProject> {
+  const root = await realpath(options.root);
+  const entry = await realpath(options.entry);
+  assertWithin(root, entry);
+  const maxModules = options.maxModules ?? DEFAULT_MAX_MODULES;
+  const maxSourceBytes = options.maxSourceBytes ?? DEFAULT_MAX_SOURCE_BYTES;
+  const queue = [entry];
+  const seen = new Set<string>();
+  const modules = new Map<string, string>();
+  const sources = new Map<string, AgentReactSourceStamp>();
+  const diagnostics: Diagnostic[] = [];
+  let sourceBytes = 0;
+
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    if (seen.size > maxModules) throw new Error(`AgentReact project exceeds the ${maxModules}-module limit.`);
+    await assertRegularUnlinkedSource(root, path);
+    const bytes = await readFile(path);
+    sourceBytes += bytes.byteLength;
+    if (sourceBytes > maxSourceBytes) {
+      throw new Error(`AgentReact project exceeds the ${maxSourceBytes}-byte source limit.`);
+    }
+    const text = bytes.toString("utf8");
+    const modulePath = revisionPath(root, path);
+    modules.set(modulePath, text);
+    const stats = await lstat(path);
+    sources.set(path, {
+      signature: `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.nlink}`,
+      digest: createHash("sha256").update(bytes).digest("hex"),
+    });
+
+    const inspected = await options.compiler.compileModule({
+      module: { path: modulePath, text },
+      entry: path === entry,
+      allowedPackages: options.allowedPackages,
+    });
+    diagnostics.push(...inspected.diagnostics);
+    for (const specifier of inspected.semanticIndex?.imports ?? []) {
+      if (!specifier.startsWith(".") && !specifier.startsWith("/")) continue;
+      const dependency = await resolveProjectImport(root, path, specifier);
+      if (dependency !== undefined && !seen.has(dependency)) queue.push(dependency);
+    }
+  }
+
+  const assembler = new AgentStreamAssembler({
+    id: options.artifactId,
+    entry: revisionPath(root, entry),
+  });
+  for (const [path, text] of [...modules].sort(([left], [right]) => left.localeCompare(right))) {
+    assembler.applyModulePatch({ path, text, mode: "replace" });
+    assembler.sealModule(path);
+  }
+  return { revision: assembler.commitArtifactRevision(), sources, diagnostics };
+}
+
+async function resolveProjectImport(root: string, importer: string, specifier: string): Promise<string | undefined> {
+  const base = specifier.startsWith("/")
+    ? resolve(root, `.${specifier}`)
+    : resolve(dirname(importer), specifier);
+  assertWithin(root, base);
+  const withoutJs = base.replace(/\.(?:js|mjs)$/u, "");
+  const roots = withoutJs === base ? [base] : [base, withoutJs];
+  const candidates = extname(base) === ""
+    ? [
+      ...roots,
+      ...roots.flatMap((candidate) => SOURCE_EXTENSIONS.map((extension) => `${candidate}${extension}`)),
+      ...roots.flatMap((candidate) => SOURCE_EXTENSIONS.map((extension) => resolve(candidate, `index${extension}`))),
+    ]
+    : [...roots, ...roots.flatMap((candidate) => SOURCE_EXTENSIONS.map((extension) => `${candidate}${extension}`))];
+  const matches: string[] = [];
+  for (const candidate of [...new Set(candidates)]) {
+    try {
+      const stats = await lstat(candidate);
+      if (stats.isFile() && !stats.isSymbolicLink()) matches.push(await realpath(candidate));
+    } catch {
+      // Missing candidates are resolved after every supported extension is tried.
+    }
+  }
+  const unique = [...new Set(matches)];
+  if (unique.length === 0) return undefined;
+  if (unique.length > 1) throw new Error(`AgentReact import '${specifier}' is ambiguous; include its extension.`);
+  assertWithin(root, unique[0]!);
+  return unique[0];
+}
+
+async function assertRegularUnlinkedSource(root: string, path: string): Promise<void> {
+  const stats = await lstat(path);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink > 1) {
+    throw new Error("AgentReact imports must resolve to one regular, non-linked file.");
+  }
+  const parts = relative(root, path).split(sep).filter((part) => part !== "");
+  let current = root;
+  for (const part of parts) {
+    current = resolve(current, part);
+    if ((await lstat(current)).isSymbolicLink()) throw new Error("AgentReact imports cannot cross symbolic links.");
+  }
+}
+
+function revisionPath(root: string, path: string): string {
+  return `/${relative(root, path).split(sep).join("/")}`;
+}
+
+function assertWithin(root: string, path: string): void {
+  const resolvedRoot = resolve(root);
+  const resolvedPath = resolve(path);
+  if (resolvedPath !== resolvedRoot && !resolvedPath.startsWith(resolvedRoot + sep)) {
+    throw new Error("AgentReact source escapes the configured Artifact directory.");
+  }
+}

--- a/packages/harness-studio/src/agent-react/host/state-store.ts
+++ b/packages/harness-studio/src/agent-react/host/state-store.ts
@@ -1,0 +1,156 @@
+import type { ArtifactStateDeclaration } from "../contracts/index.js";
+import { cloneAndFreezePlainData } from "./data-ownership.js";
+import type { ObservationBridge } from "./observation-bridge.js";
+
+export type StateValidator = (value: unknown) => true | string;
+
+export interface StateSchema {
+  readonly name: string;
+  readonly version: number;
+  readonly initial: unknown;
+  readonly validate: StateValidator;
+  /** Upgrades a value written under an older version of the same schema name. */
+  readonly migrate?: (value: unknown, fromVersion: number) => unknown;
+}
+
+export interface ArtifactStateStore {
+  /** Frozen, structurally shared view of every declared path. */
+  snapshot(): Readonly<Record<string, unknown>>;
+  get(path: string): unknown;
+  set(path: string, value: unknown): { readonly ok: true } | { readonly ok: false; readonly reason: string };
+  subscribe(path: string, listener: () => void): () => void;
+  migrate(path: string, schema: StateSchema): { readonly ok: true } | { readonly ok: false; readonly reason: string };
+  declaredSchema(path: string): StateSchema | undefined;
+}
+
+export interface ArtifactStateStoreOptions {
+  readonly declarations: readonly ArtifactStateDeclaration[];
+  readonly schemas: readonly StateSchema[];
+  readonly observations?: ObservationBridge;
+}
+
+/**
+ * Persistent Artifact state, owned by the Host.
+ *
+ * State cannot live in the artifact bundle: committing a new build replaces the
+ * frame, and anything held in a component would vanish with it. Keeping it here is
+ * also what lets a staging frame read a frozen copy while the current frame keeps
+ * writing.
+ */
+export function createArtifactStateStore(options: ArtifactStateStoreOptions): ArtifactStateStore {
+  const schemasByName = new Map(options.schemas.map((schema) => [`${schema.name}@${schema.version}`, schema]));
+  const bound = new Map<string, StateSchema>();
+  const values = new Map<string, unknown>();
+  const listeners = new Map<string, Set<() => void>>();
+
+  for (const declaration of options.declarations) {
+    const schema = schemasByName.get(`${declaration.schema}@${declaration.version}`);
+    if (schema === undefined) {
+      throw new Error(
+        `Artifact declares state '${declaration.path}' as '${declaration.schema}@${declaration.version}', which the Host does not provide.`,
+      );
+    }
+    bound.set(declaration.path, schema);
+    values.set(declaration.path, cloneAndFreezePlainData(schema.initial, "Artifact state"));
+  }
+
+  const notify = (path: string): void => {
+    for (const listener of listeners.get(path) ?? []) listener();
+  };
+
+  return {
+    snapshot() {
+      return Object.freeze(Object.fromEntries(values));
+    },
+    get(path) {
+      return values.get(path);
+    },
+    set(path, value) {
+      const schema = bound.get(path);
+      if (schema === undefined) {
+        const reason = `State path '${path}' is not declared by this Artifact View.`;
+        options.observations?.record({ kind: "stateValidationFailed", detail: { path, reason } });
+        return { ok: false, reason };
+      }
+      const verdict = schema.validate(value);
+      if (verdict !== true) {
+        // The previous value stays in place: accepting a rejected write "for now"
+        // would let an invalid value reach the next reader that trusts the schema.
+        options.observations?.record({
+          kind: "stateValidationFailed",
+          detail: { path, schema: schema.name, version: schema.version, reason: verdict },
+        });
+        return { ok: false, reason: verdict };
+      }
+      let owned: unknown;
+      try {
+        owned = cloneAndFreezePlainData(value, "Artifact state");
+      } catch (error) {
+        const reason = stateOwnershipFailure(error);
+        options.observations?.record({
+          kind: "stateValidationFailed",
+          detail: { path, schema: schema.name, version: schema.version, reason },
+        });
+        return { ok: false, reason };
+      }
+      values.set(path, owned);
+      notify(path);
+      return { ok: true };
+    },
+    subscribe(path, listener) {
+      const set = listeners.get(path) ?? new Set();
+      set.add(listener);
+      listeners.set(path, set);
+      return () => {
+        set.delete(listener);
+      };
+    },
+    migrate(path, schema) {
+      const current = bound.get(path);
+      if (current === undefined) return { ok: false, reason: `State path '${path}' is not declared.` };
+      if (current.name !== schema.name) {
+        return { ok: false, reason: `State path '${path}' cannot change schema from '${current.name}' to '${schema.name}'.` };
+      }
+      if (schema.version <= current.version) {
+        return { ok: false, reason: `State path '${path}' is already at version ${current.version}.` };
+      }
+      const migrated = schema.migrate === undefined
+        ? schema.initial
+        : schema.migrate(values.get(path), current.version);
+      const verdict = schema.validate(migrated);
+      if (verdict !== true) {
+        options.observations?.record({
+          kind: "stateValidationFailed",
+          detail: { path, schema: schema.name, version: schema.version, reason: verdict },
+        });
+        return { ok: false, reason: verdict };
+      }
+      let owned: unknown;
+      try {
+        owned = cloneAndFreezePlainData(migrated, "Artifact state");
+      } catch (error) {
+        const reason = stateOwnershipFailure(error);
+        options.observations?.record({
+          kind: "stateValidationFailed",
+          detail: { path, schema: schema.name, version: schema.version, reason },
+        });
+        return { ok: false, reason };
+      }
+      bound.set(path, schema);
+      values.set(path, owned);
+      notify(path);
+      return { ok: true };
+    },
+    declaredSchema(path) {
+      return bound.get(path);
+    },
+  };
+}
+
+/**
+ * A staging frame is handed the snapshot directly, so a shallow freeze would still
+ * let it mutate a nested array and change what the current frame reads.
+ */
+function stateOwnershipFailure(error: unknown): string {
+  return error instanceof Error ? error.message : "Artifact state could not be copied into Host ownership.";
+}

--- a/packages/harness-studio/src/agent-react/host/stream-assembler.ts
+++ b/packages/harness-studio/src/agent-react/host/stream-assembler.ts
@@ -1,0 +1,93 @@
+import { normalize } from "node:path/posix";
+import type { ArtifactDescriptor, ArtifactRevision, ModuleSource } from "../contracts/index.js";
+import { digestArtifactRevision } from "./digest.js";
+
+export interface ModulePatch {
+  readonly path: string;
+  readonly text: string;
+  /** `append` continues a streaming module; `replace` restates it in full. */
+  readonly mode?: "append" | "replace";
+}
+
+/**
+ * Turns an agent's token-by-token output into committed Revisions.
+ *
+ * The assembler refuses to commit a module the agent has not sealed. A half
+ * streamed TSX file parses as a syntax error, and a syntax error that is really
+ * "the agent is still typing" would be reported to the agent as a compile
+ * failure it must fix — so the pipeline would fight the writer.
+ */
+export class AgentStreamAssembler {
+  #pending = new Map<string, string>();
+  #sealed = new Map<string, string>();
+  #descriptor: ArtifactDescriptor;
+
+  constructor(descriptor: ArtifactDescriptor) {
+    if (descriptor.id.trim() === "") throw new Error("Artifact id must be non-empty.");
+    assertRevisionPath(descriptor.entry);
+    this.#descriptor = Object.freeze({ id: descriptor.id, entry: descriptor.entry });
+  }
+
+  applyModulePatch(patch: ModulePatch): void {
+    assertRevisionPath(patch.path);
+    if (patch.mode === "replace") {
+      this.#pending.set(patch.path, patch.text);
+      this.#sealed.delete(patch.path);
+      return;
+    }
+    this.#pending.set(patch.path, (this.#pending.get(patch.path) ?? "") + patch.text);
+    this.#sealed.delete(patch.path);
+  }
+
+  sealModule(path: string): void {
+    assertRevisionPath(path);
+    const text = this.#pending.get(path);
+    if (text === undefined) throw new Error(`Module '${path}' has no streamed content to seal.`);
+    this.#pending.delete(path);
+    this.#sealed.set(path, text);
+  }
+
+  /** Paths that received content but were never sealed. */
+  unsealedModules(): readonly string[] {
+    return [...this.#pending.keys()].sort();
+  }
+
+  commitArtifactRevision(): ArtifactRevision {
+    if (this.#pending.size > 0) {
+      throw new Error(`Cannot commit a Revision while ${this.unsealedModules().join(", ")} is unsealed.`);
+    }
+    if (!this.#sealed.has(this.#descriptor.entry)) {
+      throw new Error(`Revision is missing its entry module '${this.#descriptor.entry}'.`);
+    }
+    const modules: ModuleSource[] = [...this.#sealed]
+      .map(([path, text]) => Object.freeze({ path, text }))
+      .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+    return Object.freeze({
+      digest: digestArtifactRevision(this.#descriptor, modules),
+      modules: Object.freeze(modules),
+      descriptor: this.#descriptor,
+    });
+  }
+
+  /** Drops in-flight streaming work; already sealed modules survive. */
+  abortGeneration(): void {
+    this.#pending.clear();
+  }
+}
+
+export function isNormalizedRevisionPath(path: string): boolean {
+  return !(
+    !path.startsWith("/")
+    || path === "/"
+    || path.endsWith("/")
+    || path.includes("\\")
+    || path.includes("\0")
+    || normalize(path) !== path
+  );
+}
+
+function assertRevisionPath(path: string): void {
+  if (!isNormalizedRevisionPath(path)) {
+    throw new Error(`Revision module path '${path}' must be a normalized POSIX path rooted at '/'.`);
+  }
+}

--- a/packages/harness-studio/src/agent-react/host/worker-oxc-compiler.ts
+++ b/packages/harness-studio/src/agent-react/host/worker-oxc-compiler.ts
@@ -1,0 +1,146 @@
+import { access } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import {
+  AGENT_REACT_PROFILE_VERSION,
+  type CompileModuleInput,
+  type CompileModuleOutput,
+  type OxcCompilerPort,
+} from "../contracts/index.js";
+import {
+  DEFAULT_OXC_COMPILE_LIMITS,
+  OXC_COMPILER_VERSION,
+  type OxcCompileLimits,
+} from "../kernel/index.js";
+import {
+  isOxcWorkerResponse,
+  OXC_WORKER_REQUEST,
+  type OxcWorkerRequest,
+} from "./compiler-worker-protocol.js";
+
+export interface WorkerOxcCompiler extends OxcCompilerPort {
+  close(): Promise<void>;
+}
+
+export interface WorkerOxcCompilerOptions {
+  readonly timeoutMs?: number;
+  readonly limits?: Partial<OxcCompileLimits>;
+  readonly workerUrl?: URL;
+  readonly createWorker?: (url: URL) => Worker;
+}
+
+export const DEFAULT_OXC_WORKER_TIMEOUT_MS = 5_000;
+
+/**
+ * Production Oxc adapter.
+ *
+ * Native parsing never runs on the Studio server thread. A timeout or crash
+ * terminates the whole Worker, which is the only reliable cancellation boundary
+ * for a synchronous native parser. The next call starts a clean Worker.
+ */
+export function createWorkerOxcCompiler(options: WorkerOxcCompilerOptions = {}): WorkerOxcCompiler {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_OXC_WORKER_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError("The Oxc Worker timeout must be a positive safe integer.");
+  }
+  const limits = Object.freeze({ ...DEFAULT_OXC_COMPILE_LIMITS, ...(options.limits ?? {}) });
+  const createWorker = options.createWorker ?? ((url: URL) => new Worker(url));
+  let workerUrl = options.workerUrl;
+  let worker: Worker | undefined;
+  let requestId = 0;
+  let closed = false;
+
+  const reset = async (): Promise<void> => {
+    const current = worker;
+    worker = undefined;
+    if (current !== undefined) await current.terminate();
+  };
+
+  return {
+    compilerVersion: `${OXC_COMPILER_VERSION}+worker`,
+    profileVersion: AGENT_REACT_PROFILE_VERSION,
+    policyFingerprint: JSON.stringify({ limits, timeoutMs, transport: "worker_threads" }),
+    async compileModule(input: CompileModuleInput): Promise<CompileModuleOutput> {
+      if (closed) throw new Error("The Oxc Worker compiler is closed.");
+      workerUrl ??= await resolveCompilerWorkerUrl();
+      const active = worker ??= createWorker(workerUrl);
+      requestId += 1;
+      const mine = requestId;
+      const request: OxcWorkerRequest = {
+        type: OXC_WORKER_REQUEST,
+        requestId: mine,
+        input,
+        limits,
+      };
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await new Promise<CompileModuleOutput>((resolve, reject) => {
+          const cleanup = (): void => {
+            if (timer !== undefined) clearTimeout(timer);
+            active.off("message", onMessage);
+            active.off("error", onError);
+            active.off("exit", onExit);
+          };
+          const onMessage = (value: unknown): void => {
+            if (!isOxcWorkerResponse(value) || value.requestId !== mine) return;
+            cleanup();
+            resolve(value.output);
+          };
+          const onError = (error: Error): void => {
+            cleanup();
+            reject(error);
+          };
+          const onExit = (code: number): void => {
+            if (code === 0) return;
+            cleanup();
+            reject(new Error(`Oxc Worker exited with code ${code}.`));
+          };
+          active.on("message", onMessage);
+          active.once("error", onError);
+          active.once("exit", onExit);
+          timer = setTimeout(() => {
+            cleanup();
+            reject(new OxcWorkerDeadlineExceeded());
+          }, timeoutMs);
+          active.postMessage(request);
+        });
+      } catch (error) {
+        await reset();
+        return {
+          module: input.module.path,
+          diagnostics: [{
+            level: "error",
+            code: "limit/compile-timeout",
+            message: error instanceof OxcWorkerDeadlineExceeded
+              ? `Module compilation exceeded the ${timeoutMs}ms Worker deadline.`
+              : "The isolated Oxc compiler failed and was restarted.",
+            module: input.module.path,
+          }],
+        };
+      }
+    },
+    async close() {
+      closed = true;
+      await reset();
+    },
+  };
+}
+
+class OxcWorkerDeadlineExceeded extends Error {}
+
+async function resolveCompilerWorkerUrl(): Promise<URL> {
+  const adjacent = new URL("./compiler-worker-entry.js", import.meta.url);
+  try {
+    await access(fileURLToPath(adjacent));
+    return adjacent;
+  } catch {
+    // Vitest imports TypeScript from src/, while npm test has already built the
+    // worker into dist/. Resolve that emitted entry without teaching production
+    // code about a test runner or requiring a TypeScript loader in the Worker.
+    const sourceMarker = "/src/agent-react/host/worker-oxc-compiler.ts";
+    const sourcePath = fileURLToPath(import.meta.url).split("\\").join("/");
+    if (!sourcePath.endsWith(sourceMarker)) throw new Error("The emitted Oxc Worker entry is unavailable.");
+    const packageRoot = sourcePath.slice(0, -sourceMarker.length);
+    return pathToFileURL(`${packageRoot}/dist/agent-react/host/compiler-worker-entry.js`);
+  }
+}

--- a/packages/harness-studio/src/agent-react/index.ts
+++ b/packages/harness-studio/src/agent-react/index.ts
@@ -1,0 +1,39 @@
+/**
+ * AgentReact Artifact Runtime — proof of concept.
+ *
+ * Pipeline: Agent Source Stream → Artifact Revision → Oxc Semantic Compile →
+ * esbuild Link → immutable Build Snapshot → staged frame verification → atomic
+ * commit → Observation.
+ *
+ * Four layers, each a directory, each with one job:
+ *
+ *   contracts/  layer-crossing types plus the shared addressing algorithm
+ *   kernel/     Oxc Semantic Kernel — understands and constrains the source
+ *   linker/     esbuild Linker — turns admitted modules into one runnable bundle
+ *   runtime/    React Artifact Runtime — renders and makes the result addressable
+ *   host/       Artifact Host — owns state, capabilities, versions, and commits
+ *
+ * Dependencies point one way: `host → {kernel, linker, runtime} → contracts`.
+ * The runtime layer additionally stays browser-loadable. Both rules are asserted
+ * in `test/agent-react/layering.test.ts` against the real import graph.
+ *
+ * Spec: docs/specs/2026-08-27-agent-react-artifact-runtime-poc.md
+ */
+
+export * from "./contracts/index.js";
+export * from "./kernel/index.js";
+export * from "./linker/index.js";
+export * from "./host/index.js";
+
+export {
+  activeArtifactRuntime,
+  createNodeAddressRegistry,
+  defineArtifactView,
+  isArtifactViewDefinition,
+  setActiveArtifactRuntime,
+  useArtifactAction,
+  useArtifactState,
+  type ArtifactRuntimeBridge,
+  type ArtifactViewDefinition,
+  type NodeAddressRegistry,
+} from "./runtime/index.js";

--- a/packages/harness-studio/src/agent-react/kernel/abi.ts
+++ b/packages/harness-studio/src/agent-react/kernel/abi.ts
@@ -1,0 +1,260 @@
+import {
+  AGENT_REACT_RUNTIME_PACKAGE,
+  type ArtifactStateDeclaration,
+  type ArtifactViewDeclaration,
+  type Diagnostic,
+} from "../contracts/index.js";
+import {
+  type AstNode,
+  createPositionIndex,
+  integerLiteral,
+  isAstNode,
+  objectProperties,
+  propertyName,
+  stringLiteral,
+} from "./ast.js";
+
+export const DEFINE_ARTIFACT_VIEW = "defineArtifactView";
+
+export interface AbiExtraction {
+  readonly declaration?: ArtifactViewDeclaration;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/**
+ * Reads the Artifact View ABI out of the entry module.
+ *
+ * Everything the Host later uses to negotiate permission must be a static
+ * literal. A capability inferred from what the code *does* would grant exactly
+ * what the author wrote, which is the opposite of a permission model, so the
+ * validator refuses any shape it cannot read without executing.
+ */
+export function extractArtifactViewDeclaration(
+  modulePath: string,
+  text: string,
+  program: unknown,
+): AbiExtraction {
+  const positionAt = createPositionIndex(text);
+  const diagnostics: Diagnostic[] = [];
+  const fail = (code: "abi/missing-view" | "abi/not-static" | "abi/duplicate-state-path", message: string, offset: number): AbiExtraction => {
+    const { line, column } = positionAt(offset);
+    diagnostics.push({ level: "error", code, message, module: modulePath, line, column });
+    return { diagnostics };
+  };
+
+  const body = isAstNode(program) && Array.isArray(program.body) ? program.body.filter(isAstNode) : [];
+  const runtimeLocalNames = collectRuntimeImportNames(body);
+  const defaultExport = body.find((statement) => statement.type === "ExportDefaultDeclaration");
+  if (defaultExport === undefined) {
+    return fail("abi/missing-view", `Entry module must default-export ${DEFINE_ARTIFACT_VIEW}(...).`, 0);
+  }
+
+  const call = defaultExport.declaration;
+  if (!isAstNode(call) || call.type !== "CallExpression") {
+    return fail("abi/missing-view", `Default export must be a direct ${DEFINE_ARTIFACT_VIEW}(...) call.`, defaultExport.start);
+  }
+  const callee = call.callee;
+  const calleeName = isAstNode(callee) && callee.type === "Identifier" && typeof callee.name === "string" ? callee.name : undefined;
+  if (calleeName === undefined || !runtimeLocalNames.has(calleeName)) {
+    return fail(
+      "abi/missing-view",
+      `Default export must call ${DEFINE_ARTIFACT_VIEW} imported from '${AGENT_REACT_RUNTIME_PACKAGE}'.`,
+      call.start,
+    );
+  }
+
+  const args = Array.isArray(call.arguments) ? call.arguments.filter(isAstNode) : [];
+  const definition = args[0];
+  if (args.length !== 1 || definition === undefined || definition.type !== "ObjectExpression") {
+    return fail("abi/not-static", `${DEFINE_ARTIFACT_VIEW} takes exactly one object literal.`, call.start);
+  }
+
+  const fields = new Map<string, AstNode>();
+  for (const property of objectProperties(definition)) {
+    if (property.type !== "Property" || property.kind !== "init" || property.shorthand === true) {
+      return fail("abi/not-static", "Artifact View definition fields must be plain `key: value` literals.", property.start);
+    }
+    const name = propertyName(property);
+    if (name === undefined) {
+      return fail("abi/not-static", "Artifact View definition keys must be static.", property.start);
+    }
+    if (fields.has(name)) {
+      return fail("abi/not-static", `Artifact View definition declares '${name}' twice.`, property.start);
+    }
+    fields.set(name, property);
+  }
+
+  const idProperty = fields.get("id");
+  const id = idProperty === undefined ? undefined : stringLiteral(idProperty.value);
+  if (idProperty === undefined || id === undefined || id.length === 0) {
+    return fail("abi/not-static", "Artifact View `id` must be a non-empty string literal.", idProperty?.start ?? definition.start);
+  }
+
+  const stateProperty = fields.get("state");
+  const state: ArtifactStateDeclaration[] = [];
+  if (stateProperty !== undefined) {
+    const stateObject = stateProperty.value;
+    if (!isAstNode(stateObject) || stateObject.type !== "ObjectExpression") {
+      return fail("abi/not-static", "Artifact View `state` must be an object literal.", stateProperty.start);
+    }
+    const seen = new Set<string>();
+    for (const entry of objectProperties(stateObject)) {
+      const path = entry.type === "Property"
+        && entry.kind === "init"
+        && entry.computed !== true
+        && entry.shorthand !== true
+        ? stringLiteral(entry.key)
+        : undefined;
+      if (path === undefined || !path.startsWith("/")) {
+        return fail("abi/not-static", "Artifact View state keys must be string literals rooted at '/'.", entry.start);
+      }
+      if (seen.has(path)) {
+        return fail("abi/duplicate-state-path", `Artifact View declares state path '${path}' twice.`, entry.start);
+      }
+      seen.add(path);
+      const value = entry.value;
+      if (!isAstNode(value) || value.type !== "ObjectExpression") {
+        return fail("abi/not-static", `State path '${path}' must use a literal schema descriptor.`, entry.start);
+      }
+      const descriptorFields = new Map<string, AstNode>();
+      for (const field of objectProperties(value)) {
+        const name = field.type === "Property"
+          && field.kind === "init"
+          && field.computed !== true
+          && field.shorthand !== true
+          ? propertyName(field)
+          : undefined;
+        if ((name !== "schema" && name !== "version") || descriptorFields.has(name)) {
+          return fail(
+            "abi/not-static",
+            `State path '${path}' must contain exactly literal \`schema\` and \`version\` fields.`,
+            field.start,
+          );
+        }
+        descriptorFields.set(name, field);
+      }
+      if (descriptorFields.size !== 2) {
+        return fail(
+          "abi/not-static",
+          `State path '${path}' must contain exactly literal \`schema\` and \`version\` fields.`,
+          entry.start,
+        );
+      }
+      const schemaProperty = descriptorFields.get("schema");
+      const versionProperty = descriptorFields.get("version");
+      const schema = schemaProperty === undefined ? undefined : stringLiteral(schemaProperty.value);
+      const version = versionProperty === undefined ? undefined : integerLiteral(versionProperty.value);
+      if (schema === undefined || version === undefined || version < 1) {
+        return fail(
+          "abi/not-static",
+          `State path '${path}' must declare a literal \`schema\` string and a positive integer \`version\`.`,
+          entry.start,
+        );
+      }
+      state.push({ path, schema, version });
+    }
+  }
+
+  const capabilitiesProperty = fields.get("capabilities");
+  const capabilities = new Set<string>();
+  if (capabilitiesProperty !== undefined) {
+    const array = capabilitiesProperty.value;
+    if (!isAstNode(array) || array.type !== "ArrayExpression" || !Array.isArray(array.elements)) {
+      return fail("abi/not-static", "Artifact View `capabilities` must be an array literal.", capabilitiesProperty.start);
+    }
+    for (const element of array.elements) {
+      const capability = stringLiteral(element);
+      if (capability === undefined || capability.length === 0) {
+        return fail(
+          "abi/not-static",
+          "Artifact View capability requests must be non-empty string literals.",
+          isAstNode(element) ? element.start : capabilitiesProperty.start,
+        );
+      }
+      capabilities.add(capability);
+    }
+  }
+
+  const componentProperty = fields.get("component");
+  const componentName = componentProperty === undefined
+    ? undefined
+    : isAstNode(componentProperty.value) && componentProperty.value.type === "Identifier" && typeof componentProperty.value.name === "string"
+      ? componentProperty.value.name
+      : undefined;
+  if (componentProperty === undefined || componentName === undefined) {
+    return fail(
+      "abi/not-static",
+      "Artifact View `component` must name a binding in this module.",
+      componentProperty?.start ?? definition.start,
+    );
+  }
+  if (!isComponentBinding(body, componentName)) {
+    return fail(
+      "abi/not-static",
+      `Artifact View component '${componentName}' must be a local function or an import from this Revision.`,
+      componentProperty.start,
+    );
+  }
+
+  return {
+    declaration: Object.freeze({
+      id,
+      state: Object.freeze([...state].sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))),
+      capabilities: Object.freeze([...capabilities].sort()),
+      componentName,
+      module: modulePath,
+    }),
+    diagnostics,
+  };
+}
+
+function collectRuntimeImportNames(body: readonly AstNode[]): Set<string> {
+  const names = new Set<string>();
+  for (const statement of body) {
+    if (statement.type !== "ImportDeclaration") continue;
+    if (stringLiteral(statement.source) !== AGENT_REACT_RUNTIME_PACKAGE) continue;
+    const specifiers = Array.isArray(statement.specifiers) ? statement.specifiers.filter(isAstNode) : [];
+    for (const specifier of specifiers) {
+      if (specifier.type !== "ImportSpecifier") continue;
+      const imported = specifier.imported;
+      const local = specifier.local;
+      const importedName = isAstNode(imported) && typeof imported.name === "string" ? imported.name : undefined;
+      const localName = isAstNode(local) && typeof local.name === "string" ? local.name : undefined;
+      if (importedName === DEFINE_ARTIFACT_VIEW && localName !== undefined) names.add(localName);
+    }
+  }
+  return names;
+}
+
+/** A component is a local function or a named/default import from this Revision. */
+function isComponentBinding(body: readonly AstNode[], name: string): boolean {
+  for (const statement of body) {
+    const declaration = statement.type === "ExportNamedDeclaration" && isAstNode(statement.declaration)
+      ? statement.declaration
+      : statement;
+    if (declaration.type === "FunctionDeclaration") {
+      const id = declaration.id;
+      if (isAstNode(id) && id.name === name) return true;
+    }
+    if (declaration.type === "VariableDeclaration") {
+      const declarators = Array.isArray(declaration.declarations) ? declaration.declarations.filter(isAstNode) : [];
+      for (const declarator of declarators) {
+        const id = declarator.id;
+        if (!isAstNode(id) || id.name !== name) continue;
+        const init = declarator.init;
+        if (isAstNode(init) && (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression")) return true;
+      }
+    }
+    if (declaration.type === "ImportDeclaration") {
+      const source = stringLiteral(declaration.source);
+      if (source === undefined || (!source.startsWith(".") && !source.startsWith("/"))) continue;
+      const specifiers = Array.isArray(declaration.specifiers) ? declaration.specifiers.filter(isAstNode) : [];
+      for (const specifier of specifiers) {
+        if (specifier.type === "ImportNamespaceSpecifier") continue;
+        const local = specifier.local;
+        if (isAstNode(local) && local.name === name) return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/harness-studio/src/agent-react/kernel/ast.ts
+++ b/packages/harness-studio/src/agent-react/kernel/ast.ts
@@ -1,0 +1,122 @@
+/**
+ * Minimal AST access for the Oxc Semantic Kernel.
+ *
+ * `oxc-parser` emits an ESTree-compatible tree, so a structural walk is enough
+ * for the Profile, ABI, and index passes. This module is the only place allowed
+ * to know that shape: everything above it consumes `OxcCompilerPort` output.
+ */
+
+export interface AstNode {
+  readonly type: string;
+  readonly start: number;
+  readonly end: number;
+  readonly [key: string]: unknown;
+}
+
+export function isAstNode(value: unknown): value is AstNode {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { type?: unknown }).type === "string"
+    && typeof (value as { start?: unknown }).start === "number";
+}
+
+/** Depth-first walk. Returning `false` from `visit` skips the node's children. */
+export function walk(
+  root: unknown,
+  visit: (node: AstNode, ancestors: readonly AstNode[]) => boolean | void,
+  ancestors: AstNode[] = [],
+): void {
+  if (Array.isArray(root)) {
+    for (const item of root) walk(item, visit, ancestors);
+    return;
+  }
+  if (typeof root !== "object" || root === null) return;
+  if (!isAstNode(root)) {
+    for (const value of Object.values(root)) walk(value, visit, ancestors);
+    return;
+  }
+  if (visit(root, ancestors) === false) return;
+  ancestors.push(root);
+  for (const [key, value] of Object.entries(root)) {
+    if (key === "type" || key === "start" || key === "end") continue;
+    walk(value, visit, ancestors);
+  }
+  ancestors.pop();
+}
+
+export interface Position {
+  readonly line: number;
+  readonly column: number;
+}
+
+/**
+ * Offset → 1-based line/column, matching what the automatic development JSX
+ * transform writes into `__source`. The runtime derives node addresses from
+ * `__source`, so any drift here would silently split one JSX element into two
+ * different identities.
+ */
+export function createPositionIndex(text: string): (offset: number) => Position {
+  const lineStarts: number[] = [0];
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) === 10) lineStarts.push(index + 1);
+  }
+  return (offset: number): Position => {
+    let low = 0;
+    let high = lineStarts.length - 1;
+    while (low < high) {
+      const middle = (low + high + 1) >> 1;
+      if (lineStarts[middle]! <= offset) low = middle;
+      else high = middle - 1;
+    }
+    return { line: low + 1, column: offset - lineStarts[low]! + 1 };
+  };
+}
+
+export function propertyName(property: AstNode): string | undefined {
+  if (property.computed === true) return undefined;
+  const key = property.key;
+  if (!isAstNode(key)) return undefined;
+  if (key.type === "Identifier" && typeof key.name === "string") return key.name;
+  if (key.type === "Literal" && typeof key.value === "string") return key.value;
+  return undefined;
+}
+
+export function objectProperties(node: unknown): readonly AstNode[] {
+  if (!isAstNode(node) || node.type !== "ObjectExpression") return [];
+  const properties = node.properties;
+  return Array.isArray(properties) ? properties.filter(isAstNode) : [];
+}
+
+export function stringLiteral(node: unknown): string | undefined {
+  return isAstNode(node) && node.type === "Literal" && typeof node.value === "string" ? node.value : undefined;
+}
+
+export function integerLiteral(node: unknown): number | undefined {
+  return isAstNode(node) && node.type === "Literal" && typeof node.value === "number" && Number.isSafeInteger(node.value)
+    ? node.value
+    : undefined;
+}
+
+/** Flattens `a`, `a.b`, and `React.Component` into a dotted string. */
+export function memberPath(node: unknown): string | undefined {
+  if (!isAstNode(node)) return undefined;
+  if (node.type === "Identifier" && typeof node.name === "string") return node.name;
+  if (node.type === "JSXIdentifier" && typeof node.name === "string") return node.name;
+  if (node.type === "MemberExpression" || node.type === "JSXMemberExpression") {
+    if (node.computed === true) return undefined;
+    const object = memberPath(node.object);
+    const property = memberPath(node.property);
+    return object === undefined || property === undefined ? undefined : `${object}.${property}`;
+  }
+  return undefined;
+}
+
+export function jsxElementName(element: AstNode): string | undefined {
+  const opening = element.openingElement;
+  return isAstNode(opening) ? memberPath(opening.name) : undefined;
+}
+
+/** React treats a lowercase, dot-free name as an intrinsic DOM element. */
+export function isIntrinsicElementName(name: string): boolean {
+  return !name.includes(".") && name[0] === name[0]?.toLowerCase() && /^[a-z]/.test(name);
+}

--- a/packages/harness-studio/src/agent-react/kernel/compiler.ts
+++ b/packages/harness-studio/src/agent-react/kernel/compiler.ts
@@ -1,0 +1,162 @@
+import { parseSync } from "oxc-parser";
+import { transformSync } from "oxc-transform";
+import {
+  AGENT_REACT_PROFILE_VERSION,
+  AGENT_REACT_RUNTIME_PACKAGE,
+  type CompileModuleInput,
+  type CompileModuleOutput,
+  type Diagnostic,
+  type OxcCompilerPort,
+} from "../contracts/index.js";
+import { extractArtifactViewDeclaration } from "./abi.js";
+import { createPositionIndex } from "./ast.js";
+import { validateAgentReactProfile } from "./profile.js";
+import { buildSemanticIndex } from "./semantic-index.js";
+
+/** Oxc version reported in every Build Snapshot so a build stays replayable. */
+export const OXC_COMPILER_VERSION = "oxc-node-0.147.0";
+
+export interface OxcCompileLimits {
+  readonly maxModuleBytes: number;
+  readonly maxOutputBytes: number;
+}
+
+export const DEFAULT_OXC_COMPILE_LIMITS: Readonly<OxcCompileLimits> = Object.freeze({
+  maxModuleBytes: 512 * 1024,
+  maxOutputBytes: 1024 * 1024,
+});
+
+/**
+ * The Oxc Semantic Kernel, wired as the POC's `OxcCompilerPort`.
+ *
+ * Order matters and is not an implementation detail: the Profile and the ABI run
+ * on the *parsed source*, before any code is emitted, so a refused module never
+ * produces a bundle for the linker to pick up. A validator that ran after
+ * codegen would be advisory rather than a gate.
+ */
+export function createOxcCompiler(limits: Partial<OxcCompileLimits> = {}): OxcCompilerPort {
+  const resolved: Readonly<OxcCompileLimits> = Object.freeze({ ...DEFAULT_OXC_COMPILE_LIMITS, ...limits });
+  return {
+    compilerVersion: OXC_COMPILER_VERSION,
+    profileVersion: AGENT_REACT_PROFILE_VERSION,
+    policyFingerprint: JSON.stringify(resolved),
+    async compileModule(input: CompileModuleInput): Promise<CompileModuleOutput> {
+      return compileModule(input, resolved);
+    },
+  };
+}
+
+function compileModule(input: CompileModuleInput, limits: Readonly<OxcCompileLimits>): CompileModuleOutput {
+  const { module, entry, allowedPackages } = input;
+  const byteLength = utf8Length(module.text);
+  if (byteLength > limits.maxModuleBytes) {
+    return {
+      module: module.path,
+      diagnostics: [{
+        level: "error",
+        code: "limit/module-bytes",
+        message: `Module is ${byteLength} bytes, over the ${limits.maxModuleBytes}-byte module limit.`,
+        module: module.path,
+      }],
+    };
+  }
+
+  const filename = module.path;
+  const parsed = parseSync(filename, module.text, { lang: "tsx", sourceType: "module" });
+  const parseErrors = parseDiagnostics(module.path, module.text, parsed.errors);
+  if (parseErrors.length > 0) return { module: module.path, diagnostics: parseErrors };
+
+  const diagnostics: Diagnostic[] = [
+    ...validateAgentReactProfile({
+      modulePath: module.path,
+      text: module.text,
+      program: parsed.program,
+      allowedPackages,
+    }),
+  ];
+
+  let viewDeclaration: CompileModuleOutput["viewDeclaration"];
+  if (entry) {
+    const abi = extractArtifactViewDeclaration(module.path, module.text, parsed.program);
+    diagnostics.push(...abi.diagnostics);
+    viewDeclaration = abi.declaration;
+  }
+
+  const semanticIndex = buildSemanticIndex(module.path, module.text, parsed.program);
+  if (diagnostics.some((diagnostic) => diagnostic.level === "error")) {
+    return { module: module.path, diagnostics, semanticIndex, ...(viewDeclaration === undefined ? {} : { viewDeclaration }) };
+  }
+
+  const transformed = transformSync(filename, module.text, {
+    lang: "tsx",
+    sourceType: "module",
+    sourcemap: true,
+    jsx: {
+      runtime: "automatic",
+      development: true,
+      importSource: AGENT_REACT_RUNTIME_PACKAGE,
+      refresh: false,
+    },
+  });
+  const transformErrors = (transformed.errors ?? []).map((error): Diagnostic => ({
+    level: "error",
+    code: "syntax/parse-failed",
+    message: error.message,
+    module: module.path,
+  }));
+  if (transformErrors.length > 0) {
+    return { module: module.path, diagnostics: [...diagnostics, ...transformErrors], semanticIndex };
+  }
+  if (utf8Length(transformed.code) > limits.maxOutputBytes) {
+    return {
+      module: module.path,
+      diagnostics: [...diagnostics, {
+        level: "error",
+        code: "limit/output-bytes",
+        message: `Emitted module is over the ${limits.maxOutputBytes}-byte output limit.`,
+        module: module.path,
+      }],
+      semanticIndex,
+    };
+  }
+
+  return {
+    module: module.path,
+    code: transformed.code,
+    ...(transformed.map === undefined ? {} : { sourceMap: JSON.stringify(transformed.map) }),
+    diagnostics,
+    semanticIndex,
+    ...(viewDeclaration === undefined ? {} : { viewDeclaration }),
+  };
+}
+
+/**
+ * Oxc writes the filename it is given into `_jsxFileName`, and the runtime hashes
+ * that value into every node address. The Revision-relative path is therefore
+ * passed verbatim — the same value the semantic index hashes — so addresses carry
+ * no host filesystem layout and a build on Windows addresses the same nodes as a
+ * build on Linux.
+ */
+function parseDiagnostics(
+  modulePath: string,
+  text: string,
+  errors: readonly { message: string; labels?: readonly { start: number }[] }[],
+): Diagnostic[] {
+  if (errors.length === 0) return [];
+  const positionAt = createPositionIndex(text);
+  return errors.map((error): Diagnostic => {
+    const offset = error.labels?.[0]?.start;
+    const position = offset === undefined ? undefined : positionAt(offset);
+    return {
+      level: "error",
+      code: "syntax/parse-failed",
+      message: error.message,
+      module: modulePath,
+      ...(position === undefined ? {} : { line: position.line, column: position.column }),
+    };
+  });
+}
+
+function utf8Length(text: string): number {
+  return new TextEncoder().encode(text).length;
+}

--- a/packages/harness-studio/src/agent-react/kernel/index.ts
+++ b/packages/harness-studio/src/agent-react/kernel/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Layer 1 — Oxc Semantic Kernel.
+ *
+ * Parses TSX, admits or rejects it against the AgentReact Profile, extracts the
+ * Artifact View ABI, builds the semantic index, and erases types. It is the only
+ * layer allowed to import `oxc-parser` / `oxc-transform`, and the only one that
+ * knows what an AST node looks like — callers receive data, never an AST.
+ */
+
+export { DEFINE_ARTIFACT_VIEW, extractArtifactViewDeclaration, type AbiExtraction } from "./abi.js";
+export {
+  createOxcCompiler,
+  DEFAULT_OXC_COMPILE_LIMITS,
+  OXC_COMPILER_VERSION,
+  type OxcCompileLimits,
+} from "./compiler.js";
+export { validateAgentReactProfile, type ProfileValidationInput } from "./profile.js";
+export { buildSemanticIndex } from "./semantic-index.js";

--- a/packages/harness-studio/src/agent-react/kernel/profile.ts
+++ b/packages/harness-studio/src/agent-react/kernel/profile.ts
@@ -1,0 +1,171 @@
+import {
+  AGENT_REACT_PROFILE_VERSION,
+  type Diagnostic,
+  type ProfileDiagnosticCode,
+} from "../contracts/index.js";
+import { type AstNode, createPositionIndex, isAstNode, memberPath, walk } from "./ast.js";
+
+/**
+ * The AgentReact language Profile.
+ *
+ * This is a Semantic Firewall, not the security authority. It exists so an agent
+ * gets a fast, precise refusal at compile time instead of a mysterious runtime
+ * failure — and so the Host has one place that answers "is this still React
+ * artifact code". A bundle that defeats every rule below still cannot perform a
+ * side effect: `ActionGateway` re-validates each call against the live grant.
+ */
+
+export { AGENT_REACT_PROFILE_VERSION };
+
+const NODE_BUILTINS = new Set([
+  "assert", "buffer", "child_process", "cluster", "console", "constants", "crypto", "dgram", "dns",
+  "domain", "events", "fs", "http", "http2", "https", "inspector", "module", "net", "os", "path",
+  "perf_hooks", "process", "punycode", "querystring", "readline", "repl", "stream", "string_decoder",
+  "sys", "timers", "tls", "trace_events", "tty", "url", "util", "v8", "vm", "worker_threads", "zlib",
+]);
+
+const FORBIDDEN_CALLEES: ReadonlyMap<string, ProfileDiagnosticCode> = new Map([
+  ["require", "profile/commonjs"],
+  ["eval", "profile/dynamic-eval"],
+  ["fetch", "profile/network"],
+  ["globalThis.fetch", "profile/network"],
+  ["window.fetch", "profile/network"],
+  ["navigator.sendBeacon", "profile/network"],
+  ["createRoot", "profile/react-dom-root"],
+  ["hydrateRoot", "profile/react-dom-root"],
+  ["ReactDOM.render", "profile/react-dom-root"],
+  ["ReactDOM.createRoot", "profile/react-dom-root"],
+  ["ReactDOM.hydrate", "profile/react-dom-root"],
+]);
+
+const FORBIDDEN_CONSTRUCTORS: ReadonlyMap<string, ProfileDiagnosticCode> = new Map([
+  ["Function", "profile/dynamic-eval"],
+  ["Worker", "profile/worker"],
+  ["SharedWorker", "profile/worker"],
+  ["XMLHttpRequest", "profile/network"],
+  ["WebSocket", "profile/network"],
+  ["EventSource", "profile/network"],
+]);
+
+const FORBIDDEN_MEMBERS: ReadonlyMap<string, ProfileDiagnosticCode> = new Map([
+  ["module.exports", "profile/commonjs"],
+  ["navigator.serviceWorker", "profile/worker"],
+  ["globalThis.Worker", "profile/worker"],
+]);
+
+const REACT_CLASS_BASES = new Set([
+  "React.Component", "React.PureComponent", "Component", "PureComponent",
+]);
+
+/**
+ * A top-level statement that only declares something cannot run at import time.
+ * Anything else can, so it is refused rather than budgeted: an unbounded "some
+ * side effects allowed" rule has no test that distinguishes pass from fail.
+ */
+const DECLARATION_STATEMENTS = new Set([
+  "ImportDeclaration", "ExportNamedDeclaration", "ExportDefaultDeclaration", "ExportAllDeclaration",
+  "FunctionDeclaration", "ClassDeclaration", "VariableDeclaration", "EmptyStatement",
+  "TSInterfaceDeclaration", "TSTypeAliasDeclaration", "TSEnumDeclaration", "TSModuleDeclaration",
+  "TSImportEqualsDeclaration", "TSDeclareFunction",
+]);
+
+export interface ProfileValidationInput {
+  readonly modulePath: string;
+  readonly text: string;
+  readonly program: unknown;
+  readonly allowedPackages: readonly string[];
+}
+
+export function validateAgentReactProfile(input: ProfileValidationInput): readonly Diagnostic[] {
+  const positionAt = createPositionIndex(input.text);
+  const allowed = new Set(input.allowedPackages);
+  const diagnostics: Diagnostic[] = [];
+  const report = (code: ProfileDiagnosticCode, message: string, offset: number): void => {
+    const { line, column } = positionAt(offset);
+    diagnostics.push({ level: "error", code, message, module: input.modulePath, line, column });
+  };
+
+  validateImports(input, allowed, report);
+  validateTopLevel(input, report);
+  validateExpressions(input, report);
+  return diagnostics;
+}
+
+type Report = (code: ProfileDiagnosticCode, message: string, offset: number) => void;
+
+function validateImports(input: ProfileValidationInput, allowed: Set<string>, report: Report): void {
+  walk(input.program, (node) => {
+    if (node.type === "ImportExpression") {
+      report("profile/dynamic-import", "Dynamic `import()` is not available to an Artifact View.", node.start);
+      return;
+    }
+    if (node.type !== "ImportDeclaration" && node.type !== "ExportNamedDeclaration" && node.type !== "ExportAllDeclaration") {
+      return;
+    }
+    const source = node.source;
+    if (!isAstNode(source) || typeof source.value !== "string") return;
+    const specifier = source.value;
+    if (specifier.startsWith("./") || specifier.startsWith("../") || specifier.startsWith("/")) return;
+    const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+    if (specifier.startsWith("node:") || NODE_BUILTINS.has(bare)) {
+      report("profile/node-builtin", `Node built-in '${specifier}' is not available in the browser Artifact runtime.`, source.start);
+      return;
+    }
+    if (!allowed.has(specifier)) {
+      report("profile/package-not-allowed", `Package import '${specifier}' is not in the AgentReact allowlist.`, source.start);
+    }
+  });
+}
+
+function validateTopLevel(input: ProfileValidationInput, report: Report): void {
+  const program = input.program;
+  const body = isAstNode(program) && Array.isArray(program.body) ? program.body.filter(isAstNode) : [];
+  for (const statement of body) {
+    if (DECLARATION_STATEMENTS.has(statement.type)) continue;
+    if (statement.type === "ExpressionStatement" && isDirective(statement)) continue;
+    report(
+      "profile/top-level-effect",
+      `Top-level '${statement.type}' runs at import time; move it inside a component or an Action handler.`,
+      statement.start,
+    );
+  }
+}
+
+function isDirective(statement: AstNode): boolean {
+  if (typeof statement.directive === "string") return true;
+  const expression = statement.expression;
+  return isAstNode(expression) && expression.type === "Literal" && typeof expression.value === "string";
+}
+
+function validateExpressions(input: ProfileValidationInput, report: Report): void {
+  walk(input.program, (node) => {
+    if (node.type === "CallExpression") {
+      const callee = memberPath(node.callee);
+      const code = callee === undefined ? undefined : FORBIDDEN_CALLEES.get(callee);
+      if (code !== undefined) report(code, `Calling '${callee}' is not available to an Artifact View.`, node.start);
+      return;
+    }
+    if (node.type === "NewExpression") {
+      const callee = memberPath(node.callee);
+      const code = callee === undefined ? undefined : FORBIDDEN_CONSTRUCTORS.get(callee);
+      if (code !== undefined) report(code, `Constructing '${callee}' is not available to an Artifact View.`, node.start);
+      return;
+    }
+    if (node.type === "MemberExpression") {
+      const path = memberPath(node);
+      const code = path === undefined ? undefined : FORBIDDEN_MEMBERS.get(path);
+      if (code !== undefined) report(code, `Accessing '${path}' is not available to an Artifact View.`, node.start);
+      // `exports.foo = ...` is CommonJS even though `exports` alone is not.
+      if (memberPath(node.object) === "exports") {
+        report("profile/commonjs", "CommonJS `exports` assignment is not available; use ESM exports.", node.start);
+      }
+      return;
+    }
+    if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
+      const base = memberPath(node.superClass);
+      if (base !== undefined && REACT_CLASS_BASES.has(base)) {
+        report("profile/class-component", "Artifact Views must use React function components.", node.start);
+      }
+    }
+  });
+}

--- a/packages/harness-studio/src/agent-react/kernel/semantic-index.ts
+++ b/packages/harness-studio/src/agent-react/kernel/semantic-index.ts
@@ -1,0 +1,139 @@
+import {
+  type ReactSemanticIndex,
+  type SemanticComponentEntry,
+  type SemanticJsxNodeEntry,
+  sourceNodeId,
+} from "../contracts/index.js";
+import {
+  type AstNode,
+  createPositionIndex,
+  isAstNode,
+  isIntrinsicElementName,
+  jsxElementName,
+  memberPath,
+  walk,
+} from "./ast.js";
+
+/**
+ * The semantic index answers "what is in this module" for Diff, navigation, and
+ * local edits across Revisions. It deliberately carries no permission
+ * information: a later semantic Diff that could widen a grant would turn a
+ * convenience index into an authorization path.
+ */
+export function buildSemanticIndex(
+  modulePath: string,
+  text: string,
+  program: unknown,
+): ReactSemanticIndex {
+  const positionAt = createPositionIndex(text);
+  const body = isAstNode(program) && Array.isArray(program.body) ? program.body.filter(isAstNode) : [];
+
+  const components: SemanticComponentEntry[] = [];
+  const imports = new Set<string>();
+  const exports = new Set<string>();
+  for (const statement of body) {
+    if (statement.type === "ImportDeclaration"
+      || statement.type === "ExportNamedDeclaration"
+      || statement.type === "ExportAllDeclaration") {
+      const source = statement.source;
+      if (isAstNode(source) && typeof source.value === "string") imports.add(source.value);
+      if (statement.type === "ImportDeclaration") continue;
+    }
+    const exported = statement.type === "ExportNamedDeclaration" || statement.type === "ExportDefaultDeclaration";
+    if (statement.type === "ExportDefaultDeclaration") exports.add("default");
+    const declaration = exported && isAstNode(statement.declaration) ? statement.declaration : statement;
+    collectComponents(declaration, exported, positionAt, components, exports);
+  }
+
+  const jsxNodes: SemanticJsxNodeEntry[] = [];
+  walk(program, (node, ancestors) => {
+    if (node.type !== "JSXElement") return;
+    const elementType = jsxElementName(node);
+    if (elementType === undefined) return;
+    const { line, column } = positionAt(node.start);
+    const structurePath = ancestors
+      .filter((ancestor) => ancestor.type === "JSXElement")
+      .map((ancestor) => jsxElementName(ancestor) ?? "?");
+    jsxNodes.push({
+      sourceNodeId: sourceNodeId({ modulePath, line, column, elementType }),
+      elementType,
+      intrinsic: isIntrinsicElementName(elementType),
+      line,
+      column,
+      structurePath: Object.freeze(structurePath),
+      staticAttributes: Object.freeze(staticAttributeNames(node)),
+    });
+  });
+
+  const stateReferences = new Set<string>();
+  const actionReferences = new Set<string>();
+  walk(program, (node) => {
+    if (node.type !== "CallExpression") return;
+    const callee = memberPath(node.callee);
+    if (callee !== "useArtifactState" && callee !== "useArtifactAction") return;
+    const first = Array.isArray(node.arguments) ? node.arguments[0] : undefined;
+    const literal = isAstNode(first) && first.type === "Literal" && typeof first.value === "string" ? first.value : undefined;
+    if (literal === undefined) return;
+    if (callee === "useArtifactState") stateReferences.add(literal);
+    else actionReferences.add(literal);
+  });
+
+  return Object.freeze({
+    module: modulePath,
+    components: Object.freeze(components),
+    imports: Object.freeze([...imports].sort()),
+    exports: Object.freeze([...exports].sort()),
+    jsxNodes: Object.freeze(jsxNodes),
+    stateReferences: Object.freeze([...stateReferences].sort()),
+    actionReferences: Object.freeze([...actionReferences].sort()),
+  });
+}
+
+function collectComponents(
+  declaration: AstNode,
+  exported: boolean,
+  positionAt: (offset: number) => { line: number },
+  components: SemanticComponentEntry[],
+  exports: Set<string>,
+): void {
+  if (declaration.type === "FunctionDeclaration") {
+    const id = declaration.id;
+    const name = isAstNode(id) && typeof id.name === "string" ? id.name : undefined;
+    if (name === undefined) return;
+    if (exported) exports.add(name);
+    if (isComponentName(name)) components.push({ name, exported, line: positionAt(declaration.start).line });
+    return;
+  }
+  if (declaration.type !== "VariableDeclaration") return;
+  const declarators = Array.isArray(declaration.declarations) ? declaration.declarations.filter(isAstNode) : [];
+  for (const declarator of declarators) {
+    const id = declarator.id;
+    const name = isAstNode(id) && typeof id.name === "string" ? id.name : undefined;
+    if (name === undefined) continue;
+    if (exported) exports.add(name);
+    const init = declarator.init;
+    const isFunction = isAstNode(init) && (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression");
+    if (isFunction && isComponentName(name)) {
+      components.push({ name, exported, line: positionAt(declarator.start).line });
+    }
+  }
+}
+
+/** React's own rule: a component is a capitalized binding. */
+function isComponentName(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+function staticAttributeNames(element: AstNode): string[] {
+  const opening = element.openingElement;
+  const attributes = isAstNode(opening) && Array.isArray(opening.attributes) ? opening.attributes.filter(isAstNode) : [];
+  const names: string[] = [];
+  for (const attribute of attributes) {
+    if (attribute.type !== "JSXAttribute") continue;
+    const name = isAstNode(attribute.name) ? memberPath(attribute.name) : undefined;
+    const value = attribute.value;
+    const isStatic = value === null || (isAstNode(value) && value.type === "Literal");
+    if (name !== undefined && isStatic) names.push(name);
+  }
+  return names.sort();
+}

--- a/packages/harness-studio/src/agent-react/linker/allowed-packages.ts
+++ b/packages/harness-studio/src/agent-react/linker/allowed-packages.ts
@@ -1,0 +1,79 @@
+import { dirname, resolve } from "node:path/posix";
+import {
+  AGENT_REACT_JSX_DEV_PACKAGE,
+  AGENT_REACT_RUNTIME_PACKAGE,
+} from "../contracts/index.js";
+
+/**
+ * Which imports may cross the Artifact boundary, and where they land.
+ *
+ * A trusted package resolves to an *external* specifier rather than being bundled
+ * again. Re-bundling React per build would multiply build size and, worse, give
+ * each build its own React instance, so two frames could never share Host state
+ * or a component identity.
+ */
+
+export interface TrustedRuntimePackage {
+  /** What artifact code writes, e.g. `react`. */
+  readonly specifier: string;
+  /** What the linked bundle imports instead: a versioned Bootstrap URL. */
+  readonly external: string;
+}
+
+export interface AllowedPackageResolver {
+  /** Specifiers the Profile validator accepts, sorted. */
+  readonly allowedPackages: readonly string[];
+  resolveInternal(importer: string, specifier: string): string | undefined;
+  resolveRuntimePackage(specifier: string): string | undefined;
+  rejectPackage(specifier: string): string;
+}
+
+const INTERNAL_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs"] as const;
+
+export const REQUIRED_RUNTIME_SPECIFIERS = Object.freeze([
+  "react",
+  AGENT_REACT_RUNTIME_PACKAGE,
+  AGENT_REACT_JSX_DEV_PACKAGE,
+]);
+
+export function createAllowedPackageResolver(options: {
+  readonly modulePaths: readonly string[];
+  readonly runtimePackages: readonly TrustedRuntimePackage[];
+}): AllowedPackageResolver {
+  const modules = new Set(options.modulePaths);
+  const runtime = new Map(options.runtimePackages.map((entry) => [entry.specifier, entry.external]));
+  for (const required of REQUIRED_RUNTIME_SPECIFIERS) {
+    if (!runtime.has(required)) {
+      throw new Error(`Trusted Bootstrap must provide '${required}' for the AgentReact runtime to link.`);
+    }
+  }
+  return {
+    allowedPackages: Object.freeze([...runtime.keys()].sort()),
+    resolveInternal(importer, specifier) {
+      if (!specifier.startsWith(".") && !specifier.startsWith("/")) return undefined;
+      const base = specifier.startsWith("/") ? specifier : resolve(dirname(importer), specifier);
+      return internalCandidates(base).find((candidate) => modules.has(candidate));
+    },
+    resolveRuntimePackage(specifier) {
+      return runtime.get(specifier);
+    },
+    rejectPackage(specifier) {
+      return `Package import '${specifier}' is not provided by the AgentReact Trusted Bootstrap.`;
+    },
+  };
+}
+
+/**
+ * TypeScript source writes `./panel.js` for a file that is really `./panel.tsx`,
+ * so a resolver that only appended extensions would reject the idiomatic import
+ * every TS-aware agent produces.
+ */
+function internalCandidates(base: string): readonly string[] {
+  const withoutJsExtension = base.replace(/\.(?:js|mjs)$/, "");
+  const roots = withoutJsExtension === base ? [base] : [base, withoutJsExtension];
+  return [
+    ...roots,
+    ...roots.flatMap((root) => INTERNAL_EXTENSIONS.map((extension) => `${root}${extension}`)),
+    ...roots.flatMap((root) => INTERNAL_EXTENSIONS.map((extension) => `${root}/index${extension}`)),
+  ];
+}

--- a/packages/harness-studio/src/agent-react/linker/esbuild-linker.ts
+++ b/packages/harness-studio/src/agent-react/linker/esbuild-linker.ts
@@ -1,0 +1,172 @@
+import { build, type Message, type Plugin } from "esbuild-wasm";
+import type { Diagnostic } from "../contracts/index.js";
+import type { AllowedPackageResolver } from "./allowed-packages.js";
+
+/**
+ * The esbuild Linker.
+ *
+ * Oxc already produced plain ESM, so esbuild is not asked to transform anything:
+ * it resolves the module graph, applies the allowlist a second time, and emits one
+ * file. Letting esbuild re-parse TSX here would put a second, unvalidated compiler
+ * on the hot path and the Profile would no longer describe what actually shipped.
+ */
+
+export const LINK_ENTRY = "agent-react:bundle-entry";
+const VIRTUAL_NAMESPACE = "agent-react";
+const ENTRY_NAMESPACE = "agent-react-entry";
+
+export interface LinkInput {
+  /** Compiled ESM per Revision-relative module path. */
+  readonly compiledModules: ReadonlyMap<string, string>;
+  readonly entryModule: string;
+  readonly resolver: AllowedPackageResolver;
+  readonly maxOutputBytes: number;
+}
+
+export type LinkResult =
+  | { readonly status: "ready"; readonly bundle: string; readonly diagnostics: readonly Diagnostic[] }
+  | { readonly status: "failed"; readonly diagnostics: readonly Diagnostic[] };
+
+/**
+ * The bundle's public surface.
+ *
+ * `activateArtifactRuntime` exists so the Host installs the bridge into the very
+ * runtime instance this bundle linked against. Reaching for a shared global
+ * instead would silently break the moment two builds, or a staging and a current
+ * frame, are alive at once.
+ */
+function entryModuleSource(entryModule: string): string {
+  return [
+    'import { clearActiveArtifactRuntime, setActiveArtifactRuntime } from "@studio/agent-react";',
+    `import artifactView from ${JSON.stringify(entryModule)};`,
+    "export const view = artifactView;",
+    "let activeBridge;",
+    "export function activateArtifactRuntime(bridge) {",
+    "  activeBridge = bridge;",
+    "  setActiveArtifactRuntime(bridge);",
+    "  return artifactView;",
+    "}",
+    "export function deactivateArtifactRuntime() {",
+    "  if (activeBridge !== undefined) clearActiveArtifactRuntime(activeBridge);",
+    "  activeBridge = undefined;",
+    "}",
+  ].join("\n");
+}
+
+export async function linkArtifactBundle(input: LinkInput): Promise<LinkResult> {
+  const rejectedPackages: string[] = [];
+  let result;
+  try {
+    result = await build({
+      entryPoints: [LINK_ENTRY],
+      bundle: true,
+      write: false,
+      format: "esm",
+      platform: "browser",
+      target: "es2022",
+      sourcemap: false,
+      legalComments: "none",
+      logLevel: "silent",
+      outfile: "artifact-bundle.js",
+      plugins: [linkPlugin(input, rejectedPackages)],
+    });
+  } catch (error) {
+    return { status: "failed", diagnostics: linkDiagnostics(error, rejectedPackages) };
+  }
+
+  const output = result.outputFiles.find((file) => file.path.endsWith(".js"));
+  if (output === undefined) {
+    return {
+      status: "failed",
+      diagnostics: [{ level: "error", code: "link/failed", message: "Linker produced no JavaScript output." }],
+    };
+  }
+  if (output.contents.byteLength > input.maxOutputBytes) {
+    return {
+      status: "failed",
+      diagnostics: [{
+        level: "error",
+        code: "limit/output-bytes",
+        message: `Linked bundle is ${output.contents.byteLength} bytes, over the ${input.maxOutputBytes}-byte limit.`,
+      }],
+    };
+  }
+  return {
+    status: "ready",
+    bundle: output.text,
+    diagnostics: result.warnings.map((message) => messageDiagnostic(message, "warning", "link/failed")),
+  };
+}
+
+function linkPlugin(input: LinkInput, rejectedPackages: string[]): Plugin {
+  const { compiledModules, entryModule, resolver } = input;
+  return {
+    name: "agent-react-linker",
+    setup(api) {
+      api.onResolve({ filter: new RegExp(`^${LINK_ENTRY}$`) }, () => ({ path: LINK_ENTRY, namespace: ENTRY_NAMESPACE }));
+      api.onLoad({ filter: /.*/, namespace: ENTRY_NAMESPACE }, () => ({
+        loader: "js",
+        contents: entryModuleSource(entryModule),
+      }));
+
+      api.onResolve({ filter: /.*/ }, (args) => {
+        if (args.kind === "entry-point") return undefined;
+        const external = resolver.resolveRuntimePackage(args.path);
+        if (external !== undefined) return { path: external, external: true };
+        if (!args.path.startsWith(".") && !args.path.startsWith("/")) {
+          rejectedPackages.push(args.path);
+          return { errors: [{ text: resolver.rejectPackage(args.path) }] };
+        }
+        // `args.namespace` names the importer's namespace, so the generated entry
+        // resolves relative to the Revision's entry module rather than to itself.
+        const importer = args.namespace === ENTRY_NAMESPACE ? entryModule : args.importer;
+        const resolved = resolver.resolveInternal(importer, args.path);
+        if (resolved === undefined) {
+          return { errors: [{ text: `Artifact import '${args.path}' is not part of this Artifact Revision.` }] };
+        }
+        return { path: resolved, namespace: VIRTUAL_NAMESPACE };
+      });
+
+      api.onLoad({ filter: /.*/, namespace: VIRTUAL_NAMESPACE }, (args) => {
+        const contents = compiledModules.get(args.path);
+        if (contents === undefined) {
+          return { errors: [{ text: `Artifact module '${args.path}' has no compiled output.` }] };
+        }
+        return { loader: "js", contents };
+      });
+    },
+  };
+}
+
+/**
+ * A refused package is classified from what the resolver actually rejected, not
+ * from esbuild's message text: matching on prose would silently reclassify every
+ * diagnostic the day the wording changes.
+ */
+function linkDiagnostics(error: unknown, rejectedPackages: readonly string[]): Diagnostic[] {
+  const code = rejectedPackages.length > 0 ? "link/package-not-allowed" : "link/failed";
+  const messages = (error as { errors?: Message[] }).errors;
+  if (Array.isArray(messages) && messages.length > 0) {
+    return messages.map((message) => messageDiagnostic(message, "error", code));
+  }
+  return [{
+    level: "error",
+    code,
+    message: error instanceof Error ? error.message : String(error),
+  }];
+}
+
+function messageDiagnostic(
+  message: Message,
+  level: "error" | "warning",
+  code: "link/failed" | "link/package-not-allowed",
+): Diagnostic {
+  return {
+    level,
+    code,
+    message: message.text,
+    ...(message.location?.file === undefined ? {} : { module: message.location.file }),
+    ...(message.location?.line === undefined ? {} : { line: message.location.line }),
+    ...(message.location?.column === undefined ? {} : { column: message.location.column }),
+  };
+}

--- a/packages/harness-studio/src/agent-react/linker/index.ts
+++ b/packages/harness-studio/src/agent-react/linker/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Layer 2 — esbuild Linker.
+ *
+ * Resolves modules over the Revision's virtual filesystem, externalizes the
+ * trusted runtime packages, and emits one ESM bundle. It only ever sees code the
+ * kernel already admitted, so it performs no transform of its own: the Profile
+ * decides what is allowed, and this layer decides how it is wired together.
+ *
+ * It is the only layer allowed to import `esbuild-wasm`.
+ */
+
+export {
+  createAllowedPackageResolver,
+  REQUIRED_RUNTIME_SPECIFIERS,
+  type AllowedPackageResolver,
+  type TrustedRuntimePackage,
+} from "./allowed-packages.js";
+export { LINK_ENTRY, linkArtifactBundle, type LinkInput, type LinkResult } from "./esbuild-linker.js";

--- a/packages/harness-studio/src/agent-react/runtime/address-registry.ts
+++ b/packages/harness-studio/src/agent-react/runtime/address-registry.ts
@@ -1,0 +1,50 @@
+import {
+  ARTIFACT_NODE_ATTRIBUTE,
+  instanceAddress,
+  sourceNodeId,
+  type SourceSpan,
+} from "../contracts/addressing.js";
+
+/**
+ * Per-frame map from a rendered element's address back to its source span.
+ *
+ * The registry is frame-scoped rather than global: two frames render the same
+ * Artifact Digest during a staging swap, and a shared map would let the outgoing
+ * frame's spans answer lookups for the incoming one.
+ */
+export interface NodeAddressRegistry {
+  /** Records a span and returns the token written to `data-artifact-node`. */
+  register(span: SourceSpan, key?: string | null): string;
+  resolveSourceSpan(address: string): SourceSpan | undefined;
+  /** Looks the stamped element up in a DOM subtree; the caller supplies the root. */
+  resolveDomNode<T>(root: { querySelector(selectors: string): T | null }, address: string): T | null;
+  size(): number;
+  clear(): void;
+}
+
+export function createNodeAddressRegistry(artifactDigest: string): NodeAddressRegistry {
+  const spans = new Map<string, SourceSpan>();
+  return {
+    register(span, key) {
+      const address = instanceAddress({ artifactDigest, sourceNodeId: sourceNodeId(span), key });
+      spans.set(address, span);
+      return address;
+    },
+    resolveSourceSpan(address) {
+      return spans.get(address);
+    },
+    resolveDomNode(root, address) {
+      // Only resolve addresses this frame actually rendered, so a stale address
+      // from a previous build cannot match a coincidentally identical attribute.
+      return spans.has(address)
+        ? root.querySelector(`[${ARTIFACT_NODE_ATTRIBUTE}="${address}"]`)
+        : null;
+    },
+    size() {
+      return spans.size;
+    },
+    clear() {
+      spans.clear();
+    },
+  };
+}

--- a/packages/harness-studio/src/agent-react/runtime/bridge.ts
+++ b/packages/harness-studio/src/agent-react/runtime/bridge.ts
@@ -1,0 +1,47 @@
+import type { ActionMode, ActionOutcome } from "../contracts/index.js";
+import type { NodeAddressRegistry } from "./address-registry.js";
+
+/**
+ * The seam between artifact code and its Host.
+ *
+ * In a real sandbox frame this is backed by the transferred `MessagePort`; in
+ * tests it is backed by the in-process Host directly. Artifact code never sees
+ * either: it only ever calls the hooks in `runtime/index.ts`.
+ */
+export interface ArtifactRuntimeBridge {
+  readonly artifactDigest: string;
+  readonly buildDigest: string;
+  readonly actionMode: ActionMode;
+  readonly registry: NodeAddressRegistry;
+  getState(path: string): unknown;
+  setState(path: string, value: unknown): void;
+  subscribe(path: string, listener: () => void): () => void;
+  dispatchAction(capability: string, payload?: unknown): Promise<ActionOutcome>;
+}
+
+/**
+ * `jsxDEV` is called during element creation, outside any React context, so the
+ * bridge has to be reachable through the module scope. One frame hosts exactly
+ * one Artifact build, which is what makes a module-level slot safe here.
+ */
+let active: ArtifactRuntimeBridge | undefined;
+
+export function setActiveArtifactRuntime(bridge: ArtifactRuntimeBridge | undefined): void {
+  active = bridge;
+}
+
+/** Clears only the bridge installed by the caller, never a newer frame's bridge. */
+export function clearActiveArtifactRuntime(bridge: ArtifactRuntimeBridge): void {
+  if (active === bridge) active = undefined;
+}
+
+export function activeArtifactRuntime(): ArtifactRuntimeBridge | undefined {
+  return active;
+}
+
+export function requireActiveArtifactRuntime(): ArtifactRuntimeBridge {
+  if (active === undefined) {
+    throw new Error("No Artifact runtime is active; an Artifact View must be mounted by the Host.");
+  }
+  return active;
+}

--- a/packages/harness-studio/src/agent-react/runtime/browser-bridge.ts
+++ b/packages/harness-studio/src/agent-react/runtime/browser-bridge.ts
@@ -1,0 +1,135 @@
+import type { ActionMode, ActionOutcome } from "../contracts/index.js";
+import { createNodeAddressRegistry } from "./address-registry.js";
+import type { ArtifactRuntimeBridge } from "./bridge.js";
+
+export interface BrowserArtifactRuntimeContext {
+  readonly artifactDigest: string;
+  readonly buildDigest: string;
+  readonly frameToken: string;
+  readonly actionMode: ActionMode;
+  readonly state: Readonly<Record<string, unknown>>;
+}
+
+export interface BrowserArtifactRuntimeSession {
+  readonly bridge: ArtifactRuntimeBridge;
+  dispose(): void;
+}
+
+/** MessagePort-backed runtime installed inside the opaque AgentReact frame. */
+export function createBrowserArtifactRuntimeSession(
+  context: BrowserArtifactRuntimeContext,
+  port: MessagePort,
+): BrowserArtifactRuntimeSession {
+  let actionMode = context.actionMode;
+  const values = new Map(Object.entries(context.state));
+  const listeners = new Map<string, Set<() => void>>();
+  const pendingActions = new Map<number, (outcome: ActionOutcome) => void>();
+  let requestId = 0;
+  let disposed = false;
+
+  const matches = (message: Record<string, unknown>): boolean => message.buildDigest === context.buildDigest
+    && message.frameToken === context.frameToken;
+  const notify = (path: string): void => {
+    for (const listener of listeners.get(path) ?? []) listener();
+  };
+  const onMessage = (event: MessageEvent<unknown>): void => {
+    if (typeof event.data !== "object" || event.data === null) return;
+    const message = event.data as Record<string, unknown>;
+    if (!matches(message)) return;
+    if (message.type === "runtime.promote") {
+      actionMode = "live";
+      return;
+    }
+    if (message.type === "state.result" && typeof message.path === "string" && message.ok === true) {
+      values.set(message.path, message.value);
+      notify(message.path);
+      return;
+    }
+    if (message.type === "state.changed" && typeof message.path === "string") {
+      values.set(message.path, message.value);
+      notify(message.path);
+      return;
+    }
+    if (message.type === "action.result" && Number.isSafeInteger(message.requestId)) {
+      const settle = pendingActions.get(Number(message.requestId));
+      if (settle === undefined) return;
+      pendingActions.delete(Number(message.requestId));
+      settle(actionOutcome(message.outcome));
+    }
+  };
+  port.addEventListener("message", onMessage);
+  port.start();
+
+  const bridge: ArtifactRuntimeBridge = {
+    artifactDigest: context.artifactDigest,
+    buildDigest: context.buildDigest,
+    get actionMode() {
+      return actionMode;
+    },
+    registry: createNodeAddressRegistry(context.artifactDigest),
+    getState(path) {
+      return values.get(path);
+    },
+    setState(path, value) {
+      if (disposed) return;
+      requestId += 1;
+      port.postMessage({
+        type: "state.set",
+        buildDigest: context.buildDigest,
+        frameToken: context.frameToken,
+        requestId,
+        path,
+        value,
+      });
+    },
+    subscribe(path, listener) {
+      const subscribers = listeners.get(path) ?? new Set();
+      subscribers.add(listener);
+      listeners.set(path, subscribers);
+      return () => subscribers.delete(listener);
+    },
+    dispatchAction(capability, payload) {
+      if (disposed) return Promise.resolve({ status: "denied", reason: "Artifact frame is disposed." });
+      requestId += 1;
+      const current = requestId;
+      return new Promise<ActionOutcome>((resolve) => {
+        pendingActions.set(current, resolve);
+        port.postMessage({
+          type: "action.request",
+          buildDigest: context.buildDigest,
+          frameToken: context.frameToken,
+          requestId: current,
+          capability,
+          payload,
+        });
+      });
+    },
+  };
+
+  return {
+    bridge,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      port.removeEventListener("message", onMessage);
+      bridge.registry.clear();
+      for (const settle of pendingActions.values()) {
+        settle({ status: "denied", reason: "Artifact frame is disposed." });
+      }
+      pendingActions.clear();
+      listeners.clear();
+    },
+  };
+}
+
+function actionOutcome(value: unknown): ActionOutcome {
+  if (typeof value === "object" && value !== null) {
+    const outcome = value as Record<string, unknown>;
+    if (outcome.status === "dry-run") return { status: "dry-run" };
+    if (outcome.status === "completed") return { status: "completed", result: outcome.result };
+    if (outcome.status === "denied" && typeof outcome.reason === "string") {
+      return { status: "denied", reason: outcome.reason };
+    }
+  }
+  return { status: "denied", reason: "Host returned an invalid Action result." };
+}

--- a/packages/harness-studio/src/agent-react/runtime/index.ts
+++ b/packages/harness-studio/src/agent-react/runtime/index.ts
@@ -1,0 +1,111 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type { ActionOutcome } from "../contracts/index.js";
+import {
+  type ArtifactRuntimeBridge,
+  activeArtifactRuntime,
+  clearActiveArtifactRuntime,
+  requireActiveArtifactRuntime,
+  setActiveArtifactRuntime,
+} from "./bridge.js";
+
+/**
+ * `@studio/agent-react` — the only module an Artifact View may import besides
+ * `react` and the (future) Component Catalog.
+ */
+
+export { setActiveArtifactRuntime, clearActiveArtifactRuntime, activeArtifactRuntime };
+export type { ArtifactRuntimeBridge };
+// Re-exported from the contract, not redefined here: an Artifact View needs
+// `ARTIFACT_NODE_PROP` to forward addressing, and the compiler needs the same
+// hash. One definition, two importers.
+export {
+  ARTIFACT_NODE_ATTRIBUTE,
+  ARTIFACT_NODE_PROP,
+  instanceAddress,
+  sourceNodeId,
+  stableHash,
+} from "../contracts/addressing.js";
+export type { SourceSpan } from "../contracts/addressing.js";
+export { createNodeAddressRegistry } from "./address-registry.js";
+export type { NodeAddressRegistry } from "./address-registry.js";
+export {
+  createBrowserArtifactRuntimeSession,
+  type BrowserArtifactRuntimeContext,
+  type BrowserArtifactRuntimeSession,
+} from "./browser-bridge.js";
+
+export interface ArtifactStateSpec {
+  readonly schema: string;
+  readonly version: number;
+}
+
+export interface ArtifactViewInput<P = Record<string, unknown>> {
+  readonly id: string;
+  readonly state?: Readonly<Record<string, ArtifactStateSpec>>;
+  readonly capabilities?: readonly string[];
+  readonly component: (props: P) => unknown;
+}
+
+export interface ArtifactViewDefinition<P = Record<string, unknown>> {
+  readonly kind: "agent-react.artifact-view/v1";
+  readonly id: string;
+  readonly state: Readonly<Record<string, ArtifactStateSpec>>;
+  readonly capabilities: readonly string[];
+  readonly component: (props: P) => unknown;
+}
+
+/**
+ * Declares the Artifact View.
+ *
+ * The compiler reads the same literal statically, so this function does no
+ * validation the Host would depend on: it only produces the runtime value. If it
+ * *did* compute the declaration, a build could ship a manifest the compiler had
+ * never seen, and the ABI check would become decorative.
+ */
+export function defineArtifactView<P = Record<string, unknown>>(input: ArtifactViewInput<P>): ArtifactViewDefinition<P> {
+  if (typeof input.component !== "function") {
+    throw new TypeError(`Artifact View '${input.id}' must declare a function component.`);
+  }
+  return Object.freeze({
+    kind: "agent-react.artifact-view/v1" as const,
+    id: input.id,
+    state: Object.freeze({ ...(input.state ?? {}) }),
+    capabilities: Object.freeze([...new Set(input.capabilities ?? [])].sort()),
+    component: input.component,
+  });
+}
+
+export function isArtifactViewDefinition(value: unknown): value is ArtifactViewDefinition {
+  return typeof value === "object"
+    && value !== null
+    && (value as { kind?: unknown }).kind === "agent-react.artifact-view/v1";
+}
+
+/**
+ * Reads and writes persistent Artifact state, which lives in the Host.
+ *
+ * `useState` remains the right tool for hover, focus, and animation. Anything the
+ * Host must validate, migrate, or hand to a staging frame has to come through
+ * here, because a value that only exists in a component cannot survive the frame
+ * swap that commits a new build.
+ */
+export function useArtifactState<T>(path: string): [T, (next: T) => void] {
+  const runtime = requireActiveArtifactRuntime();
+  const subscribe = useCallback(
+    (listener: () => void) => runtime.subscribe(path, listener),
+    [runtime, path],
+  );
+  const read = useCallback(() => runtime.getState(path) as T, [runtime, path]);
+  const value = useSyncExternalStore(subscribe, read, read);
+  const write = useCallback((next: T) => runtime.setState(path, next), [runtime, path]);
+  return [value, write];
+}
+
+/** Requests a capability-gated side effect. The Host decides what actually happens. */
+export function useArtifactAction(capability: string): (payload?: unknown) => Promise<ActionOutcome> {
+  const runtime = requireActiveArtifactRuntime();
+  return useCallback(
+    (payload?: unknown) => runtime.dispatchAction(capability, payload),
+    [runtime, capability],
+  );
+}

--- a/packages/harness-studio/src/agent-react/runtime/jsx-dev-runtime.ts
+++ b/packages/harness-studio/src/agent-react/runtime/jsx-dev-runtime.ts
@@ -1,0 +1,90 @@
+import { Fragment, jsx as reactJsx, jsxs as reactJsxs } from "react/jsx-runtime";
+import { ARTIFACT_NODE_ATTRIBUTE, ARTIFACT_NODE_PROP } from "../contracts/addressing.js";
+import { activeArtifactRuntime } from "./bridge.js";
+
+/**
+ * `@studio/agent-react/jsx-dev-runtime`.
+ *
+ * Oxc's automatic development transform routes every JSX element here and hands
+ * us `__source`. That is the whole reason the POC uses the development transform:
+ * it is the only supported, public channel that carries a source span into
+ * runtime, so addressing never has to read React's Fiber internals.
+ */
+
+export { Fragment };
+
+interface JsxSource {
+  readonly fileName: string;
+  readonly lineNumber: number;
+  readonly columnNumber: number;
+}
+
+type JsxProps = Record<string, unknown> | null | undefined;
+
+/** A catalog component opts in by declaring it forwards the reserved prop. */
+interface AddressableComponent {
+  readonly acceptsArtifactNode?: boolean;
+}
+
+export function jsxDEV(
+  type: unknown,
+  props: JsxProps,
+  key: string | null | undefined,
+  isStaticChildren: boolean,
+  source: JsxSource | undefined,
+  _self: unknown,
+): unknown {
+  const stamped = stampAddress(type, props, key, source);
+  // React intentionally exports no `jsxDEV` implementation from its production
+  // runtime. Oxc still calls our development-shaped entry so it can carry the
+  // stable source span, then this trusted wrapper delegates element creation to
+  // React's production-safe automatic runtime.
+  const createElement = isStaticChildren ? reactJsxs : reactJsx;
+  return createElement(type as never, stamped as never, key as never);
+}
+
+/** Development and production entry points are identical here; both must address. */
+export const jsx = jsxDEV;
+export const jsxs = jsxDEV;
+
+function stampAddress(
+  type: unknown,
+  props: JsxProps,
+  key: string | null | undefined,
+  source: JsxSource | undefined,
+): JsxProps {
+  const runtime = activeArtifactRuntime();
+  if (runtime === undefined || source === undefined) return props;
+  const elementType = elementTypeName(type);
+  if (elementType === undefined) return props;
+
+  const address = runtime.registry.register({
+    modulePath: source.fileName,
+    line: source.lineNumber,
+    column: source.columnNumber,
+    elementType,
+  }, key ?? null);
+
+  if (typeof type === "string") return { ...props, [ARTIFACT_NODE_ATTRIBUTE]: address };
+  if ((type as AddressableComponent | null)?.acceptsArtifactNode === true) {
+    return { ...props, [ARTIFACT_NODE_PROP]: address };
+  }
+  // A component that has not opted in gets no extra prop: React would forward an
+  // unknown prop to the DOM and warn, and a warning per element would drown the
+  // diagnostics that actually matter.
+  return props;
+}
+
+function elementTypeName(type: unknown): string | undefined {
+  if (typeof type === "string") return type;
+  if (type === Fragment) return "Fragment";
+  if (typeof type === "function") {
+    const named = type as { displayName?: string; name?: string };
+    return named.displayName ?? (named.name !== undefined && named.name !== "" ? named.name : "Anonymous");
+  }
+  if (typeof type === "object" && type !== null) {
+    const named = type as { displayName?: string };
+    return named.displayName ?? "Component";
+  }
+  return undefined;
+}

--- a/packages/harness-studio/src/app/App.tsx
+++ b/packages/harness-studio/src/app/App.tsx
@@ -65,6 +65,7 @@ const EMPTY_CONFIG: StudioConfig = {
   workspaceWorkbenchEnabled: false,
   workspaceDiscoveryEnabled: false,
   workspaceConnected: false,
+  projectExecutionEnabled: false,
   projectRevision: 0,
   sessionCount: 0,
   inputCount: 0,
@@ -116,6 +117,7 @@ export function App(): React.JSX.Element {
   const [sessionCompareIds, setSessionCompareIds] = useState<[string, string] | undefined>();
   const [sessionOpenId, setSessionOpenId] = useState<string>();
   const [configFailure, setConfigFailure] = useState<string | null>(null);
+  const [bootstrapRevision, setBootstrapRevision] = useState(0);
   const [area, setArea] = useState<StudioArea>(areaFromHash);
   const [locationRevision, setLocationRevision] = useState(0);
   const [compareSurface, setCompareSurface] = useState<StudioCompareSurface>("sessions");
@@ -155,7 +157,7 @@ export function App(): React.JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [bootstrapRevision]);
 
   useEffect(() => {
     const onHashChange = (): void => {
@@ -340,7 +342,7 @@ export function App(): React.JSX.Element {
     return <main className="studio-loading"><span className="studio-loading-mark"><GitBranch aria-hidden="true" size={18} weight="bold" /></span><p>Loading Harness control plane…</p></main>;
   }
   if (configFailure !== null) {
-    return <main className="studio-loading" role="alert"><span className="studio-loading-mark"><GitBranch aria-hidden="true" size={18} weight="bold" /></span><strong>Cannot load Studio configuration.</strong><p>{configFailure}</p></main>;
+    return <main className="studio-loading" role="alert"><span className="studio-loading-mark"><GitBranch aria-hidden="true" size={18} weight="bold" /></span><strong>Cannot load Studio configuration.</strong><p>{configFailure}</p><button className="primary" type="button" onClick={() => { setConfig(undefined); setConfigFailure(null); setBootstrapRevision((revision) => revision + 1); }}>Retry</button></main>;
   }
 
   const destinations = studioDestinations(config);
@@ -360,6 +362,12 @@ export function App(): React.JSX.Element {
     ? compareNavigation
     : null;
   const activeProject = projects.find((project) => project.id === activeProjectId);
+  const openProjectAction = config.workspaceDiscoveryEnabled && !config.workspaceConnected
+    ? { label: "Open Project", onClick: () => void openProject() }
+    : undefined;
+  const projectDiscoveryDetail = config.workspaceDiscoveryEnabled
+    ? "Choose a remembered Project or open another local directory."
+    : "This Studio launcher does not provide Project discovery. Start the packaged CLI or connect a workspace Session provider.";
   const workspaceGateOpen = projects.length === 0 && studioProjectGateRequired(config, sources.length > 0);
   const overviewConfig = workspaceGateOpen ? config : { ...config, workspaceDiscoveryEnabled: false };
 
@@ -386,20 +394,20 @@ export function App(): React.JSX.Element {
         {contextNavigation && <div className="studio-context-navigation">{contextNavigation}</div>}
         <ThemeToggle theme={theme} onChange={setTheme} />
         {sources.length > 0 && <SourceSwitcher sources={sources} onSelect={(source) => void selectSource(source)} />}
-        <div className="studio-context-state"><span className={`availability-dot availability-${current.availability}`} /><strong>{current.status}</strong></div>
+        <div className="studio-context-state" role="status" aria-label={`View status: ${current.status}`}><span className={`availability-dot availability-${current.availability}`} /><strong>{current.status}</strong></div>
         {projectFailure !== undefined && <span className="studio-project-failure" role="alert">{projectFailure}</span>}
       </header>
       <div className={`studio-surface studio-surface-${area}`}>
         {area === "overview" && <Overview key={`overview-${workspaceRevision}`} config={overviewConfig} onOpen={openArea} onOpenSession={(id) => { setSessionOpenId(id); openArea("sessions"); }} />}
         {area === "customizations" && (config.customizationAnalysisEnabled
           ? <CustomizationView key={`customizations-${workspaceRevision}`} analyzed={config.customizationAnalyzed} onAnalyzed={customizationAnalyzed} />
-          : <EmptyWorkspace eyebrow="Customization catalog" title={config.workspaceConnected ? "Customization analysis is unavailable" : "Open a Project"} detail={config.workspaceConnected ? "This Studio launcher does not include the local customization collector." : "Open or select a Project from the Projects sidebar before analyzing Host customizations."} />)}
-        {area === "inputs" && (config.workspaceWorkbenchEnabled ? <InputTraceView key={`inputs-${workspaceRevision}`} intentAnalysisEnabled={config.intentAnalysisEnabled} /> : <EmptyWorkspace eyebrow="User input trace" title={config.workspaceConnected ? "No retained input trace is available" : "Open a Project"} detail={config.workspaceConnected ? "This Project source does not include structured Inspector dialogue evidence." : "Open or select a Project from the Projects sidebar before browsing retained user inputs and exact file operations."} />)}
-        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
-        {area === "commits" && (config.gitEnabled ? <GitHistoryView key={`commits-${workspaceRevision}`} /> : <EmptyWorkspace eyebrow="Repository history" title={config.workspaceConnected ? "The selected Project is not a Git repository" : "Open a Project"} detail={config.workspaceConnected ? "Commit history is available only for a local Project backed by Git." : "Open or select a Project from the Projects sidebar before browsing local commit history."} />)}
-        {area === "artifacts" && <ArtifactsWorkspace key={`artifacts-${dataRevision}-${workspaceRevision}-${config.artifactsEnabled}`} config={config} />}
-        {area === "debugger" && <DebuggerWorkspace config={config} project={activeProject === undefined ? undefined : { id: activeProject.id, label: activeProject.label, revision: config.projectRevision ?? 0 }} />}
-        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={compareSurface} navigation={null} sessionIds={sessionCompareIds} />}
+          : <EmptyWorkspace eyebrow="Customization catalog" title="Customization analysis is unavailable" detail="This Studio launcher does not include the local customization collector. Opening a Project will not enable it." />)}
+        {area === "inputs" && (config.workspaceWorkbenchEnabled ? <InputTraceView key={`inputs-${workspaceRevision}`} intentAnalysisEnabled={config.intentAnalysisEnabled} /> : <EmptyWorkspace eyebrow="User input trace" title={config.workspaceConnected ? "No retained input trace is available" : "Open a Project"} detail={config.workspaceConnected ? "This Project source does not include structured Inspector dialogue evidence." : projectDiscoveryDetail} action={openProjectAction} />)}
+        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} onOpenProject={openProjectAction?.onClick} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
+        {area === "commits" && (config.gitEnabled ? <GitHistoryView key={`commits-${workspaceRevision}`} /> : <EmptyWorkspace eyebrow="Repository history" title={config.workspaceConnected ? "The selected Project is not a Git repository" : "Open a Project"} detail={config.workspaceConnected ? "Commit history is available only for a local Project backed by Git." : projectDiscoveryDetail} action={openProjectAction} />)}
+        {area === "artifacts" && <ArtifactsWorkspace key={`artifacts-${dataRevision}-${workspaceRevision}-${config.artifactsEnabled}`} config={config} onOpenProject={openProjectAction?.onClick} />}
+        {area === "debugger" && <DebuggerWorkspace config={config} onOpenProject={openProjectAction?.onClick} project={activeProject === undefined ? undefined : { id: activeProject.id, label: activeProject.label, revision: config.projectRevision ?? 0 }} />}
+        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={compareSurface} navigation={null} sessionIds={sessionCompareIds} onOpenProject={openProjectAction?.onClick} />}
       </div>
     </section>
   </div>
@@ -439,7 +447,7 @@ function SourceSwitcher(props: {
   const active = props.sources.filter((source) => source.active);
   const kinds: StudioSourceKind[] = ["inspector", "evidence", "experiment"];
   return <div className="studio-source-switcher">
-    <button type="button" aria-haspopup="menu" aria-expanded={open} onClick={() => setOpen((value) => !value)}><GitBranch aria-hidden="true" size={14} /><span>Data sources</span><em>{active.length}</em></button>
+    <button type="button" aria-haspopup="menu" aria-expanded={open} aria-label={`Data sources (${active.length} active)`} title="Data sources" onClick={() => setOpen((value) => !value)}><GitBranch aria-hidden="true" size={14} /><span>Data sources</span><em>{active.length}</em></button>
     {open && <div className="studio-source-menu" role="menu" aria-label="Studio data sources">
       {kinds.map((kind) => {
         const entries = props.sources.filter((source) => source.kind === kind);
@@ -547,6 +555,7 @@ interface SessionSummary {
 function SessionsWorkspace(props: {
   config: StudioConfig;
   initialSessionId?: string;
+  onOpenProject?: () => void;
   onCompare: (ids: [string, string]) => void;
 }): React.JSX.Element {
   const [sessions, setSessions] = useState<SessionSummary[]>();
@@ -606,7 +615,7 @@ function SessionsWorkspace(props: {
   }
 
   if (!props.config.workspaceConnected) {
-    return <EmptyWorkspace eyebrow="Project Sessions" title="Select a Project" detail="Choose a remembered Project or open another directory from the Projects sidebar." />;
+    return <EmptyWorkspace eyebrow="Project Sessions" title="Open a Project" detail={props.config.workspaceDiscoveryEnabled ? "Choose a remembered Project or open another local directory." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
   }
   if (failure !== undefined) {
     return <EmptyWorkspace eyebrow="Project Sessions" title="Session discovery failed" detail={failure} />;
@@ -723,12 +732,12 @@ function formatSessionTime(value: string): string {
 }
 
 
-function DebuggerWorkspace(props: { config: StudioConfig; project?: { id: string; label: string; revision: number } }): React.JSX.Element {
+function DebuggerWorkspace(props: { config: StudioConfig; onOpenProject?: () => void; project?: { id: string; label: string; revision: number } }): React.JSX.Element {
   if (!props.config.aguiEnabled) {
     return <EmptyWorkspace eyebrow="Live runs" title="Load a harness for live runs" detail="The Debugger drives a live harness run over the embedded AG-UI endpoint and saves finished runs for replay." command="--harness ./my-agent.harness" />;
   }
-  if (props.config.harnessMode === "workspace-default" && props.project === undefined) {
-    return <EmptyWorkspace eyebrow="Project-scoped live runs" title="Open a Project for live runs" detail="Select or open a Project from the Projects sidebar before starting the default local harness." />;
+  if (props.config.harnessMode === "workspace-default" && !props.config.projectExecutionEnabled) {
+    return <EmptyWorkspace eyebrow="Project-scoped live runs" title={props.project === undefined ? "Open a Project for live runs" : "This Project is read-only evidence"} detail={props.project === undefined ? (props.config.workspaceDiscoveryEnabled ? "Open a local Project before starting the default harness." : "This Studio launcher does not provide Project discovery.") : "Imported retained-run folders can be inspected and compared, but they do not provide a local execution root for the default harness."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
   }
   return <div className="debugger-mode"><RunView aguiEndpoint="agui" acpEndpoint={props.config.acpEnabled ? "/agui/acp" : undefined} acpAgentLabel={props.config.acpAgentLabel} artifactEndpoint={props.config.artifactsEnabled ? "/api/artifacts" : undefined} harnessLabel={props.config.harnessMode === "workspace-default" ? "Project default · Qoder" : "Live Trial"} project={props.project} /></div>;
 }
@@ -738,10 +747,11 @@ function CompareWorkspace(props: {
   surface: StudioCompareSurface;
   navigation: ReactNode;
   sessionIds?: [string, string];
+  onOpenProject?: () => void;
 }): React.JSX.Element {
   const available = compareSurfaces(props.config);
   if (available.length === 0) {
-    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a Project with at least two Sessions" : "Open a Project"} detail={props.config.workspaceConnected ? "The selected Project needs two discovered Sessions before observational comparison is available." : "Open or select a Project from the Projects sidebar. Studio discovers its matching local agent Sessions without startup parameters."} />;
+    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a Project with at least two Sessions" : "Open a Project"} detail={props.config.workspaceConnected ? "The selected Project needs two discovered Sessions before observational comparison is available." : props.config.workspaceDiscoveryEnabled ? "Open a local Project. Studio will discover its matching agent Sessions without startup parameters." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
   }
   if (props.surface === "sessions" && props.config.sessionCount >= 2) {
     return <SessionCompareView navigation={props.navigation} initialIds={props.sessionIds} />;
@@ -835,8 +845,8 @@ function sessionMetricLabel(metric: "retainedEventCount" | "toolCallCount" | "me
   return ({ retainedEventCount: "Retained events", toolCallCount: "Tool calls", messageCount: "Messages", warningCount: "Warnings" })[metric];
 }
 
-function EmptyWorkspace(props: { eyebrow: string; title: string; detail: string; command?: string }): React.JSX.Element {
-  return <main className="empty-workspace"><span><GitBranch aria-hidden="true" size={22} /></span><small>{props.eyebrow}</small><h1>{props.title}</h1><p>{props.detail}</p>{props.command && <code>{props.command}</code>}</main>;
+function EmptyWorkspace(props: { eyebrow: string; title: string; detail: string; command?: string; action?: { label: string; onClick: () => void } }): React.JSX.Element {
+  return <main className="empty-workspace"><span><GitBranch aria-hidden="true" size={22} /></span><small>{props.eyebrow}</small><h1>{props.title}</h1><p>{props.detail}</p>{props.action && <button className="primary" type="button" onClick={props.action.onClick}>{props.action.label}</button>}{props.command && <code>{props.command}</code>}</main>;
 }
 
 // The surface switcher navigates between separate top-level views (each its own

--- a/packages/harness-studio/src/app/App.tsx
+++ b/packages/harness-studio/src/app/App.tsx
@@ -1,17 +1,9 @@
-import { lazy, Suspense, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
-import type { Icon } from "@phosphor-icons/react";
+import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { ArrowRight } from "@phosphor-icons/react/ArrowRight";
-import { Binoculars } from "@phosphor-icons/react/Binoculars";
-import { BugBeetle } from "@phosphor-icons/react/BugBeetle";
-import { ChatText } from "@phosphor-icons/react/ChatText";
-import { Flask } from "@phosphor-icons/react/Flask";
 import { FolderOpen } from "@phosphor-icons/react/FolderOpen";
 import { GitBranch } from "@phosphor-icons/react/GitBranch";
 import { Moon } from "@phosphor-icons/react/Moon";
-import { Package } from "@phosphor-icons/react/Package";
-import { PuzzlePiece } from "@phosphor-icons/react/PuzzlePiece";
 import { SidebarSimple } from "@phosphor-icons/react/SidebarSimple";
-import { SquaresFour } from "@phosphor-icons/react/SquaresFour";
 import { Sun } from "@phosphor-icons/react/Sun";
 import { ArtifactsWorkspace } from "./ArtifactsWorkspace.js";
 import { CompareView } from "./CompareView.js";
@@ -21,6 +13,9 @@ import { GitHistoryView } from "./GitHistoryView.js";
 import { InputTraceView } from "./InputTraceView.js";
 import { RunView } from "./run/RunView.js";
 import type { DebuggerSession } from "../contracts/debugger-session.js";
+import { isStudioProjectCatalog, type StudioProjectCatalog, type StudioProjectDescriptor } from "../contracts/studio-project.js";
+import { ProjectSidebar } from "./shell/ProjectSidebar.js";
+import { parseStudioLocation, studioLocationHash } from "./shell/project-routing.js";
 import { useRovingFocus } from "./roving-tablist.js";
 import { studioApiError } from "./studio-api.js";
 import { StudioThemeContext, type StudioTheme } from "./studio-theme.js";
@@ -28,24 +23,13 @@ import { StudioThemeContext, type StudioTheme } from "./studio-theme.js";
 const InspectorWorkbench = lazy(async () => ({ default: (await import("./InspectorWorkbench.js")).InspectorWorkbench }));
 import {
   compareSurfaces,
+  studioProjectGateRequired,
   studioOverview,
   studioDestinations,
   type StudioArea,
   type StudioCompareSurface,
   type StudioConfig,
-  type StudioDestination,
 } from "./studio-shell-model.js";
-
-const NAV_ICONS: Record<StudioArea, Icon> = {
-  overview: SquaresFour,
-  customizations: PuzzlePiece,
-  inputs: ChatText,
-  sessions: Binoculars,
-  commits: GitBranch,
-  artifacts: Package,
-  debugger: BugBeetle,
-  compare: Flask,
-};
 
 // The sidebar already groups these destinations, so the context bar carries the
 // view name alone rather than repeating the group as an eyebrow.
@@ -81,6 +65,7 @@ const EMPTY_CONFIG: StudioConfig = {
   workspaceWorkbenchEnabled: false,
   workspaceDiscoveryEnabled: false,
   workspaceConnected: false,
+  projectRevision: 0,
   sessionCount: 0,
   inputCount: 0,
   intentAnalysisEnabled: false,
@@ -93,29 +78,46 @@ function initialStudioTheme(): StudioTheme {
   return document.documentElement.dataset.theme === "light" ? "light" : "dark";
 }
 
-async function fetchStudioState(): Promise<{ config: StudioConfig; sources: StudioSourceOption[] }> {
-  const [configResponse, sourcesResponse] = await Promise.all([
-    fetch("api/config"),
-    fetch("api/sources"),
-  ]);
-  if (!configResponse.ok) throw new Error(`Studio config failed (${configResponse.status}).`);
-  const loaded = { ...EMPTY_CONFIG, ...(await configResponse.json() as Partial<StudioConfig>) };
-  const sourcesPayload = sourcesResponse.ok ? await sourcesResponse.json() as { sources?: StudioSourceOption[] } : {};
-  return {
-    config: loaded,
-    sources: Array.isArray(sourcesPayload.sources) ? sourcesPayload.sources : [],
-  };
+async function fetchStudioState(): Promise<{ config: StudioConfig; sources: StudioSourceOption[]; projectCatalog: StudioProjectCatalog }> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const [configResponse, sourcesResponse, projectsResponse] = await Promise.all([
+      fetch("api/config"),
+      fetch("api/sources"),
+      fetch("api/projects"),
+    ]);
+    if (!configResponse.ok) throw new Error(`Studio config failed (${configResponse.status}).`);
+    if (!projectsResponse.ok) throw new Error(`Studio Projects failed (${projectsResponse.status}).`);
+    const loaded = { ...EMPTY_CONFIG, ...(await configResponse.json() as Partial<StudioConfig>) };
+    const sourcesPayload = sourcesResponse.ok ? await sourcesResponse.json() as { sources?: StudioSourceOption[] } : {};
+    const projectCatalog = await projectsResponse.json() as unknown;
+    if (!isStudioProjectCatalog(projectCatalog)) throw new Error("Studio Project catalog is unsupported.");
+    if (loaded.projectRevision !== projectCatalog.revision || loaded.activeProjectId !== projectCatalog.activeProjectId) {
+      if (attempt < 2) continue;
+      throw new Error("Studio Project state changed while the workbench was loading.");
+    }
+    return {
+      config: loaded,
+      sources: Array.isArray(sourcesPayload.sources) ? sourcesPayload.sources : [],
+      projectCatalog,
+    };
+  }
+  throw new Error("Studio Project state is unavailable.");
 }
 
 export function App(): React.JSX.Element {
   const [config, setConfig] = useState<StudioConfig | undefined>(undefined);
   const [sources, setSources] = useState<StudioSourceOption[]>([]);
+  const [projects, setProjects] = useState<StudioProjectDescriptor[]>([]);
+  const [activeProjectId, setActiveProjectId] = useState<string>();
+  const [projectOpening, setProjectOpening] = useState(false);
+  const [projectFailure, setProjectFailure] = useState<string>();
   const [dataRevision, setDataRevision] = useState(0);
   const [workspaceRevision, setWorkspaceRevision] = useState(0);
   const [sessionCompareIds, setSessionCompareIds] = useState<[string, string] | undefined>();
   const [sessionOpenId, setSessionOpenId] = useState<string>();
   const [configFailure, setConfigFailure] = useState<string | null>(null);
   const [area, setArea] = useState<StudioArea>(areaFromHash);
+  const [locationRevision, setLocationRevision] = useState(0);
   const [compareSurface, setCompareSurface] = useState<StudioCompareSurface>("sessions");
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [theme, setTheme] = useState<StudioTheme>(initialStudioTheme);
@@ -138,6 +140,8 @@ export function App(): React.JSX.Element {
         if (!cancelled) {
           setConfigFailure(null);
           setSources(loaded.sources);
+          setProjects(loaded.projectCatalog.projects);
+          setActiveProjectId(loaded.projectCatalog.activeProjectId);
           setConfig(loaded.config);
           setCompareSurface((currentSurface) => compareSurfaces(loaded.config).includes(currentSurface) ? currentSurface : compareSurfaces(loaded.config)[0] ?? "sessions");
         }
@@ -154,7 +158,10 @@ export function App(): React.JSX.Element {
   }, []);
 
   useEffect(() => {
-    const onHashChange = (): void => setArea(areaFromHash());
+    const onHashChange = (): void => {
+      setArea(studioLocationFromHash().area);
+      setLocationRevision((revision) => revision + 1);
+    };
     globalThis.addEventListener("hashchange", onHashChange);
     globalThis.addEventListener("popstate", onHashChange);
     return () => {
@@ -162,6 +169,22 @@ export function App(): React.JSX.Element {
       globalThis.removeEventListener("popstate", onHashChange);
     };
   }, []);
+
+  useEffect(() => {
+    if (config === undefined || projectOpening) return;
+    const location = studioLocationFromHash();
+    if (location.projectId !== undefined && location.projectId !== activeProjectId && projects.some((project) => project.id === location.projectId)) {
+      void activateStudioProject(location.projectId, false);
+      return;
+    }
+    if (location.projectId !== undefined && !projects.some((project) => project.id === location.projectId)) {
+      globalThis.history.replaceState(null, "", studioLocationHash({ area: location.area, ...(activeProjectId === undefined ? {} : { projectId: activeProjectId }) }));
+      return;
+    }
+    if (location.projectId === undefined && activeProjectId !== undefined) {
+      globalThis.history.replaceState(null, "", studioLocationHash({ projectId: activeProjectId, area: location.area }));
+    }
+  }, [activeProjectId, config, locationRevision, projectOpening, projects]);
 
   useEffect(() => {
     if (!navigationOpen) return undefined;
@@ -180,10 +203,17 @@ export function App(): React.JSX.Element {
     };
   }, [navigationOpen]);
 
+  function closeNavigation(): void {
+    if (!navigationOpen) return;
+    setNavigationOpen(false);
+    globalThis.requestAnimationFrame(() => navigationToggleRef.current?.focus());
+  }
+
   function openArea(next: StudioArea): void {
     setArea(next);
-    setNavigationOpen(false);
-    if (area !== next) globalThis.history.pushState(null, "", `#/${next}`);
+    closeNavigation();
+    const nextHash = studioLocationHash({ area: next, ...(activeProjectId === undefined ? {} : { projectId: activeProjectId }) });
+    if (globalThis.location.hash !== nextHash) globalThis.history.pushState(null, "", nextHash);
   }
 
   async function selectSource(source: StudioSourceOption): Promise<void> {
@@ -197,6 +227,8 @@ export function App(): React.JSX.Element {
       const loaded = await fetchStudioState();
       setConfigFailure(null);
       setSources(loaded.sources);
+      setProjects(loaded.projectCatalog.projects);
+      setActiveProjectId(loaded.projectCatalog.activeProjectId);
       setConfig(loaded.config);
       setCompareSurface((currentSurface) => compareSurfaces(loaded.config).includes(currentSurface) ? currentSurface : compareSurfaces(loaded.config)[0] ?? "sessions");
       setDataRevision((revision) => revision + 1);
@@ -205,15 +237,95 @@ export function App(): React.JSX.Element {
     }
   }
 
-  async function workspaceChanged(): Promise<void> {
+  async function workspaceChanged(): Promise<string | undefined> {
     const loaded = await fetchStudioState();
     setConfigFailure(null);
     setSources(loaded.sources);
+    setProjects(loaded.projectCatalog.projects);
+    setActiveProjectId(loaded.projectCatalog.activeProjectId);
     setConfig(loaded.config);
     setSessionCompareIds(undefined);
     setSessionOpenId(undefined);
     setCompareSurface((currentSurface) => compareSurfaces(loaded.config).includes(currentSurface) ? currentSurface : compareSurfaces(loaded.config)[0] ?? "sessions");
     setWorkspaceRevision((revision) => revision + 1);
+    return loaded.projectCatalog.activeProjectId;
+  }
+
+  async function refreshProjectCatalog(): Promise<void> {
+    try {
+      const response = await fetch("api/projects");
+      if (!response.ok) return;
+      const catalog = await response.json() as unknown;
+      if (!isStudioProjectCatalog(catalog)) return;
+      setProjects(catalog.projects);
+      setActiveProjectId(catalog.activeProjectId);
+    } catch {
+      // Preserve the last coherent catalog; the Project operation remains the error channel.
+    }
+  }
+
+  async function openProject(): Promise<void> {
+    if (projectOpening) return;
+    setProjectOpening(true);
+    setProjectFailure(undefined);
+    try {
+      const response = await fetch("api/projects/open", { method: "POST" });
+      if (!response.ok) throw new Error(await studioApiError(response));
+      const result = await response.json() as { opened?: boolean; cancelled?: boolean; project?: StudioProjectDescriptor };
+      if (result.cancelled || result.opened !== true) return;
+      await workspaceChanged();
+      if (result.project !== undefined) {
+        closeNavigation();
+        const hash = studioLocationHash({ projectId: result.project.id, area });
+        globalThis.history.pushState(null, "", hash);
+      }
+    } catch (error) {
+      setProjectFailure(error instanceof Error ? error.message : "Project discovery failed.");
+      closeNavigation();
+    } finally {
+      setProjectOpening(false);
+    }
+  }
+
+  async function activateStudioProject(projectId: string, updateHistory = true): Promise<void> {
+    if (projectId === activeProjectId || projectOpening) return;
+    setProjectOpening(true);
+    setProjectFailure(undefined);
+    try {
+      const response = await fetch(`api/projects/${encodeURIComponent(projectId)}/activate`, { method: "POST" });
+      if (!response.ok) throw new Error(await studioApiError(response));
+      await workspaceChanged();
+      closeNavigation();
+      if (updateHistory) globalThis.history.pushState(null, "", studioLocationHash({ projectId, area }));
+    } catch (error) {
+      setProjectFailure(error instanceof Error ? error.message : "Project activation failed.");
+      await refreshProjectCatalog();
+      closeNavigation();
+      if (!updateHistory) {
+        globalThis.history.replaceState(null, "", studioLocationHash({ area, ...(activeProjectId === undefined ? {} : { projectId: activeProjectId }) }));
+      }
+    } finally {
+      setProjectOpening(false);
+    }
+  }
+
+  async function removeStudioProject(projectId: string): Promise<void> {
+    if (projectOpening) return;
+    setProjectOpening(true);
+    setProjectFailure(undefined);
+    try {
+      const response = await fetch(`api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" });
+      if (!response.ok) throw new Error(await studioApiError(response));
+      const wasActive = projectId === activeProjectId;
+      await workspaceChanged();
+      closeNavigation();
+      if (wasActive) globalThis.history.pushState(null, "", studioLocationHash({ area }));
+    } catch (error) {
+      setProjectFailure(error instanceof Error ? error.message : "Project removal failed.");
+      closeNavigation();
+    } finally {
+      setProjectOpening(false);
+    }
   }
 
   function customizationAnalyzed(definitionCount: number): void {
@@ -247,39 +359,54 @@ export function App(): React.JSX.Element {
   const contextNavigation = area === "compare" && compareSurfaces(config).length > 1
     ? compareNavigation
     : null;
-  const workspaceGateOpen = config.workspaceDiscoveryEnabled && !config.workspaceConnected;
+  const activeProject = projects.find((project) => project.id === activeProjectId);
+  const workspaceGateOpen = projects.length === 0 && studioProjectGateRequired(config, sources.length > 0);
+  const overviewConfig = workspaceGateOpen ? config : { ...config, workspaceDiscoveryEnabled: false };
 
   return <StudioThemeContext.Provider value={theme}>
   <div className={`studio-control-plane${navigationOpen ? " navigation-open" : ""}`} inert={workspaceGateOpen ? true : undefined} aria-hidden={workspaceGateOpen ? true : undefined}>
-    <PrimaryNavigation destinations={destinations} current={area} onSelect={openArea} />
+    <ProjectSidebar
+      projects={projects}
+      activeProjectId={activeProjectId}
+      destinations={destinations}
+      current={area}
+      opening={projectOpening}
+      canOpenProject={config.workspaceDiscoveryEnabled}
+      onOpenProject={() => void openProject()}
+      onActivateProject={(projectId) => void activateStudioProject(projectId)}
+      onRemoveProject={(projectId) => void removeStudioProject(projectId)}
+      onSelectView={openArea}
+      onCloseNavigation={() => { setNavigationOpen(false); navigationToggleRef.current?.focus(); }}
+    />
     <button className="studio-nav-backdrop" type="button" aria-label="Close Studio navigation" onClick={() => { setNavigationOpen(false); navigationToggleRef.current?.focus(); }} />
     <section className="studio-area">
       <header className={`studio-context-bar${contextNavigation ? " has-surface-navigation" : ""}`}>
         <button ref={navigationToggleRef} className="studio-nav-toggle" type="button" title={navigationOpen ? "Close navigation" : "Open navigation"} aria-label={navigationOpen ? "Close Studio navigation" : "Open Studio navigation"} aria-expanded={navigationOpen} onClick={() => setNavigationOpen((value) => !value)}><SidebarSimple aria-hidden="true" size={17} /></button>
-        <div className="studio-context-title"><h1>{AREA_COPY[area]}</h1></div>
+        <div className="studio-context-title"><small>{activeProject?.label ?? (sources.length > 0 ? "Configured sources" : "No Project")}</small><h1>{AREA_COPY[area]}</h1></div>
         {contextNavigation && <div className="studio-context-navigation">{contextNavigation}</div>}
-        {config.workspaceDiscoveryEnabled && config.workspaceConnected && <WorkspaceFolderControls compact onWorkspaceChanged={workspaceChanged} />}
         <ThemeToggle theme={theme} onChange={setTheme} />
         {sources.length > 0 && <SourceSwitcher sources={sources} onSelect={(source) => void selectSource(source)} />}
         <div className="studio-context-state"><span className={`availability-dot availability-${current.availability}`} /><strong>{current.status}</strong></div>
+        {projectFailure !== undefined && <span className="studio-project-failure" role="alert">{projectFailure}</span>}
       </header>
       <div className={`studio-surface studio-surface-${area}`}>
-        {area === "overview" && <Overview key={`overview-${workspaceRevision}`} config={config} onOpen={openArea} onOpenSession={(id) => { setSessionOpenId(id); openArea("sessions"); }} />}
+        {area === "overview" && <Overview key={`overview-${workspaceRevision}`} config={overviewConfig} onOpen={openArea} onOpenSession={(id) => { setSessionOpenId(id); openArea("sessions"); }} />}
         {area === "customizations" && (config.customizationAnalysisEnabled
           ? <CustomizationView key={`customizations-${workspaceRevision}`} analyzed={config.customizationAnalyzed} onAnalyzed={customizationAnalyzed} />
-          : <EmptyWorkspace eyebrow="Customization catalog" title={config.workspaceConnected ? "Customization analysis is unavailable" : "Open a project workspace"} detail={config.workspaceConnected ? "This Studio launcher does not include the local customization collector." : "Choose the project directory in Sessions before analyzing Host customizations."} />)}
-        {area === "inputs" && (config.workspaceWorkbenchEnabled ? <InputTraceView key={`inputs-${workspaceRevision}`} intentAnalysisEnabled={config.intentAnalysisEnabled} /> : <EmptyWorkspace eyebrow="User input trace" title={config.workspaceConnected ? "No retained input trace is available" : "Open a project workspace"} detail={config.workspaceConnected ? "This workspace source does not include structured Inspector dialogue evidence." : "Choose the project directory in Sessions before browsing retained user inputs and exact file operations."} />)}
-        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} onWorkspaceChanged={workspaceChanged} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
-        {area === "commits" && (config.gitEnabled ? <GitHistoryView key={`commits-${workspaceRevision}`} /> : <EmptyWorkspace eyebrow="Repository history" title={config.workspaceConnected ? "The open workspace is not a Git repository" : "Open a project workspace"} detail={config.workspaceConnected ? "Commit history is available only for a local workspace backed by Git." : "Choose the project directory in Sessions before browsing its local commit history."} />)}
+          : <EmptyWorkspace eyebrow="Customization catalog" title={config.workspaceConnected ? "Customization analysis is unavailable" : "Open a Project"} detail={config.workspaceConnected ? "This Studio launcher does not include the local customization collector." : "Open or select a Project from the Projects sidebar before analyzing Host customizations."} />)}
+        {area === "inputs" && (config.workspaceWorkbenchEnabled ? <InputTraceView key={`inputs-${workspaceRevision}`} intentAnalysisEnabled={config.intentAnalysisEnabled} /> : <EmptyWorkspace eyebrow="User input trace" title={config.workspaceConnected ? "No retained input trace is available" : "Open a Project"} detail={config.workspaceConnected ? "This Project source does not include structured Inspector dialogue evidence." : "Open or select a Project from the Projects sidebar before browsing retained user inputs and exact file operations."} />)}
+        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
+        {area === "commits" && (config.gitEnabled ? <GitHistoryView key={`commits-${workspaceRevision}`} /> : <EmptyWorkspace eyebrow="Repository history" title={config.workspaceConnected ? "The selected Project is not a Git repository" : "Open a Project"} detail={config.workspaceConnected ? "Commit history is available only for a local Project backed by Git." : "Open or select a Project from the Projects sidebar before browsing local commit history."} />)}
         {area === "artifacts" && <ArtifactsWorkspace key={`artifacts-${dataRevision}-${workspaceRevision}-${config.artifactsEnabled}`} config={config} />}
-        {area === "debugger" && <DebuggerWorkspace config={config} />}
-        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={compareSurface} navigation={compareNavigation} sessionIds={sessionCompareIds} />}
+        {area === "debugger" && <DebuggerWorkspace config={config} project={activeProject === undefined ? undefined : { id: activeProject.id, label: activeProject.label, revision: config.projectRevision ?? 0 }} />}
+        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={compareSurface} navigation={null} sessionIds={sessionCompareIds} />}
       </div>
     </section>
   </div>
   {workspaceGateOpen && <WorkspaceGate onWorkspaceChanged={async () => {
-    await workspaceChanged();
-    openArea(area === "overview" ? "sessions" : area);
+    const projectId = await workspaceChanged();
+    const nextHash = studioLocationHash({ area, ...(projectId === undefined ? {} : { projectId }) });
+    if (globalThis.location.hash !== nextHash) globalThis.history.pushState(null, "", nextHash);
   }} />}
   </StudioThemeContext.Provider>;
 }
@@ -287,10 +414,10 @@ export function App(): React.JSX.Element {
 function WorkspaceGate(props: { onWorkspaceChanged: () => Promise<void> }): React.JSX.Element {
   return <section className="studio-workspace-gate" role="dialog" aria-modal="true" aria-labelledby="workspace-gate-title" aria-describedby="workspace-gate-description">
     <div className="studio-workspace-gate-panel">
-      <header><span><FolderOpen aria-hidden="true" size={22} /></span><div><small>Local Web workspace</small><h1 id="workspace-gate-title">Open a workspace to start</h1></div></header>
-      <p id="workspace-gate-description">Choose the repository or project directory you worked in. Studio will discover matching local agent inputs and Sessions before opening the workbench.</p>
-      <WorkspaceFolderControls autoFocus onWorkspaceChanged={props.onWorkspaceChanged} />
-      <footer><strong>Workspace-scoped discovery</strong><span>The selected directory scopes Session lookup; Studio does not treat a global Session folder as the project.</span></footer>
+      <header><span><FolderOpen aria-hidden="true" size={22} /></span><div><small>Local Project</small><h1 id="workspace-gate-title">Open a Project to start</h1></div></header>
+      <p id="workspace-gate-description">Choose a repository or project directory. Studio will remember it as a Project and discover its matching local agent inputs and Sessions.</p>
+      <ProjectFolderControls autoFocus onWorkspaceChanged={props.onWorkspaceChanged} />
+      <footer><strong>Project-scoped discovery</strong><span>The selected directory scopes Session lookup; global Session folders are not treated as Project evidence.</span></footer>
     </div>
   </section>;
 }
@@ -332,54 +459,13 @@ function sourceKindLabel(kind: StudioSourceKind): string {
   return "Experiment bench";
 }
 
-function PrimaryNavigation(props: {
-  destinations: readonly StudioDestination[];
-  current: StudioArea;
-  onSelect: (area: StudioArea) => void;
-}): React.JSX.Element {
-  const groups = [...new Set(props.destinations.map((destination) => destination.group))];
-  const buttonRefs = useRef(new Map<StudioArea, HTMLButtonElement>());
-
-  function onNavigationKeyDown(event: ReactKeyboardEvent<HTMLElement>): void {
-    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
-    event.preventDefault();
-    const destinations = props.destinations.map((destination) => destination.id);
-    const focused = [...buttonRefs.current.entries()].find(([, button]) => button === document.activeElement)?.[0];
-    const currentIndex = Math.max(0, destinations.indexOf(focused ?? props.current));
-    const nextIndex = event.key === "Home"
-      ? 0
-      : event.key === "End"
-        ? destinations.length - 1
-        : event.key === "ArrowDown"
-          ? (currentIndex + 1) % destinations.length
-          : (currentIndex - 1 + destinations.length) % destinations.length;
-    buttonRefs.current.get(destinations[nextIndex]!)?.focus();
-  }
-
-  return <aside className="studio-primary-nav" aria-label="Studio navigation">
-    <header className="studio-product-brand"><span><GitBranch aria-hidden="true" size={18} weight="bold" /></span><div><strong>Better Harness</strong><small>Studio</small></div></header>
-    <nav aria-label="Harness control plane" onKeyDown={onNavigationKeyDown}>
-      {groups.map((group) => <section className="studio-nav-group" key={group}><h2>{group}</h2>{props.destinations.filter((destination) => destination.group === group).map((destination) => {
-        const NavIcon = NAV_ICONS[destination.id];
-        return <button key={destination.id} ref={(node) => { if (node) buttonRefs.current.set(destination.id, node); else buttonRefs.current.delete(destination.id); }} type="button" tabIndex={props.current === destination.id ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onClick={() => props.onSelect(destination.id)}>
-          <NavIcon aria-hidden="true" size={17} weight={props.current === destination.id ? "fill" : "regular"} />
-          <span><strong>{destination.label}</strong><small>{destination.status}</small></span>
-          <i className={`availability-dot availability-${destination.availability}`} aria-label={destination.availability} />
-        </button>;
-      })}</section>)}
-    </nav>
-  </aside>;
-}
-
 function Overview(props: { config: StudioConfig; onOpen: (area: StudioArea) => void; onOpenSession: (id: string) => void }): React.JSX.Element {
   const model = studioOverview(props.config);
-  const [workspaceLabel, setWorkspaceLabel] = useState<string>();
   const [recentSessions, setRecentSessions] = useState<SessionSummary[]>();
   const [recentFailure, setRecentFailure] = useState<string>();
 
   useEffect(() => {
     if (!props.config.workspaceConnected) {
-      setWorkspaceLabel(undefined);
       setRecentSessions(undefined);
       setRecentFailure(undefined);
       return undefined;
@@ -389,9 +475,8 @@ function Overview(props: { config: StudioConfig; onOpen: (area: StudioArea) => v
       try {
         const response = await fetch("api/sessions");
         if (!response.ok) throw new Error(await studioApiError(response));
-        const payload = await response.json() as { workspace: { label: string }; sessions: SessionSummary[] };
+        const payload = await response.json() as { sessions: SessionSummary[] };
         if (cancelled) return;
-        setWorkspaceLabel(payload.workspace.label);
         setRecentSessions(payload.sessions.slice(0, 5));
         setRecentFailure(undefined);
       } catch (error) {
@@ -403,13 +488,13 @@ function Overview(props: { config: StudioConfig; onOpen: (area: StudioArea) => v
     return () => { cancelled = true; };
   }, [props.config.workspaceConnected, props.config.sessionCount]);
 
-  const heading = model.mode === "workspace" ? workspaceLabel ?? "Project workspace" : model.title;
+  const heading = model.title;
   const context = model.mode === "workspace"
-    ? "Workspace overview"
+    ? "Project overview"
     : model.mode === "configured"
       ? "Configured local sources"
       : model.mode === "workspace-required"
-        ? "Workspace setup"
+        ? "Project setup"
         : "Studio setup";
 
   return <main className={`control-overview overview-mode-${model.mode}`}>
@@ -417,7 +502,7 @@ function Overview(props: { config: StudioConfig; onOpen: (area: StudioArea) => v
       <div className="overview-lead">
         <small>{context}</small>
         <h1>{heading}</h1>
-        <p>{model.mode === "workspace" && workspaceLabel !== undefined ? `${model.title} ${model.detail}` : model.detail}</p>
+        <p>{model.detail}</p>
         {model.primaryAction !== undefined && model.mode !== "workspace-required" && <button className="primary" type="button" onClick={() => props.onOpen(model.primaryAction!.area)}>{model.primaryAction.label}<ArrowRight aria-hidden="true" size={15} weight="bold" /></button>}
       </div>
       {model.mode === "workspace" && <dl className="overview-facts" aria-label="Workspace summary">{model.facts.map((fact) => <div key={fact.id}><dt>{fact.label}</dt><dd>{fact.value}</dd><small>{fact.detail}</small></div>)}</dl>}
@@ -431,7 +516,7 @@ function Overview(props: { config: StudioConfig; onOpen: (area: StudioArea) => v
           : recentSessions === undefined
             ? <p className="overview-pane-status" role="status">Loading retained Sessions…</p>
             : recentSessions.length === 0
-              ? <p className="overview-pane-status">No retained Sessions were discovered in this workspace.</p>
+              ? <p className="overview-pane-status">No retained Sessions were discovered in this Project.</p>
               : <ol className="overview-session-rows">{recentSessions.map((session) => <li key={session.id}><button type="button" aria-label={`Open Session: ${session.prompt}`} onClick={() => props.onOpenSession(session.id)}><span><small>{session.provider ?? "Local agent"} · {formatSessionTime(session.savedAt)}</small><strong>{session.prompt}</strong></span><em>{session.toolCallCount} calls</em><ArrowRight aria-hidden="true" size={14} /></button></li>)}</ol>}
       </section> : <section className="overview-pane overview-context">
         <header><h2>{model.mode === "configured" ? "Loaded context" : "Getting started"}</h2><span>{model.facts.length || undefined}</span></header>
@@ -462,11 +547,9 @@ interface SessionSummary {
 function SessionsWorkspace(props: {
   config: StudioConfig;
   initialSessionId?: string;
-  onWorkspaceChanged: () => Promise<void>;
   onCompare: (ids: [string, string]) => void;
 }): React.JSX.Element {
   const [sessions, setSessions] = useState<SessionSummary[]>();
-  const [workspaceLabel, setWorkspaceLabel] = useState("Project workspace");
   const [omittedCount, setOmittedCount] = useState(0);
   const [selected, setSelected] = useState<string>();
   const [compareIds, setCompareIds] = useState<Set<string>>(new Set());
@@ -486,7 +569,6 @@ function SessionsWorkspace(props: {
         if (!response.ok) throw new Error(await studioApiError(response));
         const payload = await response.json() as { workspace: { label: string; omittedCount: number }; sessions: SessionSummary[] };
         if (cancelled) return;
-        setWorkspaceLabel(payload.workspace.label);
         setOmittedCount(payload.workspace.omittedCount);
         setSessions(payload.sessions);
         const initialSession = payload.sessions.find((session) => session.id === props.initialSessionId) ?? payload.sessions[0];
@@ -523,33 +605,24 @@ function SessionsWorkspace(props: {
     });
   }
 
-  async function disconnect(): Promise<void> {
-    const response = await fetch("api/workspace", { method: "DELETE" });
-    if (!response.ok) {
-      setFailure(await studioApiError(response));
-      return;
-    }
-    await props.onWorkspaceChanged();
-  }
-
   if (!props.config.workspaceConnected) {
-    return <WorkspaceIntake onWorkspaceChanged={props.onWorkspaceChanged} />;
+    return <EmptyWorkspace eyebrow="Project Sessions" title="Select a Project" detail="Choose a remembered Project or open another directory from the Projects sidebar." />;
   }
   if (failure !== undefined) {
-    return <WorkspaceIntake title="Choose another project workspace" detail={failure} onWorkspaceChanged={props.onWorkspaceChanged} />;
+    return <EmptyWorkspace eyebrow="Project Sessions" title="Session discovery failed" detail={failure} />;
   }
   if (sessions === undefined) return <p className="artifact-status" role="status">Indexing sessions…</p>;
 
   const pair = [...compareIds];
   const catalog = <section className="session-browser-workspace" aria-label="Project workspace sessions">
     <aside className="session-catalog-pane">
-      <header><div><small>Local workspace</small><h2 title={workspaceLabel}>{workspaceLabel}</h2></div><span>{sessions.length}</span></header>
+      <header><div><small>Project evidence</small><h2>Sessions</h2></div><span>{sessions.length}</span></header>
       {omittedCount > 0 && <p className="session-omissions">{omittedCount} unsupported or malformed file{omittedCount === 1 ? "" : "s"} omitted.</p>}
       <ul className="session-catalog-rows">{sessions.map((session) => <li key={session.id}>
         <label title="Select for comparison"><input type="checkbox" checked={compareIds.has(session.id)} disabled={!compareIds.has(session.id) && compareIds.size >= 2} onChange={() => toggleCompare(session.id)} /></label>
         <button type="button" className={selected === session.id ? "selected" : undefined} onClick={() => void openSession(session.id)}><small>{session.provider ?? "Local agent"} · {formatSessionTime(session.savedAt)}</small><strong>{session.prompt}</strong><small>{session.status} · {session.toolCallCount} calls</small></button>
       </li>)}</ul>
-      <footer><button type="button" className="primary" disabled={pair.length !== 2} onClick={() => props.onCompare(pair as [string, string])}>Compare {pair.length}/2</button><button type="button" onClick={() => void disconnect()}>Disconnect</button></footer>
+      <footer><button type="button" className="primary" disabled={pair.length !== 2} onClick={() => props.onCompare(pair as [string, string])}>Compare {pair.length}/2</button></footer>
     </aside>
     <main className="session-detail-pane">
       {detailFailure !== undefined
@@ -563,7 +636,7 @@ function SessionsWorkspace(props: {
   if (!props.config.workspaceWorkbenchEnabled) return catalog;
   return <section className="session-workbench-stack" aria-label="Workspace Session evidence">
     <header className="session-workbench-toolbar">
-      <div><strong>{workspaceLabel}</strong><span>Inspector-owned workspace evidence</span></div>
+      <div><strong>Session evidence</strong><span>Inspector-owned Project observations</span></div>
       <div className="session-surface-tabs" role="tablist" aria-label="Session views">
         <button id="session-tab-inspector" type="button" role="tab" aria-controls="session-workbench-panel" aria-selected={surface === "inspector"} tabIndex={surface === "inspector" ? 0 : -1} className={surface === "inspector" ? "selected" : undefined} onClick={() => setSurface("inspector")} onKeyDown={(event) => { if (event.key === "ArrowRight") { event.preventDefault(); setSurface("catalog"); (event.currentTarget.nextElementSibling as HTMLButtonElement | null)?.focus(); } }}>Inspector</button>
         <button id="session-tab-catalog" type="button" role="tab" aria-controls="session-workbench-panel" aria-selected={surface === "catalog"} tabIndex={surface === "catalog" ? 0 : -1} className={surface === "catalog" ? "selected" : undefined} onClick={() => setSurface("catalog")} onKeyDown={(event) => { if (event.key === "ArrowLeft") { event.preventDefault(); setSurface("inspector"); (event.currentTarget.previousElementSibling as HTMLButtonElement | null)?.focus(); } }}>Catalog &amp; Compare</button>
@@ -588,16 +661,12 @@ function SessionDetail({ session }: { session: DebuggerSession }): React.JSX.Ele
   </section>;
 }
 
-function WorkspaceIntake(props: { title?: string; detail?: string; onWorkspaceChanged: () => Promise<void> }): React.JSX.Element {
-  return <main className="workspace-intake empty-workspace"><span><FolderOpen aria-hidden="true" size={22} /></span><small>Local Web workspace</small><h1>{props.title ?? "Open a project workspace"}</h1><p>{props.detail ?? "Choose the repository or project directory you worked in. Studio uses Inspector's provider discovery to find matching Sessions in local agent evidence stores."}</p><WorkspaceFolderControls onWorkspaceChanged={props.onWorkspaceChanged} /></main>;
-}
-
-function WorkspaceFolderControls(props: { autoFocus?: boolean; compact?: boolean; onWorkspaceChanged: () => Promise<void> }): React.JSX.Element {
+function ProjectFolderControls(props: { autoFocus?: boolean; onWorkspaceChanged: () => Promise<void> }): React.JSX.Element {
   const [busy, setBusy] = useState(false);
   const [stage, setStage] = useState<"idle" | "choosing" | "discovering" | "opening">("idle");
   const [failure, setFailure] = useState<string>();
 
-  async function openWorkspace(): Promise<void> {
+  async function openProject(): Promise<void> {
     setBusy(true);
     setFailure(undefined);
     setStage("choosing");
@@ -607,7 +676,7 @@ function WorkspaceFolderControls(props: { autoFocus?: boolean; compact?: boolean
         await new Promise((resolve) => window.setTimeout(resolve, 150));
         if (!monitoring) return;
         try {
-          const response = await fetch("api/workspace/open/status");
+          const response = await fetch("api/projects/open/status");
           if (!response.ok) continue;
           const result = await response.json() as { stage?: "idle" | "choosing" | "discovering" };
           if (result.stage === "choosing" || result.stage === "discovering") setStage(result.stage);
@@ -617,7 +686,7 @@ function WorkspaceFolderControls(props: { autoFocus?: boolean; compact?: boolean
       }
     })();
     try {
-      const opened = await fetch("api/workspace/open", { method: "POST" });
+      const opened = await fetch("api/projects/open", { method: "POST" });
       if (!opened.ok) throw new Error(await studioApiError(opened));
       const result = await opened.json() as { opened?: boolean; cancelled?: boolean };
       if (result.cancelled || result.opened !== true) {
@@ -626,7 +695,7 @@ function WorkspaceFolderControls(props: { autoFocus?: boolean; compact?: boolean
       setStage("opening");
       await props.onWorkspaceChanged();
     } catch (error) {
-      setFailure(error instanceof Error ? error.message : "Workspace discovery failed.");
+      setFailure(error instanceof Error ? error.message : "Project discovery failed.");
     } finally {
       monitoring = false;
       await monitor;
@@ -636,13 +705,13 @@ function WorkspaceFolderControls(props: { autoFocus?: boolean; compact?: boolean
   }
 
   const progressMessage = stage === "discovering"
-    ? "Finding matching Sessions across local providers…"
+    ? "Finding matching Project Sessions across local providers…"
     : stage === "opening"
-      ? "Opening the discovered Session list…"
-      : "Waiting for a project folder selection…";
+      ? "Opening the Project workbench…"
+      : "Waiting for a Project directory selection…";
 
-  return <div className={`workspace-folder-controls${props.compact ? " is-compact" : ""}`}>
-    <button autoFocus={props.autoFocus} className={props.compact ? undefined : "primary"} type="button" disabled={busy} aria-label={busy ? "Opening workspace" : props.compact ? "Change workspace" : "Choose workspace"} onClick={() => void openWorkspace()}><FolderOpen aria-hidden="true" size={14} /><span>{busy ? "Opening…" : props.compact ? "Change workspace" : "Choose workspace"}</span></button>
+  return <div className="workspace-folder-controls">
+    <button autoFocus={props.autoFocus} className="primary" type="button" disabled={busy} aria-label={busy ? "Opening Project" : "Choose Project"} onClick={() => void openProject()}><FolderOpen aria-hidden="true" size={14} /><span>{busy ? "Opening…" : "Choose Project"}</span></button>
     {busy && <span className="workspace-open-progress" role="status" aria-live="polite"><i aria-hidden="true" /><small>{progressMessage}</small></span>}
     {failure !== undefined && <small className="workspace-folder-error" role="alert">{failure}</small>}
   </div>;
@@ -654,11 +723,14 @@ function formatSessionTime(value: string): string {
 }
 
 
-function DebuggerWorkspace(props: { config: StudioConfig }): React.JSX.Element {
+function DebuggerWorkspace(props: { config: StudioConfig; project?: { id: string; label: string; revision: number } }): React.JSX.Element {
   if (!props.config.aguiEnabled) {
     return <EmptyWorkspace eyebrow="Live runs" title="Load a harness for live runs" detail="The Debugger drives a live harness run over the embedded AG-UI endpoint and saves finished runs for replay." command="--harness ./my-agent.harness" />;
   }
-  return <div className="debugger-mode"><RunView aguiEndpoint="agui" acpEndpoint={props.config.acpEnabled ? "/agui/acp" : undefined} acpAgentLabel={props.config.acpAgentLabel} artifactEndpoint={props.config.artifactsEnabled ? "/api/artifacts" : undefined} harnessLabel={props.config.harnessMode === "workspace-default" ? "Workspace default · Qoder" : "Live Trial"} /></div>;
+  if (props.config.harnessMode === "workspace-default" && props.project === undefined) {
+    return <EmptyWorkspace eyebrow="Project-scoped live runs" title="Open a Project for live runs" detail="Select or open a Project from the Projects sidebar before starting the default local harness." />;
+  }
+  return <div className="debugger-mode"><RunView aguiEndpoint="agui" acpEndpoint={props.config.acpEnabled ? "/agui/acp" : undefined} acpAgentLabel={props.config.acpAgentLabel} artifactEndpoint={props.config.artifactsEnabled ? "/api/artifacts" : undefined} harnessLabel={props.config.harnessMode === "workspace-default" ? "Project default · Qoder" : "Live Trial"} project={props.project} /></div>;
 }
 
 function CompareWorkspace(props: {
@@ -669,7 +741,7 @@ function CompareWorkspace(props: {
 }): React.JSX.Element {
   const available = compareSurfaces(props.config);
   if (available.length === 0) {
-    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a workspace with at least two Sessions" : "Open a project workspace"} detail={props.config.workspaceConnected ? "The current workspace needs two discovered Sessions before observational comparison is available." : "Choose the project directory in Sessions. Studio discovers its matching local agent Sessions without startup parameters."} />;
+    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a Project with at least two Sessions" : "Open a Project"} detail={props.config.workspaceConnected ? "The selected Project needs two discovered Sessions before observational comparison is available." : "Open or select a Project from the Projects sidebar. Studio discovers its matching local agent Sessions without startup parameters."} />;
   }
   if (props.surface === "sessions" && props.config.sessionCount >= 2) {
     return <SessionCompareView navigation={props.navigation} initialIds={props.sessionIds} />;
@@ -780,7 +852,10 @@ function SurfaceNavigation<T extends string>(props: {
   return <nav className="studio-tabs studio-secondary-tabs" aria-label={props.label} onKeyDown={roving.onKeyDown} style={{ gridTemplateColumns: `repeat(${props.items.length}, minmax(0, 1fr))` }}>{props.items.map((item) => <button key={item.id} ref={roving.itemRef(item.id)} type="button" tabIndex={roving.tabIndexFor(item.id)} aria-current={props.active === item.id ? "page" : undefined} className={props.active === item.id ? "active" : ""} onClick={() => props.onSelect(item.id)}>{item.label}</button>)}</nav>;
 }
 
+function studioLocationFromHash(): { area: StudioArea; projectId?: string } {
+  return parseStudioLocation(globalThis.location?.hash, new Set(Object.keys(AREA_COPY)));
+}
+
 function areaFromHash(): StudioArea {
-  const candidate = globalThis.location?.hash.replace(/^#\/?/, "") as StudioArea | undefined;
-  return candidate !== undefined && Object.hasOwn(AREA_COPY, candidate) ? candidate : "overview";
+  return studioLocationFromHash().area;
 }

--- a/packages/harness-studio/src/app/App.tsx
+++ b/packages/harness-studio/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { ArrowRight } from "@phosphor-icons/react/ArrowRight";
 import { FolderOpen } from "@phosphor-icons/react/FolderOpen";
 import { GitBranch } from "@phosphor-icons/react/GitBranch";
@@ -58,6 +58,7 @@ const EMPTY_CONFIG: StudioConfig = {
   artifactsEnabled: false,
   evidenceEnabled: false,
   experimentEnabled: false,
+  experimentRunnable: false,
   gitEnabled: false,
   harnessMode: "none",
   historyEnabled: false,
@@ -345,25 +346,29 @@ export function App(): React.JSX.Element {
     return <main className="studio-loading" role="alert"><span className="studio-loading-mark"><GitBranch aria-hidden="true" size={18} weight="bold" /></span><strong>Cannot load Studio configuration.</strong><p>{configFailure}</p><button className="primary" type="button" onClick={() => { setConfig(undefined); setConfigFailure(null); setBootstrapRevision((revision) => revision + 1); }}>Retry</button></main>;
   }
 
-  const destinations = studioDestinations(config);
+  const availableCompareSurfaces = compareSurfaces(config);
+  const effectiveCompareSurface = availableCompareSurfaces.includes(compareSurface)
+    ? compareSurface
+    : availableCompareSurfaces[0] ?? compareSurface;
+  const destinations = studioDestinations(config, effectiveCompareSurface);
   const current = destinations.find((destination) => destination.id === area) ?? destinations[0]!;
   const compareNavigation = (
     <SurfaceNavigation
       label="Compare surfaces"
-      items={compareSurfaces(config).map((id) => ({
+      items={availableCompareSurfaces.map((id) => ({
         id,
         label: id === "sessions" ? "Sessions" : id === "bench" ? "Bench" : "Evidence results",
       }))}
-      active={compareSurface}
+      active={effectiveCompareSurface}
       onSelect={setCompareSurface}
     />
   );
-  const contextNavigation = area === "compare" && compareSurfaces(config).length > 1
+  const contextNavigation = area === "compare" && availableCompareSurfaces.length > 1
     ? compareNavigation
     : null;
   const activeProject = projects.find((project) => project.id === activeProjectId);
-  const openProjectAction = config.workspaceDiscoveryEnabled && !config.workspaceConnected
-    ? { label: "Open Project", onClick: () => void openProject() }
+  const openProjectAction = config.workspaceDiscoveryEnabled
+    ? { label: config.workspaceConnected ? "Open Another Project" : "Open Project", onClick: () => void openProject() }
     : undefined;
   const projectDiscoveryDetail = config.workspaceDiscoveryEnabled
     ? "Choose a remembered Project or open another local directory."
@@ -401,13 +406,13 @@ export function App(): React.JSX.Element {
         {area === "overview" && <Overview key={`overview-${workspaceRevision}`} config={overviewConfig} onOpen={openArea} onOpenSession={(id) => { setSessionOpenId(id); openArea("sessions"); }} />}
         {area === "customizations" && (config.customizationAnalysisEnabled
           ? <CustomizationView key={`customizations-${workspaceRevision}`} analyzed={config.customizationAnalyzed} onAnalyzed={customizationAnalyzed} />
-          : <EmptyWorkspace eyebrow="Customization catalog" title="Customization analysis is unavailable" detail="This Studio launcher does not include the local customization collector. Opening a Project will not enable it." />)}
+          : <EmptyWorkspace eyebrow="Customization catalog" title="Customization analysis is unavailable" detail="This Studio launcher does not include the local customization collector. Opening a Project will not enable it." command="npx @qoder-ai/harness-studio" />)}
         {area === "inputs" && (config.workspaceWorkbenchEnabled ? <InputTraceView key={`inputs-${workspaceRevision}`} intentAnalysisEnabled={config.intentAnalysisEnabled} /> : <EmptyWorkspace eyebrow="User input trace" title={config.workspaceConnected ? "No retained input trace is available" : "Open a Project"} detail={config.workspaceConnected ? "This Project source does not include structured Inspector dialogue evidence." : projectDiscoveryDetail} action={openProjectAction} />)}
-        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} onOpenProject={openProjectAction?.onClick} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
+        {area === "sessions" && <SessionsWorkspace key={`sessions-${dataRevision}-${workspaceRevision}-${sessionOpenId ?? "recent"}`} config={config} initialSessionId={sessionOpenId} openProjectAction={openProjectAction} onCompare={(ids) => { setSessionCompareIds(ids); setCompareSurface("sessions"); openArea("compare"); }} />}
         {area === "commits" && (config.gitEnabled ? <GitHistoryView key={`commits-${workspaceRevision}`} /> : <EmptyWorkspace eyebrow="Repository history" title={config.workspaceConnected ? "The selected Project is not a Git repository" : "Open a Project"} detail={config.workspaceConnected ? "Commit history is available only for a local Project backed by Git." : projectDiscoveryDetail} action={openProjectAction} />)}
-        {area === "artifacts" && <ArtifactsWorkspace key={`artifacts-${dataRevision}-${workspaceRevision}-${config.artifactsEnabled}`} config={config} onOpenProject={openProjectAction?.onClick} />}
-        {area === "debugger" && <DebuggerWorkspace config={config} onOpenProject={openProjectAction?.onClick} project={activeProject === undefined ? undefined : { id: activeProject.id, label: activeProject.label, revision: config.projectRevision ?? 0 }} />}
-        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={compareSurface} navigation={null} sessionIds={sessionCompareIds} onOpenProject={openProjectAction?.onClick} />}
+        {area === "artifacts" && <ArtifactsWorkspace key={`artifacts-${dataRevision}-${workspaceRevision}-${config.artifactsEnabled}`} config={config} openProjectAction={openProjectAction} />}
+        {area === "debugger" && <DebuggerWorkspace config={config} openProjectAction={openProjectAction} project={activeProject === undefined ? undefined : { id: activeProject.id, label: activeProject.label, revision: config.projectRevision ?? 0 }} />}
+        {area === "compare" && <CompareWorkspace key={`compare-${dataRevision}-${workspaceRevision}-${config.experimentEnabled}-${config.evidenceEnabled}`} config={config} surface={effectiveCompareSurface} navigation={null} sessionIds={sessionCompareIds} openProjectAction={openProjectAction} />}
       </div>
     </section>
   </div>
@@ -555,7 +560,7 @@ interface SessionSummary {
 function SessionsWorkspace(props: {
   config: StudioConfig;
   initialSessionId?: string;
-  onOpenProject?: () => void;
+  openProjectAction?: { label: string; onClick: () => void };
   onCompare: (ids: [string, string]) => void;
 }): React.JSX.Element {
   const [sessions, setSessions] = useState<SessionSummary[]>();
@@ -565,6 +570,8 @@ function SessionsWorkspace(props: {
   const [detail, setDetail] = useState<DebuggerSession>();
   const [failure, setFailure] = useState<string>();
   const [detailFailure, setDetailFailure] = useState<string>();
+  const sessionRowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const [focusedSessionId, setFocusedSessionId] = useState<string>();
   const [surface, setSurface] = useState<"inspector" | "catalog">(
     props.config.workspaceWorkbenchEnabled ? "inspector" : "catalog",
   );
@@ -588,6 +595,13 @@ function SessionsWorkspace(props: {
     })();
     return () => { cancelled = true; };
   }, [props.config.workspaceConnected, props.initialSessionId]);
+
+  useEffect(() => {
+    if (sessions === undefined || sessions.length === 0) return;
+    setFocusedSessionId((current) => sessions.some((session) => session.id === current)
+      ? current
+      : sessions.find((session) => session.id === props.initialSessionId)?.id ?? selected ?? sessions[0]!.id);
+  }, [props.initialSessionId, selected, sessions]);
 
   async function openSession(id: string, cancelled: () => boolean = () => false): Promise<void> {
     try {
@@ -614,8 +628,24 @@ function SessionsWorkspace(props: {
     });
   }
 
+  function moveSessionFocus(event: ReactKeyboardEvent<HTMLButtonElement>, id: string): void {
+    if (sessions === undefined || !["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    const index = Math.max(0, sessions.findIndex((session) => session.id === id));
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? sessions.length - 1
+        : event.key === "ArrowDown"
+          ? (index + 1) % sessions.length
+          : (index - 1 + sessions.length) % sessions.length;
+    const nextId = sessions[nextIndex]!.id;
+    setFocusedSessionId(nextId);
+    sessionRowRefs.current.get(nextId)?.focus();
+  }
+
   if (!props.config.workspaceConnected) {
-    return <EmptyWorkspace eyebrow="Project Sessions" title="Open a Project" detail={props.config.workspaceDiscoveryEnabled ? "Choose a remembered Project or open another local directory." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
+    return <EmptyWorkspace eyebrow="Project Sessions" title="Open a Project" detail={props.config.workspaceDiscoveryEnabled ? "Choose a remembered Project or open another local directory." : "This Studio launcher does not provide Project discovery."} action={props.openProjectAction} />;
   }
   if (failure !== undefined) {
     return <EmptyWorkspace eyebrow="Project Sessions" title="Session discovery failed" detail={failure} />;
@@ -628,8 +658,8 @@ function SessionsWorkspace(props: {
       <header><div><small>Project evidence</small><h2>Sessions</h2></div><span>{sessions.length}</span></header>
       {omittedCount > 0 && <p className="session-omissions">{omittedCount} unsupported or malformed file{omittedCount === 1 ? "" : "s"} omitted.</p>}
       <ul className="session-catalog-rows">{sessions.map((session) => <li key={session.id}>
-        <label title="Select for comparison"><input type="checkbox" checked={compareIds.has(session.id)} disabled={!compareIds.has(session.id) && compareIds.size >= 2} onChange={() => toggleCompare(session.id)} /></label>
-        <button type="button" className={selected === session.id ? "selected" : undefined} onClick={() => void openSession(session.id)}><small>{session.provider ?? "Local agent"} · {formatSessionTime(session.savedAt)}</small><strong>{session.prompt}</strong><small>{session.status} · {session.toolCallCount} calls</small></button>
+        <label title={`Select ${session.prompt} for comparison`}><input type="checkbox" aria-label={`Select ${session.prompt} from ${session.provider ?? "Local agent"} at ${formatSessionTime(session.savedAt)} for comparison`} checked={compareIds.has(session.id)} disabled={!compareIds.has(session.id) && compareIds.size >= 2} onChange={() => toggleCompare(session.id)} /></label>
+        <button ref={(node) => { if (node) sessionRowRefs.current.set(session.id, node); else sessionRowRefs.current.delete(session.id); }} type="button" tabIndex={focusedSessionId === session.id ? 0 : -1} className={selected === session.id ? "selected" : undefined} onFocus={() => setFocusedSessionId(session.id)} onKeyDown={(event) => moveSessionFocus(event, session.id)} onClick={() => { setFocusedSessionId(session.id); void openSession(session.id); }}><small>{session.provider ?? "Local agent"} · {formatSessionTime(session.savedAt)}</small><strong>{session.prompt}</strong><small>{session.status} · {session.toolCallCount} calls</small></button>
       </li>)}</ul>
       <footer><button type="button" className="primary" disabled={pair.length !== 2} onClick={() => props.onCompare(pair as [string, string])}>Compare {pair.length}/2</button></footer>
     </aside>
@@ -732,12 +762,12 @@ function formatSessionTime(value: string): string {
 }
 
 
-function DebuggerWorkspace(props: { config: StudioConfig; onOpenProject?: () => void; project?: { id: string; label: string; revision: number } }): React.JSX.Element {
+function DebuggerWorkspace(props: { config: StudioConfig; openProjectAction?: { label: string; onClick: () => void }; project?: { id: string; label: string; revision: number } }): React.JSX.Element {
   if (!props.config.aguiEnabled) {
     return <EmptyWorkspace eyebrow="Live runs" title="Load a harness for live runs" detail="The Debugger drives a live harness run over the embedded AG-UI endpoint and saves finished runs for replay." command="--harness ./my-agent.harness" />;
   }
   if (props.config.harnessMode === "workspace-default" && !props.config.projectExecutionEnabled) {
-    return <EmptyWorkspace eyebrow="Project-scoped live runs" title={props.project === undefined ? "Open a Project for live runs" : "This Project is read-only evidence"} detail={props.project === undefined ? (props.config.workspaceDiscoveryEnabled ? "Open a local Project before starting the default harness." : "This Studio launcher does not provide Project discovery.") : "Imported retained-run folders can be inspected and compared, but they do not provide a local execution root for the default harness."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
+    return <EmptyWorkspace eyebrow="Project-scoped live runs" title={props.project === undefined ? "Open a Project for live runs" : "This Project is read-only evidence"} detail={props.project === undefined ? (props.config.workspaceDiscoveryEnabled ? "Open a local Project before starting the default harness." : "This Studio launcher does not provide Project discovery.") : "Imported retained-run folders can be inspected and compared, but they do not provide a local execution root for the default harness."} action={props.openProjectAction} />;
   }
   return <div className="debugger-mode"><RunView aguiEndpoint="agui" acpEndpoint={props.config.acpEnabled ? "/agui/acp" : undefined} acpAgentLabel={props.config.acpAgentLabel} artifactEndpoint={props.config.artifactsEnabled ? "/api/artifacts" : undefined} harnessLabel={props.config.harnessMode === "workspace-default" ? "Project default · Qoder" : "Live Trial"} project={props.project} /></div>;
 }
@@ -747,17 +777,17 @@ function CompareWorkspace(props: {
   surface: StudioCompareSurface;
   navigation: ReactNode;
   sessionIds?: [string, string];
-  onOpenProject?: () => void;
+  openProjectAction?: { label: string; onClick: () => void };
 }): React.JSX.Element {
   const available = compareSurfaces(props.config);
   if (available.length === 0) {
-    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a Project with at least two Sessions" : "Open a Project"} detail={props.config.workspaceConnected ? "The selected Project needs two discovered Sessions before observational comparison is available." : props.config.workspaceDiscoveryEnabled ? "Open a local Project. Studio will discover its matching agent Sessions without startup parameters." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject === undefined ? undefined : { label: "Open Project", onClick: props.onOpenProject }} />;
+    return <EmptyWorkspace eyebrow="Session comparison" title={props.config.workspaceConnected ? "Choose a Project with at least two Sessions" : "Open a Project"} detail={props.config.workspaceConnected ? "The selected Project needs two discovered Sessions before observational comparison is available." : props.config.workspaceDiscoveryEnabled ? "Open a local Project. Studio will discover its matching agent Sessions without startup parameters." : "This Studio launcher does not provide Project discovery."} action={props.openProjectAction} />;
   }
   if (props.surface === "sessions" && props.config.sessionCount >= 2) {
     return <SessionCompareView navigation={props.navigation} initialIds={props.sessionIds} />;
   }
   if (props.surface === "bench" && props.config.experimentEnabled) {
-    return <main className="experiment-mode"><ExperimentView navigation={props.navigation} /></main>;
+    return <main className="experiment-mode"><ExperimentView historyEnabled={props.config.historyEnabled} navigation={props.navigation} /></main>;
   }
   if (props.surface === "results" && props.config.evidenceEnabled) {
     return <main className="evidence-results"><header><div><small>Frozen comparison</small><h1>Evidence results</h1></div>{props.navigation}</header><CompareView /></main>;
@@ -834,6 +864,7 @@ function SessionCompareView(props: { navigation: ReactNode; initialIds?: [string
       <p className="session-compare-boundary"><strong>No winner inferred.</strong> {comparison.boundary}</p>
       <div className="session-compare-heads"><article><small>Left</small><h2>{comparison.left.prompt}</h2><span className={`run-badge status-${comparison.left.status}`}>{comparison.left.status}</span></article><article><small>Right</small><h2>{comparison.right.prompt}</h2><span className={`run-badge status-${comparison.right.status}`}>{comparison.right.status}</span></article></div>
       <div className="session-compare-table" role="table" aria-label="Observed Session differences">
+        <div className="session-compare-columns" role="row"><strong role="columnheader">Metric</strong><strong role="columnheader">Left</strong><strong role="columnheader">Right</strong></div>
         {(["retainedEventCount", "toolCallCount", "messageCount", "warningCount"] as const).map((metric) => <div role="row" key={metric}><strong role="rowheader">{sessionMetricLabel(metric)}</strong><span role="cell">{comparison.left[metric]}</span><span role="cell">{comparison.right[metric]}</span></div>)}
       </div>
       <div className="session-tool-sequences"><section><header>Left tool sequence</header><ol>{comparison.left.toolSequence.map((tool, index) => <li key={`${tool}-${index}`}>{tool}</li>)}</ol></section><section><header>Right tool sequence</header><ol>{comparison.right.toolSequence.map((tool, index) => <li key={`${tool}-${index}`}>{tool}</li>)}</ol></section></div>

--- a/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
+++ b/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
@@ -127,14 +127,14 @@ export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.E
   });
 
   if (!props.config.artifactsEnabled) {
-    return <ArtifactEmpty title={props.config.workspaceConnected ? "No workspace artifacts are available" : "Open a project workspace"} detail={props.config.workspaceConnected
+    return <ArtifactEmpty title={props.config.workspaceConnected ? "No Project artifacts are available" : "Open a Project"} detail={props.config.workspaceConnected
       ? "Studio found no current files backed by retained change or delivery evidence."
-      : "Choose the project once; Artifacts will use the same workspace as Sessions and Commits."} />;
+      : "Open or select a Project once; Artifacts, Sessions, and Commits will share that Project context."} />;
   }
-  if (failure !== undefined) return <ArtifactEmpty title="Cannot read workspace artifacts" detail={failure} />;
-  if (catalog === undefined) return <p className="artifact-status" role="status">Indexing workspace artifacts…</p>;
+  if (failure !== undefined) return <ArtifactEmpty title="Cannot read Project artifacts" detail={failure} />;
+  if (catalog === undefined) return <p className="artifact-status" role="status">Indexing Project artifacts…</p>;
   if (catalog.artifacts.length === 0) {
-    return <ArtifactEmpty title="No changed artifacts in this workspace" detail="No current regular files are referenced by retained change or delivery evidence. Read-only and missing paths are not promoted into the Artifact catalog." />;
+    return <ArtifactEmpty title="No changed artifacts in this Project" detail="No current regular files are referenced by retained change or delivery evidence. Read-only and missing paths are not promoted into the Artifact catalog." />;
   }
 
   const active = catalog.artifacts.find((artifact) => artifact.id === selected);
@@ -150,8 +150,8 @@ export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.E
     setNarrowPane("preview");
   };
 
-  return <section className="artifact-workspace" data-narrow-pane={narrowPane} aria-label="Workspace artifacts">
-    <div className="artifact-narrow-tabs" role="tablist" aria-label="Artifact workspace panes" onKeyDown={narrowTabs.onKeyDown}>
+  return <section className="artifact-workspace" data-narrow-pane={narrowPane} aria-label="Project artifacts">
+    <div className="artifact-narrow-tabs" role="tablist" aria-label="Artifact Project panes" onKeyDown={narrowTabs.onKeyDown}>
       {(["scope", "artifacts", "preview"] as const).map((pane) => <button
         key={pane}
         type="button"
@@ -167,7 +167,7 @@ export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.E
     </div>
 
     <aside className="artifact-scope-pane" id="artifact-scope-pane" role="tabpanel" aria-labelledby="artifact-tab-scope">
-      <header><div><small>Open workspace</small><h2>{catalog.navigation?.workspaceLabel ?? "Compatibility catalog"}</h2></div><span>{catalog.artifacts.length}</span></header>
+      <header><div><small>{catalog.navigation === undefined ? "Configured source" : "Project scope"}</small><h2>{catalog.navigation === undefined ? "Compatibility catalog" : "Browse"}</h2></div><span>{catalog.artifacts.length}</span></header>
       <div className="artifact-scope-switch" role="tablist" aria-label="Artifact scope mode">
         <button type="button" role="tab" aria-selected={effectiveMode === "date"} disabled={catalog.navigation === undefined} onClick={() => setScopeMode("date")}><CalendarBlank aria-hidden="true" size={14} />Date</button>
         <button type="button" role="tab" aria-selected={effectiveMode === "files"} onClick={() => setScopeMode("files")}><TreeStructure aria-hidden="true" size={14} />Files</button>
@@ -191,7 +191,7 @@ export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.E
 
     <main className="artifact-preview-pane" id="artifact-preview-pane" role="tabpanel" aria-labelledby="artifact-tab-preview">
       {active === undefined
-        ? <p className="artifact-status" role="status">Select an Artifact to preview its current workspace revision.</p>
+        ? <p className="artifact-status" role="status">Select an Artifact to preview its current Project revision.</p>
         : <>
           <header className="artifact-editor-header">
             <div><strong title={active.label}>{basename(active.label)}</strong><small>{formatLabel(active.format)} · {formatBytes(active.size)} · {active.adapter.id} · current {shortRevision(active.revision.id)}</small></div>

--- a/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
+++ b/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
@@ -51,7 +51,7 @@ interface ArtifactDayGroup {
   sessions: ArtifactSessionGroup[];
 }
 
-export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.Element {
+export function ArtifactsWorkspace(props: { config: StudioConfig; onOpenProject?: () => void }): React.JSX.Element {
   const [catalog, setCatalog] = useState<StudioArtifactCatalogResponse>();
   const [failure, setFailure] = useState<string>();
   const [selected, setSelected] = useState<string>();
@@ -129,7 +129,7 @@ export function ArtifactsWorkspace(props: { config: StudioConfig }): React.JSX.E
   if (!props.config.artifactsEnabled) {
     return <ArtifactEmpty title={props.config.workspaceConnected ? "No Project artifacts are available" : "Open a Project"} detail={props.config.workspaceConnected
       ? "Studio found no current files backed by retained change or delivery evidence."
-      : "Open or select a Project once; Artifacts, Sessions, and Commits will share that Project context."} />;
+      : props.config.workspaceDiscoveryEnabled ? "Open a local Project once; Artifacts, Sessions, and Commits will share that Project context." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject} />;
   }
   if (failure !== undefined) return <ArtifactEmpty title="Cannot read Project artifacts" detail={failure} />;
   if (catalog === undefined) return <p className="artifact-status" role="status">Indexing Project artifacts…</p>;
@@ -311,8 +311,8 @@ function ArtifactRow(props: { artifact: ArtifactDescriptor; selected: boolean; o
   </button>;
 }
 
-function ArtifactEmpty(props: { title: string; detail: string }): React.JSX.Element {
-  return <main className="artifact-empty"><span><FolderOpen aria-hidden="true" size={22} /></span><small>Workspace artifacts</small><h1>{props.title}</h1><p>{props.detail}</p></main>;
+function ArtifactEmpty(props: { title: string; detail: string; action?: () => void }): React.JSX.Element {
+  return <main className="artifact-empty"><span><FolderOpen aria-hidden="true" size={22} /></span><small>Workspace artifacts</small><h1>{props.title}</h1><p>{props.detail}</p>{props.action && <button className="primary" type="button" onClick={props.action}>Open Project</button>}</main>;
 }
 
 function artifactDays(navigation: WorkspaceArtifactNavigation | undefined): ArtifactDayGroup[] {

--- a/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
+++ b/packages/harness-studio/src/app/ArtifactsWorkspace.tsx
@@ -51,7 +51,7 @@ interface ArtifactDayGroup {
   sessions: ArtifactSessionGroup[];
 }
 
-export function ArtifactsWorkspace(props: { config: StudioConfig; onOpenProject?: () => void }): React.JSX.Element {
+export function ArtifactsWorkspace(props: { config: StudioConfig; openProjectAction?: { label: string; onClick: () => void } }): React.JSX.Element {
   const [catalog, setCatalog] = useState<StudioArtifactCatalogResponse>();
   const [failure, setFailure] = useState<string>();
   const [selected, setSelected] = useState<string>();
@@ -129,12 +129,12 @@ export function ArtifactsWorkspace(props: { config: StudioConfig; onOpenProject?
   if (!props.config.artifactsEnabled) {
     return <ArtifactEmpty title={props.config.workspaceConnected ? "No Project artifacts are available" : "Open a Project"} detail={props.config.workspaceConnected
       ? "Studio found no current files backed by retained change or delivery evidence."
-      : props.config.workspaceDiscoveryEnabled ? "Open a local Project once; Artifacts, Sessions, and Commits will share that Project context." : "This Studio launcher does not provide Project discovery."} action={props.onOpenProject} />;
+      : props.config.workspaceDiscoveryEnabled ? "Open a local Project once; Artifacts, Sessions, and Commits will share that Project context." : "This Studio launcher does not provide Project discovery."} action={props.openProjectAction} />;
   }
   if (failure !== undefined) return <ArtifactEmpty title="Cannot read Project artifacts" detail={failure} />;
   if (catalog === undefined) return <p className="artifact-status" role="status">Indexing Project artifacts…</p>;
   if (catalog.artifacts.length === 0) {
-    return <ArtifactEmpty title="No changed artifacts in this Project" detail="No current regular files are referenced by retained change or delivery evidence. Read-only and missing paths are not promoted into the Artifact catalog." />;
+    return <ArtifactEmpty title="No changed artifacts in this Project" detail="No current regular files are referenced by retained change or delivery evidence. Read-only and missing paths are not promoted into the Artifact catalog." action={props.openProjectAction} />;
   }
 
   const active = catalog.artifacts.find((artifact) => artifact.id === selected);
@@ -311,8 +311,8 @@ function ArtifactRow(props: { artifact: ArtifactDescriptor; selected: boolean; o
   </button>;
 }
 
-function ArtifactEmpty(props: { title: string; detail: string; action?: () => void }): React.JSX.Element {
-  return <main className="artifact-empty"><span><FolderOpen aria-hidden="true" size={22} /></span><small>Workspace artifacts</small><h1>{props.title}</h1><p>{props.detail}</p>{props.action && <button className="primary" type="button" onClick={props.action}>Open Project</button>}</main>;
+function ArtifactEmpty(props: { title: string; detail: string; action?: { label: string; onClick: () => void } }): React.JSX.Element {
+  return <main className="artifact-empty"><span><FolderOpen aria-hidden="true" size={22} /></span><small>Workspace artifacts</small><h1>{props.title}</h1><p>{props.detail}</p>{props.action && <button className="primary" type="button" onClick={props.action.onClick}>{props.action.label}</button>}</main>;
 }
 
 function artifactDays(navigation: WorkspaceArtifactNavigation | undefined): ArtifactDayGroup[] {

--- a/packages/harness-studio/src/app/CustomizationView.tsx
+++ b/packages/harness-studio/src/app/CustomizationView.tsx
@@ -125,8 +125,8 @@ function CustomizationResults(props: {
           <div><strong>{host.label}</strong><small>{host.status === "ok" ? "Collected" : host.status}</small></div>
           <dl><div><dt>Definitions</dt><dd>{host.definitions}</dd></div><div><dt>Packages</dt><dd>{host.packages}</dd></div><div><dt>MCP</dt><dd>{host.registrations}</dd></div></dl>
         </li>)}</ul>
-        <footer>{catalog.runtimeObservations.map((item) => item.kind === "host-collection" && item.status === "error"
-          ? <p key={item.id}>{item.message}</p>
+        <footer aria-live="polite">{catalog.runtimeObservations.map((item) => item.kind === "host-collection" && item.status === "error"
+          ? <p key={item.id} role="alert">{item.message}</p>
           : null)}</footer>
       </aside>
       <section className="customization-definitions">

--- a/packages/harness-studio/src/app/CustomizationView.tsx
+++ b/packages/harness-studio/src/app/CustomizationView.tsx
@@ -82,7 +82,7 @@ export function CustomizationView(props: CustomizationViewProps): React.JSX.Elem
     {busy && <p className="customization-progress" role="status" aria-live="polite">Collecting Codex, Claude, and Qoder independently…</p>}
     {failure !== undefined && <p className="customization-failure" role="alert">{failure}</p>}
     {loading
-      ? <p className="customization-progress" role="status">Loading the current workspace catalog…</p>
+      ? <p className="customization-progress" role="status">Loading the current Project catalog…</p>
       : analysis === undefined
         ? <CustomizationEmpty />
         : <CustomizationResults analysis={analysis} hostsByDefinition={hostsByDefinition} />}
@@ -91,7 +91,7 @@ export function CustomizationView(props: CustomizationViewProps): React.JSX.Elem
 
 function CustomizationEmpty(): React.JSX.Element {
   return <div className="customization-empty">
-    <section><h2>Analysis starts only when requested</h2><p>Studio has not read local customization metadata for this workspace. Analyze collects recognized definitions from Codex, Claude, and Qoder while keeping native paths and private values on the server.</p></section>
+    <section><h2>Analysis starts only when requested</h2><p>Studio has not read local customization metadata for this Project. Analyze collects recognized definitions from Codex, Claude, and Qoder while keeping native paths and private values on the server.</p></section>
     <dl>
       <div><dt>Collected</dt><dd>Plugin manifests, Skills, instructions, Prompt Commands, Agent definitions, Hooks, and MCP registrations</dd></div>
       <div><dt>Not collected</dt><dd>Memory bodies, environment values, authorization headers, raw Hook commands, and MCP call results</dd></div>

--- a/packages/harness-studio/src/app/GitHistoryView.tsx
+++ b/packages/harness-studio/src/app/GitHistoryView.tsx
@@ -197,7 +197,7 @@ export function GitHistoryView(): React.JSX.Element {
   const canLoadMore = hasMore && !loading && loadedLogKey === logQueryKey;
   return <main className="git-history-workbench" data-narrow-pane={narrowPane}>
     <header className="git-history-titlebar">
-      <div><GitCommit aria-hidden="true" size={18} weight="fill" /><span><strong>Commit history</strong><small>{refs?.repository.label ?? "Open workspace"}</small></span></div>
+      <div><GitCommit aria-hidden="true" size={18} weight="fill" /><span><strong>Commit history</strong><small>Repository evidence</small></span></div>
       {refs !== undefined && <span className="git-current-branch"><GitBranch aria-hidden="true" size={14} /><strong>{refs.repository.currentBranch ?? "Detached HEAD"}</strong><code>{refs.repository.headSha?.slice(0, 8) ?? "no commits"}</code></span>}
       <button type="button" title="Refresh Git history" aria-label="Refresh Git history" disabled={loading || refsLoading} onClick={() => setRevision((value) => value + 1)}><ArrowClockwise aria-hidden="true" size={15} className={loading || refsLoading ? "spin" : undefined} /></button>
     </header>

--- a/packages/harness-studio/src/app/InputTraceView.tsx
+++ b/packages/harness-studio/src/app/InputTraceView.tsx
@@ -161,7 +161,7 @@ export function InputTraceView(props: { intentAnalysisEnabled: boolean }): React
         </div>}
     </aside>
     <section className={`input-list-pane${trace.summary.truncatedSessionCount > 0 ? " has-boundary" : ""}${analysis !== undefined || analysisFailure !== undefined ? " has-analysis" : ""}`} aria-label="Retained user inputs">
-      <header><div><strong>{trace.workspace.label}</strong><span>Retained inputs and exact observed file operations</span></div>{selectedPath !== undefined && <button type="button" onClick={() => setSelectedPath(undefined)}><X aria-hidden="true" size={13} />{selectedPath}</button>}</header>
+      <header><div><strong>Retained inputs</strong><span>Exact observed file operations</span></div>{selectedPath !== undefined && <button type="button" onClick={() => setSelectedPath(undefined)}><X aria-hidden="true" size={13} />{selectedPath}</button>}</header>
       {trace.summary.truncatedSessionCount > 0 && <p className="input-trace-boundary">{trace.summary.truncatedSessionCount} Session{trace.summary.truncatedSessionCount === 1 ? " was" : "s were"} truncated by retained dialogue limits.</p>}
       {(analysis !== undefined || analysisFailure !== undefined) && <IntentAnalysisPane analysis={analysis} failure={analysisFailure} onClose={() => { setAnalysis(undefined); setAnalysisFailure(undefined); }} />}
       {visibleInputs.length === 0

--- a/packages/harness-studio/src/app/artifacts/AgentReactHostServices.ts
+++ b/packages/harness-studio/src/app/artifacts/AgentReactHostServices.ts
@@ -1,0 +1,100 @@
+import type { AgentReactBuildMetadata } from "../../contracts/artifact.js";
+
+export const AGENT_REACT_SHOW_SOURCE_ACTION = "studio.show-source";
+export const AGENT_REACT_ALLOWED_ACTIONS = Object.freeze([AGENT_REACT_SHOW_SOURCE_ACTION]);
+
+export interface AgentReactStateSlot {
+  readonly schema: string;
+  readonly version: number;
+  readonly value: unknown;
+}
+
+export interface AgentReactStagedState {
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly slots: ReadonlyMap<string, AgentReactStateSlot>;
+}
+
+export function stageAgentReactState(
+  declarations: AgentReactBuildMetadata["view"]["state"],
+  current: ReadonlyMap<string, AgentReactStateSlot>,
+): AgentReactStagedState {
+  const slots = new Map<string, AgentReactStateSlot>();
+  for (const declaration of declarations) {
+    const retained = current.get(declaration.path);
+    const value = retained?.schema === declaration.schema && retained.version === declaration.version
+      ? retained.value
+      : initialState(declaration.schema, declaration.version);
+    slots.set(declaration.path, {
+      schema: declaration.schema,
+      version: declaration.version,
+      value: cloneAgentReactValue(value),
+    });
+  }
+  return {
+    slots,
+    values: Object.freeze(Object.fromEntries([...slots].map(([path, slot]) => [path, slot.value]))),
+  };
+}
+
+export function validateAgentReactStateValue(
+  schema: string,
+  version: number,
+  value: unknown,
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly reason: string } {
+  if (version !== 1 || !["json", "list", "record"].includes(schema)) {
+    return { ok: false, reason: `State schema '${schema}@${version}' is not provided by this Studio Host.` };
+  }
+  let owned: unknown;
+  try {
+    owned = cloneAgentReactValue(value);
+  } catch {
+    return { ok: false, reason: "Artifact state must be structured-cloneable JSON data." };
+  }
+  if (!isJsonValue(owned)) return { ok: false, reason: "Artifact state must contain only finite JSON values." };
+  if (schema === "list" && !Array.isArray(owned)) return { ok: false, reason: "State schema 'list@1' requires an array." };
+  if (schema === "record" && !isPlainRecord(owned)) return { ok: false, reason: "State schema 'record@1' requires an object." };
+  return { ok: true, value: owned };
+}
+
+export function grantedAgentReactCapabilities(requested: readonly string[]): readonly string[] {
+  return [...new Set(requested)].filter((capability) => AGENT_REACT_ALLOWED_ACTIONS.includes(capability)).sort();
+}
+
+export function isAgentReactFrameRequest(value: unknown): value is Record<string, unknown> & {
+  type: "state.set" | "action.request";
+  buildDigest: string;
+  frameToken: string;
+  requestId: number;
+} {
+  if (typeof value !== "object" || value === null) return false;
+  const message = value as Record<string, unknown>;
+  return (message.type === "state.set" || message.type === "action.request")
+    && typeof message.buildDigest === "string"
+    && typeof message.frameToken === "string"
+    && Number.isSafeInteger(message.requestId)
+    && Number(message.requestId) > 0;
+}
+
+function initialState(schema: string, version: number): unknown {
+  if (version !== 1) return null;
+  if (schema === "list") return [];
+  if (schema === "record") return {};
+  return null;
+}
+
+function cloneAgentReactValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function isJsonValue(value: unknown): boolean {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isPlainRecord(value) && Object.values(value).every(isJsonValue);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/harness-studio/src/app/artifacts/AgentReactPreviewHost.tsx
+++ b/packages/harness-studio/src/app/artifacts/AgentReactPreviewHost.tsx
@@ -1,0 +1,415 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  isArtifactBuildSnapshot,
+  type ArtifactBuildSnapshot,
+  type ArtifactDescriptor,
+} from "../../contracts/artifact.js";
+import { ArtifactCodeView } from "../code/ArtifactCodeView.js";
+import { useRovingTablist } from "../roving-tablist.js";
+import { studioApiError } from "../studio-api.js";
+import { useStudioTheme } from "../studio-theme.js";
+import {
+  AGENT_REACT_SHOW_SOURCE_ACTION,
+  grantedAgentReactCapabilities,
+  isAgentReactFrameRequest,
+  stageAgentReactState,
+  type AgentReactStateSlot,
+  validateAgentReactStateValue,
+} from "./AgentReactHostServices.js";
+
+type PreviewState = "compiling" | "starting" | "ready" | "compile-failed" | "runtime-failed";
+type PreviewSurface = "preview" | "source";
+
+const HANDSHAKE_TIMEOUT_MS = 10_000;
+const PANEL_ID = "agent-react-preview-panel";
+const OBSERVATION_EVENT = "harness.artifact-observation";
+
+interface FrameSession {
+  readonly build: ArtifactBuildSnapshot;
+  readonly channel: MessageChannel;
+  readonly frameToken: string;
+  readonly generation: number;
+  mode: "dry-run" | "live";
+  stateSlots: Map<string, AgentReactStateSlot>;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+/** Production AgentReact Surface: one visible Current plus one hidden Staging frame. */
+export function AgentReactPreviewHost(props: {
+  artifact: ArtifactDescriptor;
+  liveGeneration: number;
+}): React.JSX.Element {
+  const [surface, setSurface] = useState<PreviewSurface>("preview");
+  const [current, setCurrent] = useState<ArtifactBuildSnapshot>();
+  const [staging, setStaging] = useState<ArtifactBuildSnapshot>();
+  const [previewState, setPreviewState] = useState<PreviewState>("compiling");
+  const [failure, setFailure] = useState<string>();
+  const [source, setSource] = useState<string>();
+  const [attempt, setAttempt] = useState(0);
+  const frames = useRef(new Map<string, HTMLIFrameElement>());
+  const sessions = useRef(new Map<string, FrameSession>());
+  const initializeFrameRef = useRef<(build: ArtifactBuildSnapshot) => void>(() => undefined);
+  const currentRef = useRef<ArtifactBuildSnapshot | undefined>(undefined);
+  const stagingRef = useRef<ArtifactBuildSnapshot | undefined>(undefined);
+  const stateSlots = useRef(new Map<string, AgentReactStateSlot>());
+  const generation = useRef(0);
+  const observationSequence = useRef(0);
+  const theme = useStudioTheme();
+  const tablist = useRovingTablist<PreviewSurface>({
+    ids: ["preview", "source"],
+    active: surface,
+    onSelect: setSurface,
+    panelId: PANEL_ID,
+  });
+
+  const record = (build: ArtifactBuildSnapshot, kind: string, detail?: Record<string, unknown>): void => {
+    observationSequence.current += 1;
+    window.dispatchEvent(new CustomEvent(OBSERVATION_EVENT, { detail: {
+      type: "CUSTOM",
+      name: OBSERVATION_EVENT,
+      value: {
+        kind,
+        sequence: observationSequence.current,
+        artifactDigest: build.agentReact!.artifactDigest,
+        buildDigest: build.agentReact!.buildDigest,
+        ...(detail === undefined ? {} : { detail }),
+      },
+    } }));
+  };
+
+  const closeSession = (buildId: string): void => {
+    const session = sessions.current.get(buildId);
+    if (session === undefined) return;
+    clearTimeout(session.timeout);
+    session.channel.port1.close();
+    session.channel.port2.close();
+    sessions.current.delete(buildId);
+  };
+
+  const rejectStaging = (build: ArtifactBuildSnapshot, reason: string): void => {
+    if (stagingRef.current?.buildId !== build.buildId) return;
+    closeSession(build.buildId);
+    stagingRef.current = undefined;
+    setStaging(undefined);
+    setPreviewState("runtime-failed");
+    setFailure(reason);
+    record(build, "renderFailed", { phase: "staging", reason });
+    if (currentRef.current === undefined) setSurface("source");
+  };
+
+  const failCurrent = (build: ArtifactBuildSnapshot, reason: string): void => {
+    if (currentRef.current?.buildId !== build.buildId) return;
+    closeSession(build.buildId);
+    currentRef.current = undefined;
+    setCurrent(undefined);
+    setPreviewState("runtime-failed");
+    setFailure(reason);
+    setSurface("source");
+    record(build, "renderFailed", { phase: "current", reason });
+  };
+
+  const promote = (session: FrameSession): void => {
+    if (stagingRef.current?.buildId !== session.build.buildId || session.generation !== generation.current) return;
+    clearTimeout(session.timeout);
+    session.timeout = undefined;
+    const outgoing = currentRef.current;
+    stateSlots.current = new Map(session.stateSlots);
+    session.mode = "live";
+    session.channel.port1.postMessage({
+      type: "runtime.promote",
+      buildDigest: session.build.agentReact!.buildDigest,
+      frameToken: session.frameToken,
+    });
+    currentRef.current = session.build;
+    stagingRef.current = undefined;
+    setCurrent(session.build);
+    setStaging(undefined);
+    setPreviewState("ready");
+    setFailure(undefined);
+    record(session.build, "renderCompleted", { phase: "committed" });
+    if (outgoing !== undefined && outgoing.buildId !== session.build.buildId) closeSession(outgoing.buildId);
+  };
+
+  const postResult = (session: FrameSession, message: Record<string, unknown>): void => {
+    session.channel.port1.postMessage({
+      ...message,
+      buildDigest: session.build.agentReact!.buildDigest,
+      frameToken: session.frameToken,
+    });
+  };
+
+  const handleStateSet = (session: FrameSession, message: Record<string, unknown>): void => {
+    const requestId = Number(message.requestId);
+    const path = message.path;
+    if (typeof path !== "string") return;
+    const declaration = session.build.agentReact!.view.state.find((entry) => entry.path === path);
+    if (session.mode !== "live" || currentRef.current?.buildId !== session.build.buildId) {
+      postResult(session, { type: "state.result", requestId, path, ok: false, reason: "A staging or stale frame cannot write Artifact state." });
+      record(session.build, "stateValidationFailed", { path, reason: "not-live" });
+      return;
+    }
+    if (declaration === undefined) {
+      postResult(session, { type: "state.result", requestId, path, ok: false, reason: "State path is not declared." });
+      record(session.build, "stateValidationFailed", { path, reason: "not-declared" });
+      return;
+    }
+    const validated = validateAgentReactStateValue(declaration.schema, declaration.version, message.value);
+    if (!validated.ok) {
+      postResult(session, { type: "state.result", requestId, path, ok: false, reason: validated.reason });
+      record(session.build, "stateValidationFailed", { path, reason: validated.reason });
+      return;
+    }
+    const slot = { schema: declaration.schema, version: declaration.version, value: validated.value };
+    session.stateSlots.set(path, slot);
+    stateSlots.current.set(path, slot);
+    postResult(session, { type: "state.result", requestId, path, ok: true, value: validated.value });
+  };
+
+  const handleAction = (session: FrameSession, message: Record<string, unknown>): void => {
+    const requestId = Number(message.requestId);
+    const capability = message.capability;
+    if (typeof capability !== "string") return;
+    record(session.build, "actionAttempted", { capability, actionMode: session.mode });
+    const declared = session.build.agentReact!.view.capabilities.includes(capability);
+    const granted = grantedAgentReactCapabilities(session.build.agentReact!.view.capabilities).includes(capability);
+    if (!declared || !granted) {
+      const reason = !declared ? "Action capability is not declared by this build." : "Action capability is refused by Host policy.";
+      postResult(session, { type: "action.result", requestId, outcome: { status: "denied", reason } });
+      record(session.build, "actionDenied", { capability, reason });
+      return;
+    }
+    if (session.mode === "dry-run") {
+      postResult(session, { type: "action.result", requestId, outcome: { status: "dry-run" } });
+      return;
+    }
+    if (currentRef.current?.buildId !== session.build.buildId) {
+      const reason = "Action frame is stale.";
+      postResult(session, { type: "action.result", requestId, outcome: { status: "denied", reason } });
+      record(session.build, "actionDenied", { capability, reason });
+      return;
+    }
+    if (capability === AGENT_REACT_SHOW_SOURCE_ACTION) {
+      setSurface("source");
+      postResult(session, { type: "action.result", requestId, outcome: { status: "completed", result: { surface: "source" } } });
+    }
+  };
+
+  const initializeFrame = (build: ArtifactBuildSnapshot): void => {
+    if (stagingRef.current?.buildId !== build.buildId || build.agentReact === undefined) return;
+    const frame = frames.current.get(build.buildId);
+    if (frame?.contentWindow == null) return;
+    // The child can announce readiness more than once across browser lifecycle
+    // events. A build owns exactly one channel, so duplicate readiness must not
+    // invalidate the port that is already executing the verified bundle.
+    if (sessions.current.has(build.buildId)) return;
+    const channel = new MessageChannel();
+    const staged = stageAgentReactState(build.agentReact.view.state, stateSlots.current);
+    const session: FrameSession = {
+      build,
+      channel,
+      frameToken: crypto.randomUUID(),
+      generation: generation.current,
+      mode: "dry-run",
+      stateSlots: new Map(staged.slots),
+    };
+    sessions.current.set(build.buildId, session);
+    channel.port1.onmessage = (event: MessageEvent<unknown>) => {
+      const message = event.data;
+      if (isRuntimeReport(message, build, session.frameToken)) {
+        if (message.type === "renderCompleted") {
+          if (session.mode === "dry-run") {
+            record(build, "renderCompleted", { phase: "staging" });
+            promote(session);
+          }
+        } else if (session.mode === "live") {
+          failCurrent(build, message.message ?? "The committed AgentReact build failed at runtime.");
+        } else {
+          rejectStaging(build, message.message ?? "AgentReact preview failed at runtime.");
+        }
+        return;
+      }
+      if (!isAgentReactFrameRequest(message)
+        || message.buildDigest !== build.agentReact!.buildDigest
+        || message.frameToken !== session.frameToken) return;
+      if (message.type === "state.set") handleStateSet(session, message);
+      else handleAction(session, message);
+    };
+    channel.port1.start();
+    session.timeout = setTimeout(() => rejectStaging(build, "The AgentReact staging frame did not report a render before its deadline."), HANDSHAKE_TIMEOUT_MS);
+    frame.contentWindow.postMessage({
+      type: "runtime.init",
+      artifactId: build.artifactId,
+      revisionId: build.revisionId,
+      buildId: build.buildId,
+      runtimeId: build.runtime.id,
+      agentReact: build.agentReact,
+      frameToken: session.frameToken,
+      actionMode: "dry-run",
+      state: staged.values,
+      grantedCapabilities: grantedAgentReactCapabilities(build.agentReact.view.capabilities),
+      theme,
+    }, "*", [channel.port2]);
+  };
+  initializeFrameRef.current = initializeFrame;
+
+  useEffect(() => {
+    const acceptReadyFrame = (event: MessageEvent<unknown>): void => {
+      const build = stagingRef.current;
+      if (build === undefined || !isRuntimeReady(event.data, build)) return;
+      const frame = frames.current.get(build.buildId);
+      if (frame?.contentWindow == null || event.source !== frame.contentWindow) return;
+      initializeFrameRef.current(build);
+    };
+    window.addEventListener("message", acceptReadyFrame);
+    return () => window.removeEventListener("message", acceptReadyFrame);
+  }, []);
+
+  useEffect(() => {
+    const buildUri = props.artifact.build?.snapshotUri;
+    const controller = new AbortController();
+    generation.current += 1;
+    const mine = generation.current;
+    if (stagingRef.current !== undefined
+      && stagingRef.current.buildId !== currentRef.current?.buildId) closeSession(stagingRef.current.buildId);
+    stagingRef.current = undefined;
+    setStaging(undefined);
+    setPreviewState("compiling");
+    setFailure(undefined);
+    if (buildUri === undefined) {
+      setPreviewState("compile-failed");
+      setFailure("The AgentReact Artifact has no build reference.");
+      return () => controller.abort();
+    }
+    void fetch(buildUri, { signal: controller.signal, cache: "no-store" }).then(async (response) => {
+      if (!response.ok) throw new Error(await studioApiError(response));
+      const value: unknown = await response.json();
+      if (!isArtifactBuildSnapshot(value)
+        || value.artifactId !== props.artifact.id
+        || value.revisionId !== props.artifact.revision.id
+        || (value.status === "ready" && value.agentReact === undefined)) {
+        throw new Error("AgentReact build snapshot contract is unsupported.");
+      }
+      if (mine !== generation.current) return;
+      if (value.status === "failed") {
+        setPreviewState("compile-failed");
+        setFailure(value.diagnostics[0]?.message ?? "AgentReact compilation failed.");
+        if (currentRef.current === undefined) setSurface("source");
+        return;
+      }
+      if (currentRef.current?.buildId === value.buildId) {
+        stagingRef.current = undefined;
+        setStaging(undefined);
+        setPreviewState("ready");
+        setFailure(undefined);
+        return;
+      }
+      stagingRef.current = value;
+      setStaging(value);
+      setPreviewState("starting");
+    }).catch((error: unknown) => {
+      if (controller.signal.aborted || mine !== generation.current) return;
+      setPreviewState("compile-failed");
+      setFailure(error instanceof Error ? error.message : String(error));
+      if (currentRef.current === undefined) setSurface("source");
+    });
+    return () => controller.abort();
+  }, [props.artifact.build?.snapshotUri, props.artifact.id, props.artifact.revision.id, props.liveGeneration, attempt]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setSource(undefined);
+    void fetch(props.artifact.revision.content.uri, { signal: controller.signal }).then(async (response) => {
+      if (!response.ok) throw new Error(`Artifact source failed (${response.status}).`);
+      setSource(await response.text());
+    }).catch((error: unknown) => {
+      if (!controller.signal.aborted) setFailure(error instanceof Error ? error.message : String(error));
+    });
+    return () => controller.abort();
+  }, [props.artifact.id, props.artifact.revision.content.uri, props.artifact.revision.id]);
+
+  useEffect(() => {
+    for (const session of sessions.current.values()) session.channel.port1.postMessage({ type: "runtime.theme", theme });
+  }, [theme]);
+
+  useEffect(() => () => {
+    generation.current += 1;
+    for (const buildId of [...sessions.current.keys()]) closeSession(buildId);
+  }, []);
+
+  const builds = [current, staging].filter((build, index, all): build is ArtifactBuildSnapshot =>
+    build !== undefined && all.findIndex((candidate) => candidate?.buildId === build.buildId) === index);
+  const displayedBuild = staging ?? current;
+
+  return <section className="artifact-runtime-host agent-react-runtime-host" aria-label={`AgentReact view: ${props.artifact.label}`}>
+    <div className="artifact-runtime-header">
+      <div className="artifact-runtime-tabs" aria-label="Artifact view mode" {...tablist.tablistProps}>
+        <button type="button" {...tablist.getTabProps("preview")} onClick={() => setSurface("preview")}>Preview</button>
+        <button type="button" {...tablist.getTabProps("source")} onClick={() => setSurface("source")}>Source</button>
+      </div>
+      <span>{displayedBuild === undefined ? "No build" : `${displayedBuild.agentReact?.view.id ?? "AgentReact"} · build ${displayedBuild.sequence}`}</span>
+    </div>
+    <div className="artifact-runtime-panel agent-react-runtime-panel" id={PANEL_ID} role="tabpanel">
+      {builds.map((build) => <iframe
+        key={build.buildId}
+        ref={(element) => {
+          if (element === null) frames.current.delete(build.buildId);
+          else frames.current.set(build.buildId, element);
+        }}
+        className={`artifact-frame artifact-runtime-frame agent-react-frame${build.buildId === current?.buildId && surface === "preview" ? " is-current" : " is-staging"}`}
+        title={`${build.buildId === staging?.buildId ? "Staging" : "Live"} AgentReact preview: ${props.artifact.label}`}
+        src={build.previewUri}
+        sandbox="allow-scripts"
+        referrerPolicy="no-referrer"
+        aria-hidden={build.buildId !== current?.buildId || surface !== "preview"}
+      />)}
+      {surface === "source" && (source === undefined
+        ? <p className="artifact-status" role="status">Loading source…</p>
+        : <ArtifactCodeView mode="source" content={source} sourceHint={props.artifact.label} className="artifact-code-preview" label={`Artifact source: ${props.artifact.label}`} />)}
+      {surface === "preview" && current === undefined && <p className="artifact-status agent-react-starting" role="status">{failure ?? "Verifying AgentReact build in an isolated staging frame…"}</p>}
+    </div>
+    <div className={`artifact-runtime-status state-${previewState}`} role={previewState.endsWith("failed") ? "alert" : "status"} aria-live="polite">
+      <span>{statusText(previewState, failure, current !== undefined)}</span>
+      {previewState.endsWith("failed") && <button type="button" className="artifact-runtime-retry" onClick={() => setAttempt((value) => value + 1)}>Retry</button>}
+    </div>
+  </section>;
+}
+
+function isRuntimeReady(value: unknown, build: ArtifactBuildSnapshot): boolean {
+  if (typeof value !== "object" || value === null || build.agentReact === undefined) return false;
+  const message = value as Record<string, unknown>;
+  return message.type === "runtime.ready"
+    && message.artifactId === build.artifactId
+    && message.revisionId === build.revisionId
+    && message.buildId === build.buildId
+    && message.runtimeId === build.runtime.id
+    && message.agentReact !== null
+    && typeof message.agentReact === "object"
+    && (message.agentReact as Record<string, unknown>).buildDigest === build.agentReact.buildDigest;
+}
+
+function isRuntimeReport(
+  value: unknown,
+  build: ArtifactBuildSnapshot,
+  frameToken: string,
+): value is { type: "renderCompleted" | "renderFailed"; message?: string } {
+  if (typeof value !== "object" || value === null) return false;
+  const message = value as Record<string, unknown>;
+  return (message.type === "renderCompleted" || message.type === "renderFailed")
+    && message.artifactId === build.artifactId
+    && message.revisionId === build.revisionId
+    && message.buildId === build.buildId
+    && message.runtimeId === build.runtime.id
+    && message.frameToken === frameToken
+    && message.agentReact !== null
+    && typeof message.agentReact === "object"
+    && (message.agentReact as Record<string, unknown>).buildDigest === build.agentReact?.buildDigest
+    && (message.message === undefined || typeof message.message === "string");
+}
+
+function statusText(state: PreviewState, failure: string | undefined, retained: boolean): string {
+  if (state === "compiling") return retained ? "Compiling the next AgentReact revision; Current remains live." : "Compiling AgentReact revision…";
+  if (state === "starting") return retained ? "Verifying the next build; Current remains live." : "Verifying AgentReact staging frame…";
+  if (state === "ready") return "AgentReact build committed from isolated staging.";
+  if (failure !== undefined && retained) return `${failure} Current remains on the last verified build.`;
+  return failure ?? "AgentReact build failed.";
+}

--- a/packages/harness-studio/src/app/artifacts/ArtifactSurfaceRegistry.tsx
+++ b/packages/harness-studio/src/app/artifacts/ArtifactSurfaceRegistry.tsx
@@ -1,5 +1,6 @@
 import type { ArtifactDescriptor } from "../../contracts/artifact.js";
 import { ArtifactPreviewHost } from "./ArtifactPreviewHost.js";
+import { AgentReactPreviewHost } from "./AgentReactPreviewHost.js";
 import { MarkdownArtifactView } from "./MarkdownArtifactView.js";
 import { DocxArtifactView } from "./docx/DocxArtifactView.js";
 import { ExternalHostedArtifactView } from "./ExternalHostedArtifactView.js";
@@ -27,6 +28,13 @@ export function normalizeArtifactSurfaceKind(artifact: ArtifactDescriptor): Arti
 const TEXT_RENDERER_IDS = new Set(["studio.code", "studio.diff", "studio.json", "studio.text"]);
 
 export const ARTIFACT_SURFACE_MOUNTS: readonly ArtifactSurfaceMount[] = Object.freeze([
+  {
+    id: "studio.agent-react-preview",
+    matches: (artifact) => normalizeArtifactSurfaceKind(artifact) === "studio-sandbox"
+      && artifact.backing === "code"
+      && artifact.renderer.id === "studio.agent-react-preview",
+    Component: AgentReactPreviewHost,
+  },
   {
     id: "studio.sandboxed-preview",
     matches: (artifact) => normalizeArtifactSurfaceKind(artifact) === "studio-sandbox" && artifact.backing === "code",

--- a/packages/harness-studio/src/app/experiment/ExperimentBuilder.tsx
+++ b/packages/harness-studio/src/app/experiment/ExperimentBuilder.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import {
   canLockCompare,
+  isExperimentRunnable,
   type CheckpointHistoryPreview,
   type ExperimentSetupPreview,
   type ResolvedHistoryDraftPreview,
@@ -40,7 +41,8 @@ export function ExperimentBuilder(props: {
   const selectedHistoryLocked = props.preview.lock !== undefined
     && historyRequiresDraft
     && props.preview.lock.historyId === props.selectedHistoryId;
-  const canOpenWorkbench = selectedHistoryLocked || loadedDefinition;
+  const runnable = isExperimentRunnable(setup);
+  const canOpenWorkbench = runnable && (selectedHistoryLocked || loadedDefinition);
   const facts = [source.resource, source.revision, ...(source.history ? [source.history] : []), source.materialization];
   const executeRuns = props.preview.manifest.lanes.filter((lane) => lane.origin === "execute");
   const treatment = deriveTreatmentSummary(props.preview);
@@ -56,10 +58,12 @@ export function ExperimentBuilder(props: {
   const actionEnabled = (lockable || canOpenWorkbench) && !busy;
   const actionLabel = props.historyAction.phase === "locking"
     ? "Locking…"
+    : !runnable
+      ? "Checkpoint unavailable"
     : canOpenWorkbench
       ? "Open workbench"
       : "Lock and compare";
-  const status = builderStatus(props.history, props.historyAction, lockable, canOpenWorkbench);
+  const status = builderStatus(props.history, props.historyAction, lockable, canOpenWorkbench, runnable, source.limitation);
 
   return <section className="builder-shell">
     <header className="builder-topbar">
@@ -161,11 +165,14 @@ function builderStatus(
   action: HistoryActionState,
   lockable: boolean,
   canOpenWorkbench: boolean,
+  runnable: boolean,
+  limitation?: string,
 ): { title: string; detail: string } {
   if (action.phase === "locking") return { title: "Locking comparison…", detail: "Writing the immutable request and checkpoint definition." };
   if (action.phase === "error") return { title: "Comparison not ready", detail: action.detail };
   if (history.phase === "loading") return { title: "Checking project history", detail: "The lock action will appear after history is ready." };
   if (history.phase === "error") return { title: "Project history unavailable", detail: history.detail };
+  if (!runnable) return { title: "Comparison blocked", detail: limitation ?? "The checkpoint source cannot create isolated fresh runs." };
   if (canOpenWorkbench) return { title: "Comparison ready", detail: "Isolated copies are created only when Run starts." };
   if (lockable) return { title: "Ready to compare", detail: "Lock the selected request and checkpoint before opening the workbench." };
   return { title: "Choose a valid request", detail: "Resolve a request with a valid checkpoint and at least one fresh run." };

--- a/packages/harness-studio/src/app/experiment/ExperimentView.tsx
+++ b/packages/harness-studio/src/app/experiment/ExperimentView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import type { CheckpointHistoryPreview, ResolvedHistoryDraftPreview } from "../../contracts/experiment-setup.js";
+import { isExperimentRunnable, type CheckpointHistoryPreview, type ResolvedHistoryDraftPreview } from "../../contracts/experiment-setup.js";
 import { applyLaneEvent, emptyLane, globalStreamFailure, mergeCallPage } from "./experiment-comparison-model.js";
 import { ExperimentBuilder, type HistoryActionState, type HistoryLoadState } from "./ExperimentBuilder.js";
 import { ExperimentWorkbench } from "./ExperimentWorkbench.js";
@@ -20,7 +20,7 @@ type LoadState =
   | { phase: "error"; detail: string }
   | { phase: "ready"; preview: ExperimentPreview };
 
-export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JSX.Element {
+export function ExperimentView(props: { historyEnabled?: boolean; navigation?: ReactNode } = {}): React.JSX.Element {
   const [load, setLoad] = useState<LoadState>({ phase: "loading" });
   const [lanes, setLanes] = useState<Record<string, LaneTrace>>({});
   const [selection, setSelection] = useState<Selection | null>(null);
@@ -39,7 +39,9 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
   const [submittedPrompt, setSubmittedPrompt] = useState<string | null>(null);
   const [runError, setRunError] = useState<string>();
   const [agentIds, setAgentIds] = useState<Record<string, string>>({});
-  const [history, setHistory] = useState<HistoryLoadState>({ phase: "loading" });
+  const [history, setHistory] = useState<HistoryLoadState>(props.historyEnabled === false
+    ? { phase: "disabled" }
+    : { phase: "loading" });
   const [historyId, setHistoryId] = useState<string | null>(null);
   const [historyDraft, setHistoryDraft] = useState<ResolvedHistoryDraftPreview | null>(null);
   const [historyAction, setHistoryAction] = useState<HistoryActionState>({ phase: "idle" });
@@ -57,6 +59,10 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
         initializePreview(payload);
       } catch (error) {
         if (!cancelled) setLoad({ phase: "error", detail: error instanceof Error ? error.message : String(error) });
+        return;
+      }
+      if (props.historyEnabled === false) {
+        setHistory({ phase: "disabled" });
         return;
       }
       try {
@@ -78,7 +84,7 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
       }
     })();
     return () => { cancelled = true; abortRef.current?.abort(); };
-  }, []);
+  }, [props.historyEnabled]);
 
   useEffect(() => {
     const media = globalThis.matchMedia?.("(max-width: 1080px)");
@@ -113,8 +119,9 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
     setPrompt(payload.setup.request.prompt);
     setSubmittedPrompt(null);
     setRunError(undefined);
-    const defaultAgentId = payload.acpAgents?.defaultAgentId ?? "";
-    setAgentIds(Object.fromEntries(fresh.map((lane) => [lane.id, defaultAgentId])));
+    const acpHosted = payload.manifest.runtime?.host === "acp";
+    const defaultAgentId = acpHosted ? payload.acpAgents?.defaultAgentId ?? "" : "";
+    setAgentIds(acpHosted ? Object.fromEntries(fresh.map((lane) => [lane.id, defaultAgentId])) : {});
   }
 
   async function loadMoreCalls(laneId: string): Promise<void> {
@@ -177,7 +184,7 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
 
   async function lockBuilder(): Promise<void> {
     if (history.phase === "disabled") {
-      setSurface("workbench");
+      if (load.phase === "ready" && isExperimentRunnable(load.preview.setup)) setSurface("workbench");
       return;
     }
     if (history.phase !== "ready" || historyId === null || historyDraft?.selection.id !== historyId) return;
@@ -223,6 +230,12 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
   }
 
   async function runExperiment(): Promise<void> {
+    if (load.phase !== "ready" || !isExperimentRunnable(load.preview.setup)) {
+      setRunError(load.phase === "ready"
+        ? load.preview.setup.checkpointSource.limitation ?? "The checkpoint source cannot create isolated fresh runs."
+        : "Comparison setup is not ready.");
+      return;
+    }
     const nextId = `exp_${globalThis.crypto.randomUUID().replaceAll("-", "")}`;
     const controller = new AbortController();
     abortRef.current = controller;
@@ -240,7 +253,11 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
       const response = await fetch("api/experiment/runs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ experimentId: nextId, prompt, agentIds }),
+        body: JSON.stringify({
+          experimentId: nextId,
+          prompt,
+          ...(load.preview.manifest.runtime?.host === "acp" ? { agentIds } : {}),
+        }),
         signal: controller.signal,
       });
       if (!response.ok || response.body === null) {
@@ -359,6 +376,7 @@ export function ExperimentView(props: { navigation?: ReactNode } = {}): React.JS
       onCancel={() => void cancelExperiment()}
       onPermission={(laneId, runId, requestId, optionId) =>
         void decidePermission(laneId, runId, requestId, optionId)}
+      onSetup={() => setSurface("builder")}
       onAdvanced={() => setSurface("workbench")}
     />;
   }

--- a/packages/harness-studio/src/app/experiment/ExperimentWorkbench.tsx
+++ b/packages/harness-studio/src/app/experiment/ExperimentWorkbench.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { useRovingTablist } from "../roving-tablist.js";
 import type { ExperimentToolCall } from "../../contracts/experiment-stream-contract.js";
+import { isExperimentRunnable } from "../../contracts/experiment-setup.js";
 import {
   activityPhaseSequence,
   alignToolCalls,
@@ -97,7 +98,18 @@ export function ExperimentWorkbench(props: {
   const freshDefinitions = props.preview.manifest.lanes.filter((lane) => lane.origin === "execute");
   const harnesses = [...new Set(freshDefinitions.map((lane) => lane.harnessId ?? "unknown"))].join(" · ");
   const runtimes = [...new Set(freshDefinitions.map((lane) => laneIdentityLabel(lane)))].join(" ↔ ");
-  const selectedAgents = [props.agentIds?.[props.baselineId], props.agentIds?.[props.candidateId]].filter(Boolean).join(" ↔ ");
+  const agentLabels = new Map((props.preview.acpAgents?.agents ?? []).map((agent) => [agent.id, agent.label]));
+  const selectedAgents = [props.agentIds?.[props.baselineId], props.agentIds?.[props.candidateId]]
+    .filter((id): id is string => typeof id === "string" && id !== "")
+    .map((id) => agentLabels.get(id) ?? id)
+    .join(" ↔ ");
+  const acpHosted = props.preview.manifest.runtime?.host === "acp";
+  const executionIdentity = acpHosted ? selectedAgents || "ACP Agent unavailable" : `Qoder · ${runtimes || "runtime unavailable"}`;
+  const runnable = isExperimentRunnable(props.preview.setup);
+  const runState = props.running ? "Streaming" : runnable ? "Ready" : "Blocked";
+  const runDetail = runnable
+    ? `Fresh ${acpHosted ? "ACP " : "Qoder "}runs execute from the shared checkpoint; the recorded run remains Reference evidence.`
+    : props.preview.setup.checkpointSource.limitation ?? "Fresh runs are blocked because the checkpoint source is unavailable.";
   const compareTablist = useRovingTablist({ ids: COMPARE_VIEWS.map((view) => view.id), active: props.activeView, onSelect: props.onActiveView, panelId: "compare-view-panel" });
 
   return <section className={`experiment-shell${props.railCollapsed ? " rail-collapsed" : ""}`}>
@@ -105,7 +117,7 @@ export function ExperimentWorkbench(props: {
       <div className="notebook-brand"><strong>Harness Bench</strong><span>Experiment Notebook</span></div>
       <div className="notebook-navigation">{props.navigation}</div>
       <div className="notebook-document"><strong>Comparison workbench</strong><span>{treatment.value}</span></div>
-      <div className="notebook-bar-actions"><span className={`notebook-save-state${props.running ? " running" : ""}`}>{props.running ? "Running" : "Saved"}</span><button type="button" onClick={props.onSimple}>Simple compare</button><button type="button" onClick={props.onSetup}>Setup</button><button className="rail-toggle" type="button" aria-label={props.railCollapsed ? "Show checkpoints" : "Hide checkpoints"} aria-expanded={!props.railCollapsed} onClick={() => props.onRailCollapsed(!props.railCollapsed)}>{props.railCollapsed ? "Checkpoints" : "Hide rail"}</button></div>
+      <div className="notebook-bar-actions"><span className={`notebook-save-state${props.running ? " running" : ""}`}>{props.running ? "Running" : runnable ? "Saved" : "Blocked"}</span><button type="button" onClick={props.onSimple}>Simple compare</button><button type="button" onClick={props.onSetup}>Setup</button><button className="rail-toggle" type="button" aria-label={props.railCollapsed ? "Show checkpoints" : "Hide checkpoints"} aria-expanded={!props.railCollapsed} onClick={() => props.onRailCollapsed(!props.railCollapsed)}>{props.railCollapsed ? "Checkpoints" : "Hide rail"}</button></div>
     </header>
 
     <div className="experiment-workspace">
@@ -115,7 +127,7 @@ export function ExperimentWorkbench(props: {
           <div className="notebook-context-grid">
             <article className="notebook-request"><small>Request</small><p>{compactPrompt(props.preview.setup.request.prompt)}</p><span>{requestProvenanceLabel(props.preview.setup.request.provenance)}</span></article>
             <article><small>Starting checkpoint</small><code title={props.preview.checkpoint.digest}>{shortDigest(props.preview.checkpoint.digest)}</code><span>{props.preview.setup.checkpointSource.revision.value}</span></article>
-            <article><small>Harness</small><strong>{harnesses || "unverified"}</strong><span>{selectedAgents || runtimes || "runtime unavailable"}</span></article>
+            <article><small>Harness</small><strong>{harnesses || "unverified"}</strong><span>{executionIdentity}</span></article>
             <article><small>{treatment.label}</small><strong>{treatment.value}</strong><span>{treatment.controlled ? "Single setting changed" : "Descriptive comparison"}</span></article>
           </div>
         </section>
@@ -123,7 +135,7 @@ export function ExperimentWorkbench(props: {
         <section className="notebook-cell notebook-run-cell" aria-labelledby="run-cell-title">
           <div className="notebook-cell-marker"><span>In [1]</span></div>
           <div className="notebook-cell-card">
-            <header className="compare-titlebar"><div><h2 id="run-cell-title">Run comparison</h2><p>Fresh {props.preview.manifest.runtime?.host === "acp" ? "ACP " : ""}runs execute from the shared checkpoint; the recorded run remains Reference evidence.</p></div><div className="compare-actions"><span className={`live-state${props.running ? " running" : ""}`}>{props.running ? "Streaming" : "Ready"}</span>{props.running ? <button className="secondary" onClick={props.onCancel}>Cancel comparison</button> : <button onClick={props.onRun}>Run comparison</button>}</div></header>
+            <header className="compare-titlebar"><div><h2 id="run-cell-title">Run comparison</h2><p>{runDetail}</p></div><div className="compare-actions"><span className={`live-state${props.running ? " running" : ""}`}>{runState}</span>{props.running ? <button className="secondary" onClick={props.onCancel}>Cancel comparison</button> : <button disabled={!runnable} onClick={props.onRun}>Run comparison</button>}</div></header>
             <section className="run-prompt"><small>Prompt</small><p>{compactPrompt(props.preview.setup.request.prompt)}</p></section>
             {pendingPermissions.length > 0 && <section className="acp-permission-queue" aria-live="polite" aria-label="ACP permission requests"><header><strong>ACP permissions</strong><span>{pendingPermissions.length} waiting</span></header>{pendingPermissions.map(({ laneId, permission }) => <article key={`${permission.runId}:${permission.requestId}`}><div><small>{laneId}</small><strong>{permission.title}</strong><code>{permission.toolCallId}</code></div><div>{permission.options.map((option) => <button key={option.optionId} type="button" onClick={() => props.onPermission(laneId, permission.runId, permission.requestId, option.optionId)}>{option.name}</button>)}</div></article>)}</section>}
             <details className="run-process-summary"><summary><span>Process</span><em>{totalCalls} canonical tool calls across {props.preview.manifest.lanes.length} runs</em></summary><ol>{props.preview.manifest.lanes.map((definition) => {
@@ -155,7 +167,7 @@ export function ExperimentWorkbench(props: {
             </div>
           </div>
         </section>
-        <footer className="notebook-footer" aria-label="Notebook actions"><button type="button" onClick={props.onSetup}>Edit setup</button><button type="button" onClick={props.onRun} disabled={props.running}>Run again</button><button type="button" onClick={() => props.onActiveView("summary")}>Open summary</button></footer>
+        <footer className="notebook-footer" aria-label="Notebook actions"><button type="button" onClick={props.onSetup}>Edit setup</button><button type="button" onClick={props.onRun} disabled={props.running || !runnable}>Run again</button><button type="button" onClick={() => props.onActiveView("summary")}>Open summary</button></footer>
       </section></div>
     </div>
 
@@ -171,7 +183,7 @@ export function ExperimentWorkbench(props: {
         })}</ol>
         <section className="checkpoint-detail"><header><strong>{props.candidateId}</strong><span>Candidate</span></header><dl><div><dt>Harness</dt><dd>{candidateDefinition?.harnessId ?? "unverified"}</dd></div><div><dt>Runtime</dt><dd>{candidateDefinition ? laneIdentityLabel(candidateDefinition) : "unavailable"}</dd></div><div><dt>Status</dt><dd>{candidate.status}</dd></div><div><dt>Evidence</dt><dd>{candidate.calls.length} calls</dd></div></dl><footer><button type="button" onClick={() => props.onActiveView("evidence")}>View evidence</button><button type="button" onClick={() => props.onActiveView("trace")}>Inspect trace</button></footer></section>
       </div>
-      <footer className="rail-footer"><div><strong>{props.running ? "Comparison running" : `${totalCalls} tool calls`}</strong><span>{props.experimentId ? shortDigest(props.experimentId) : "ready"}</span></div><button className="secondary" onClick={props.onSetup}>Setup</button></footer>
+      <footer className="rail-footer"><div><strong>{props.running ? "Comparison running" : runnable ? `${totalCalls} tool calls` : "Comparison blocked"}</strong><span>{props.experimentId ? shortDigest(props.experimentId) : runnable ? "ready" : "blocked"}</span></div><button className="secondary" onClick={props.onSetup}>Setup</button></footer>
     </aside>
   </section>;
 }

--- a/packages/harness-studio/src/app/experiment/SimpleCompareView.tsx
+++ b/packages/harness-studio/src/app/experiment/SimpleCompareView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type FormEvent, type KeyboardEvent } from "react";
 import type { ExperimentToolCall } from "../../contracts/experiment-stream-contract.js";
+import { isExperimentRunnable } from "../../contracts/experiment-setup.js";
 import { resourceComparisonRows } from "./experiment-comparison-model.js";
 import { summarizeToolResult, type ToolOperation, type ToolOperationKind } from "./experiment-trace-model.js";
 import type { ExperimentPreview, LaneDefinition, LaneTrace } from "./experiment-view-types.js";
@@ -21,6 +22,7 @@ export function SimpleCompareView(props: {
   onRun: () => void;
   onCancel: () => void;
   onPermission: (laneId: string, runId: string, requestId: string, optionId: string) => void;
+  onSetup: () => void;
   onAdvanced: () => void;
 }): React.JSX.Element {
   const baseline = props.preview.manifest.lanes.find((lane) => lane.id === props.baselineId);
@@ -36,6 +38,14 @@ export function SimpleCompareView(props: {
   const candidateAgent = agentProfiles.find((agent) => agent.id === props.agentIds[props.candidateId]);
   const needsAcpAgents = props.preview.manifest.runtime?.host === "acp";
   const agentsReady = !needsAcpAgents || (baselineAgent?.available === true && candidateAgent?.available === true);
+  const checkpointReady = isExperimentRunnable(props.preview.setup);
+  const runReady = checkpointReady && agentsReady;
+  const runtimeLabel = needsAcpAgents ? undefined : "Qoder";
+  const readyMessage = !checkpointReady
+    ? props.preview.setup.checkpointSource.limitation ?? "The checkpoint source cannot create isolated fresh runs."
+    : agentsReady
+      ? "Ready"
+      : "Select an available ACP Agent for both AIs";
   const hasRun = props.submittedPrompt !== null;
   useEffect(() => {
     if (props.running) {
@@ -47,7 +57,7 @@ export function SimpleCompareView(props: {
   }, [props.running, hasRun, baselineLane?.status, candidateLane?.status]);
   const submit = (event: FormEvent): void => {
     event.preventDefault();
-    if (!props.running && props.prompt.trim() !== "" && agentsReady) props.onRun();
+    if (!props.running && props.prompt.trim() !== "" && runReady) props.onRun();
   };
   const selectResultViewFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>): void => {
     const views: SimpleResultView[] = ["resources", "messages"];
@@ -101,13 +111,14 @@ export function SimpleCompareView(props: {
         </label>
         <div className="simple-run-control">
           <span role="status" aria-live="polite">
-            {props.running ? "Both AIs are running…" : props.runError ?? (agentsReady ? "Ready" : "Select an available ACP Agent for both AIs")}
+            {props.running ? "Both AIs are running…" : props.runError ?? readyMessage}
           </span>
           <div>
-            <button className="secondary" type="button" onClick={props.onAdvanced}>Advanced evidence</button>
+            <button className="secondary" type="button" onClick={props.onSetup}>Review setup</button>
+            <button className="secondary" type="button" disabled={!checkpointReady} onClick={props.onAdvanced}>Advanced evidence</button>
             {props.running
               ? <button className="secondary cancel-comparison" type="button" onClick={props.onCancel}>Cancel</button>
-              : <button type="submit" disabled={props.prompt.trim() === "" || !agentsReady}>Run compare</button>}
+              : <button type="submit" disabled={props.prompt.trim() === "" || !runReady}>Run compare</button>}
           </div>
         </div>
       </form>
@@ -133,8 +144,8 @@ export function SimpleCompareView(props: {
               candidateLane={candidateLane}
               selectedOperationId={selectedOperationId}
               onSelectOperation={(id) => setSelectedOperationId((current) => current === id ? null : id)}
-              baselineAgentLabel={baselineAgent?.label}
-              candidateAgentLabel={candidateAgent?.label}
+              baselineAgentLabel={baselineAgent?.label ?? runtimeLabel}
+              candidateAgentLabel={candidateAgent?.label ?? runtimeLabel}
               baselineModelLabel={agentModelName(baseline, baselineAgent)}
               candidateModelLabel={agentModelName(candidate, candidateAgent)}
             />
@@ -144,7 +155,7 @@ export function SimpleCompareView(props: {
                 definition={baseline}
                 lane={baselineLane}
                 submittedPrompt={props.submittedPrompt}
-                agentLabel={baselineAgent?.label}
+                agentLabel={baselineAgent?.label ?? runtimeLabel}
                 modelLabel={agentModelName(baseline, baselineAgent)}
                 onPermission={(runId, requestId, optionId) => props.onPermission(props.baselineId, runId, requestId, optionId)}
               />
@@ -153,7 +164,7 @@ export function SimpleCompareView(props: {
                 definition={candidate}
                 lane={candidateLane}
                 submittedPrompt={props.submittedPrompt}
-                agentLabel={candidateAgent?.label}
+                agentLabel={candidateAgent?.label ?? runtimeLabel}
                 modelLabel={agentModelName(candidate, candidateAgent)}
                 onPermission={(runId, requestId, optionId) => props.onPermission(props.candidateId, runId, requestId, optionId)}
               />

--- a/packages/harness-studio/src/app/experiment/SimpleCompareView.tsx
+++ b/packages/harness-studio/src/app/experiment/SimpleCompareView.tsx
@@ -66,11 +66,9 @@ export function SimpleCompareView(props: {
   return <section className="simple-compare-shell">
     <main className="simple-compare-main">
       <form className={`simple-compare-composer${needsAcpAgents ? " has-agent-catalog" : ""}`} onSubmit={submit}>
-        <div className="simple-project-control">
-          <label htmlFor="compare-project">Current project</label>
-          <select id="compare-project" defaultValue={project.value} aria-describedby="compare-project-detail">
-            <option value={project.value}>{project.value}</option>
-          </select>
+        <div className="simple-project-control" aria-label="Checkpoint project">
+          <span>Checkpoint project</span>
+          <strong>{project.value}</strong>
           <span id="compare-project-detail">Current checkpoint · {revision.value}</span>
         </div>
         {needsAcpAgents && <div className="simple-agent-controls" aria-label="ACP Agents">

--- a/packages/harness-studio/src/app/run/RunView.tsx
+++ b/packages/harness-studio/src/app/run/RunView.tsx
@@ -89,11 +89,18 @@ async function streamRun(
   prompt: string,
   threadId: string,
   runId: string,
+  project: { id: string; label: string; revision: number } | undefined,
   onEvents: (events: AguiEvent[]) => void,
 ): Promise<void> {
   const response = await fetch(endpoint, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(project === undefined ? {} : {
+        "X-Harness-Project-Id": project.id,
+        "X-Harness-Project-Revision": String(project.revision),
+      }),
+    },
     body: JSON.stringify({
       threadId,
       runId,
@@ -249,6 +256,7 @@ export function RunView({
   harnessLabel = "Live Trial",
   navigation,
   initialMode = "live",
+  project,
 }: {
   aguiEndpoint: string;
   acpEndpoint?: string;
@@ -257,12 +265,14 @@ export function RunView({
   harnessLabel?: string;
   navigation?: ReactNode;
   initialMode?: SurfaceMode;
+  project?: { id: string; label: string; revision: number };
 }): React.JSX.Element {
   const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>(initialMode);
   const [prompt, setPrompt] = useState("");
   const [runtime, setRuntime] = useState<LiveRuntime>("qoder");
   const [activeRuntime, setActiveRuntime] = useState<LiveRuntime>("qoder");
   const [submittedPrompt, setSubmittedPrompt] = useState("");
+  const [runProject, setRunProject] = useState(project);
   const [state, setState] = useState<AguiRunState>(initialRunState);
   const [cursor, setCursor] = useState<DebuggerCursor>(DEFAULT_DEBUGGER_CURSOR);
   const [stopConditions, setStopConditions] = useState<StopConditionState>(DEFAULT_STOP_CONDITIONS);
@@ -386,6 +396,7 @@ export function RunView({
     const runId = `run_${stamp}`;
     setActiveRuntime(selectedRuntime);
     setSubmittedPrompt(promptText);
+    setRunProject(project);
     setSurfaceMode("live");
     setSavedRun(null);
     setRetainedSession(SAMPLE_DEBUGGER_SESSION);
@@ -395,7 +406,7 @@ export function RunView({
     liveStateRef.current = fresh;
     setState(fresh);
     try {
-      await streamRun(endpoint, promptText, threadId, runId, (events) => {
+      await streamRun(endpoint, promptText, threadId, runId, project, (events) => {
         // Fold outside any React updater: applyAguiEvent mutates the keyed
         // map for O(1) deltas and each batch must be applied exactly once.
         liveStateRef.current = events.reduce(applyAguiEvent, liveStateRef.current);
@@ -429,7 +440,7 @@ export function RunView({
         // Saving is best-effort evidence retention; the live view already holds the run.
       }
     }
-  }, [acpEndpoint, aguiEndpoint, prompt, refreshRuns, runtime]);
+  }, [acpEndpoint, aguiEndpoint, project, prompt, refreshRuns, runtime]);
 
   const cancelLiveRun = useCallback(async (): Promise<void> => {
     if (activeRuntime !== "acp" || state.runId === undefined) return;
@@ -450,10 +461,11 @@ export function RunView({
   const sessionName = live ? (viewPrompt || "New harness run") : retainedSession.name;
   const connectionState = live ? viewState.status : retainedSession.connection;
   const runMode = saved ? "Saved run · Evidence Cursor" : live ? (state.status === "running" ? "Live · Following" : "Live · Soft paused") : retainedSession.mode;
+  const visibleProject = submittedPrompt === "" ? project : runProject;
 
   return <section className={`debugger-shell${treeCollapsed ? " tree-collapsed" : ""}${inspectorCollapsed ? " inspector-collapsed" : ""}`}>
     <header className="debugger-topbar">
-      <div className="debugger-brand"><span className="debugger-mark"><BugBeetle size={18} weight="fill" /></span><strong>{live ? "Harness Run" : "Inspector"}</strong><span>{live ? harnessLabel : saved ? "Retained Session Debugger" : "Session Debugger · Demo"}</span></div>
+      <div className="debugger-brand"><span className="debugger-mark"><BugBeetle size={18} weight="fill" /></span><strong>{live ? "Harness Run" : "Inspector"}</strong><span title={visibleProject === undefined ? undefined : `Project ${visibleProject.label}, revision ${visibleProject.revision}`}>{live ? `${harnessLabel}${visibleProject === undefined ? "" : ` · ${visibleProject.label}`}` : saved ? "Retained Session Debugger" : "Session Debugger · Demo"}</span></div>
       <div className="debugger-session-meta"><span>Session</span><strong title={sessionName}>{sessionName}</strong><em className={live ? "live" : "recorded"}>{runMode}</em></div>
       <div className="debugger-runtime-meta"><span className={`connection-dot status-${connectionState}`} /><strong>{connectionState}</strong><i /><span>Agent</span><strong>{live ? activeRuntime === "acp" ? acpAgentLabel : "local harness" : retainedSession.agent}</strong><i /><span>Protocol</span><strong>{live ? activeRuntime === "acp" ? "ACP v1 · AG-UI projection" : "AG-UI" : retainedSession.protocol}</strong></div>
       <div className="debugger-top-actions">{navigation}{live && activeRuntime === "acp" && state.status === "running" ? <button type="button" className="cancel-live-run" onClick={() => void cancelLiveRun()}><XCircle size={15} />Cancel run</button> : null}<div className="saved-runs"><button type="button" onClick={() => { setRunsPanelOpen((value) => !value); void refreshRuns(); }} aria-expanded={runsPanelOpen} aria-haspopup="true"><ClockCounterClockwise size={15} /><span>Saved runs{savedRuns.length > 0 ? ` (${savedRuns.length})` : ""}</span></button>{runsPanelOpen && <div className="saved-runs-panel" role="menu" aria-label="Saved runs">{saved && <button type="button" role="menuitem" className="saved-runs-live" onClick={() => { setSavedRun(null); setRetainedSession(SAMPLE_DEBUGGER_SESSION); setSurfaceMode("live"); setRunsPanelOpen(false); }}>Back to live view</button>}{savedRuns.length === 0 ? <p className="saved-runs-empty">No saved runs yet. Finished runs are saved automatically.</p> : savedRuns.map((run) => <button type="button" role="menuitem" key={run.id} className={savedRun?.id === run.id ? "selected" : ""} onClick={() => void openSavedRun(run.id)}><strong title={run.prompt}>{run.prompt}</strong><span><em className={`run-badge status-${run.status}`}>{run.status}</em>{run.toolCallCount} call{run.toolCallCount === 1 ? "" : "s"} · {run.savedAt.slice(0, 19).replace("T", " ")}</span></button>)}</div>}</div><button type="button" onClick={() => setTreeCollapsed((value) => !value)} aria-pressed={!treeCollapsed} title="Toggle Execution Tree"><TreeStructure size={15} /></button><button type="button" onClick={() => setInspectorCollapsed((value) => !value)} aria-pressed={!inspectorCollapsed} title="Toggle State Inspector"><SidebarSimple size={15} /></button><button type="button" className="new-run" onClick={() => setComposerOpen(true)}><Plus size={14} weight="bold" />New live run</button></div>
@@ -482,7 +494,7 @@ export function RunView({
 
     {live ? <LiveTimeline state={viewState} bins={liveBins} eventCount={liveTimeline.length} /> : <TimelineMinimap session={retainedSession} cursor={cursor} onSelect={selectCursor} />}
 
-    {composerOpen && <div className="live-composer-backdrop" role="presentation" onMouseDown={(event) => { if (event.currentTarget === event.target) setComposerOpen(false); }}><section className="live-composer" role="dialog" aria-modal="true" aria-labelledby="live-composer-title"><header><div><small>{harnessLabel}</small><h2 id="live-composer-title">Start a live harness session</h2></div><button type="button" onClick={() => setComposerOpen(false)} aria-label="Close live run dialog"><XCircle size={19} /></button></header><p>Live events use the selected workspace. ACP runs launch the server-configured local Agent and expose its real protocol evidence.</p>{acpEndpoint !== undefined ? <label className="live-runtime-select"><span>Runtime</span><select value={runtime} onChange={(event) => setRuntime(event.target.value as LiveRuntime)}><option value="qoder">Qoder SDK · AG-UI</option><option value="acp">{acpAgentLabel} · ACP v1</option></select></label> : null}<textarea value={prompt} placeholder="Task prompt for the harness run…" onChange={(event) => setPrompt(event.target.value)} rows={5} autoFocus /><footer><button type="button" onClick={() => setComposerOpen(false)}>Cancel</button><button type="button" className="primary" onClick={() => void start()} disabled={state.status === "running" || prompt.trim().length === 0}><Play size={14} weight="fill" />Run harness</button></footer></section></div>}
+    {composerOpen && <div className="live-composer-backdrop" role="presentation" onMouseDown={(event) => { if (event.currentTarget === event.target) setComposerOpen(false); }}><section className="live-composer" role="dialog" aria-modal="true" aria-labelledby="live-composer-title"><header><div><small>{harnessLabel}</small><h2 id="live-composer-title">Start a live harness session</h2></div><button type="button" onClick={() => setComposerOpen(false)} aria-label="Close live run dialog"><XCircle size={19} /></button></header><p>Live events use {project === undefined ? "the configured runtime context" : `Project ${project.label} at revision ${project.revision}`}. The run keeps that binding if the selected Project changes later. ACP runs expose the configured local Agent's real protocol evidence.</p>{acpEndpoint !== undefined ? <label className="live-runtime-select"><span>Runtime</span><select value={runtime} onChange={(event) => setRuntime(event.target.value as LiveRuntime)}><option value="qoder">Qoder SDK · AG-UI</option><option value="acp">{acpAgentLabel} · ACP v1</option></select></label> : null}<textarea value={prompt} placeholder="Task prompt for the harness run…" onChange={(event) => setPrompt(event.target.value)} rows={5} autoFocus /><footer><button type="button" onClick={() => setComposerOpen(false)}>Cancel</button><button type="button" className="primary" onClick={() => void start()} disabled={state.status === "running" || prompt.trim().length === 0}><Play size={14} weight="fill" />Run harness</button></footer></section></div>}
   </section>;
 }
 

--- a/packages/harness-studio/src/app/run/RunView.tsx
+++ b/packages/harness-studio/src/app/run/RunView.tsx
@@ -362,8 +362,9 @@ export function RunView({
   }, []);
 
   useEffect(() => {
+    setSavedRuns([]);
     void refreshRuns();
-  }, [refreshRuns]);
+  }, [project?.id, project?.revision, refreshRuns]);
 
   const openSavedRun = useCallback(async (id: string): Promise<void> => {
     try {
@@ -423,7 +424,13 @@ export function RunView({
       try {
         await fetch("api/runs", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(project === undefined ? {} : {
+              "X-Harness-Project-Id": project.id,
+              "X-Harness-Project-Revision": String(project.revision),
+            }),
+          },
           body: JSON.stringify({
             prompt: promptText,
             status: final.status,
@@ -460,7 +467,9 @@ export function RunView({
   const saved = savedRun !== null;
   const sessionName = live ? (viewPrompt || "New harness run") : retainedSession.name;
   const connectionState = live ? viewState.status : retainedSession.connection;
-  const runMode = saved ? "Saved run · Evidence Cursor" : live ? (state.status === "running" ? "Live · Following" : "Live · Soft paused") : retainedSession.mode;
+  const liveStatus = liveRunStatusLabel(viewState);
+  const liveObservation = liveObservationCopy(viewState);
+  const runMode = saved ? "Saved run · Evidence Cursor" : live ? `Live · ${liveStatus}` : retainedSession.mode;
   const visibleProject = submittedPrompt === "" ? project : runProject;
 
   return <section className={`debugger-shell${treeCollapsed ? " tree-collapsed" : ""}${inspectorCollapsed ? " inspector-collapsed" : ""}`}>
@@ -468,7 +477,7 @@ export function RunView({
       <div className="debugger-brand"><span className="debugger-mark"><BugBeetle size={18} weight="fill" /></span><strong>{live ? "Harness Run" : "Inspector"}</strong><span title={visibleProject === undefined ? undefined : `Project ${visibleProject.label}, revision ${visibleProject.revision}`}>{live ? `${harnessLabel}${visibleProject === undefined ? "" : ` · ${visibleProject.label}`}` : saved ? "Retained Session Debugger" : "Session Debugger · Demo"}</span></div>
       <div className="debugger-session-meta"><span>Session</span><strong title={sessionName}>{sessionName}</strong><em className={live ? "live" : "recorded"}>{runMode}</em></div>
       <div className="debugger-runtime-meta"><span className={`connection-dot status-${connectionState}`} /><strong>{connectionState}</strong><i /><span>Agent</span><strong>{live ? activeRuntime === "acp" ? acpAgentLabel : "local harness" : retainedSession.agent}</strong><i /><span>Protocol</span><strong>{live ? activeRuntime === "acp" ? "ACP v1 · AG-UI projection" : "AG-UI" : retainedSession.protocol}</strong></div>
-      <div className="debugger-top-actions">{navigation}{live && activeRuntime === "acp" && state.status === "running" ? <button type="button" className="cancel-live-run" onClick={() => void cancelLiveRun()}><XCircle size={15} />Cancel run</button> : null}<div className="saved-runs"><button type="button" onClick={() => { setRunsPanelOpen((value) => !value); void refreshRuns(); }} aria-expanded={runsPanelOpen} aria-haspopup="true"><ClockCounterClockwise size={15} /><span>Saved runs{savedRuns.length > 0 ? ` (${savedRuns.length})` : ""}</span></button>{runsPanelOpen && <div className="saved-runs-panel" role="menu" aria-label="Saved runs">{saved && <button type="button" role="menuitem" className="saved-runs-live" onClick={() => { setSavedRun(null); setRetainedSession(SAMPLE_DEBUGGER_SESSION); setSurfaceMode("live"); setRunsPanelOpen(false); }}>Back to live view</button>}{savedRuns.length === 0 ? <p className="saved-runs-empty">No saved runs yet. Finished runs are saved automatically.</p> : savedRuns.map((run) => <button type="button" role="menuitem" key={run.id} className={savedRun?.id === run.id ? "selected" : ""} onClick={() => void openSavedRun(run.id)}><strong title={run.prompt}>{run.prompt}</strong><span><em className={`run-badge status-${run.status}`}>{run.status}</em>{run.toolCallCount} call{run.toolCallCount === 1 ? "" : "s"} · {run.savedAt.slice(0, 19).replace("T", " ")}</span></button>)}</div>}</div><button type="button" onClick={() => setTreeCollapsed((value) => !value)} aria-pressed={!treeCollapsed} title="Toggle Execution Tree"><TreeStructure size={15} /></button><button type="button" onClick={() => setInspectorCollapsed((value) => !value)} aria-pressed={!inspectorCollapsed} title="Toggle State Inspector"><SidebarSimple size={15} /></button><button type="button" className="new-run" onClick={() => setComposerOpen(true)}><Plus size={14} weight="bold" />New live run</button></div>
+      <div className="debugger-top-actions">{navigation}{live && activeRuntime === "acp" && state.status === "running" ? <button type="button" className="cancel-live-run" onClick={() => void cancelLiveRun()}><XCircle size={15} />Cancel run</button> : null}<div className="saved-runs"><button type="button" onClick={() => { setRunsPanelOpen((value) => !value); void refreshRuns(); }} aria-expanded={runsPanelOpen} aria-haspopup="true"><ClockCounterClockwise size={15} /><span>Saved runs{savedRuns.length > 0 ? ` (${savedRuns.length})` : ""}</span></button>{runsPanelOpen && <div className="saved-runs-panel" role="menu" aria-label="Saved runs">{saved && <button type="button" role="menuitem" className="saved-runs-live" onClick={() => { setSavedRun(null); setRetainedSession(SAMPLE_DEBUGGER_SESSION); setSurfaceMode("live"); setRunsPanelOpen(false); }}>Back to live view</button>}{savedRuns.length === 0 ? <p className="saved-runs-empty">No saved runs yet. Finish a run to retain it when storage is available.</p> : savedRuns.map((run) => <button type="button" role="menuitem" key={run.id} className={savedRun?.id === run.id ? "selected" : ""} onClick={() => void openSavedRun(run.id)}><strong title={run.prompt}>{run.prompt}</strong><span><em className={`run-badge status-${run.status}`}>{run.status}</em>{run.toolCallCount} call{run.toolCallCount === 1 ? "" : "s"} · {run.savedAt.slice(0, 19).replace("T", " ")}</span></button>)}</div>}</div><button type="button" onClick={() => setTreeCollapsed((value) => !value)} aria-pressed={!treeCollapsed} title="Toggle Execution Tree"><TreeStructure size={15} /></button><button type="button" onClick={() => setInspectorCollapsed((value) => !value)} aria-pressed={!inspectorCollapsed} title="Toggle State Inspector"><SidebarSimple size={15} /></button><button type="button" className="new-run" onClick={() => setComposerOpen(true)}><Plus size={14} weight="bold" />New live run</button></div>
     </header>
 
     {!live ? <nav className="debugger-toolbar" aria-label="Session debugger controls">
@@ -484,7 +493,7 @@ export function RunView({
       </div>
       <fieldset className="stop-conditions" aria-label={stopConditionLabel(stopConditions)}><legend>Stop on</legend>{STOP_CONDITIONS.map((condition) => <label key={condition}><input type="checkbox" checked={stopConditions[condition]} onChange={(event) => setStopConditions((previous) => ({ ...previous, [condition]: event.target.checked }))} /><span>{STOP_LABELS[condition]}</span></label>)}</fieldset>
       <div className="pause-boundary"><Pause size={13} weight="fill" /><span>Evidence Cursor</span></div>
-    </nav> : <div className="live-observation-bar" role="status"><span><Pause size={13} weight="fill" />Live observation · no Evidence Cursor</span><strong>Step controls become available after selecting a saved retained run.</strong></div>}
+    </nav> : <div className="live-observation-bar" role="status"><span><i className={`status-dot status-${viewState.status}`} aria-hidden="true" />{liveObservation.title}</span><strong>{liveObservation.detail}</strong></div>}
 
     <div className="debugger-grid">
       {live ? <LiveExecutionTree state={viewState} prompt={viewPrompt} /> : <ExecutionTree session={retainedSession} cursor={cursor} expanded={expandedNodes} onToggle={toggleExpanded} onSelect={selectNode} />}
@@ -743,9 +752,26 @@ function LiveGroupEntry({ group }: { group: LiveTimelineGroup }): React.JSX.Elem
 }
 
 function LiveInspector({ state, runtime, onPermission }: { state: AguiRunState; runtime: LiveRuntime; onPermission: (requestId: string, optionId: string) => Promise<void> }): React.JSX.Element {
-  return <aside className="state-inspector live-inspector" aria-label="State Inspector"><header><div><small>State Inspector</small><strong>Live observation</strong></div><span>{state.pendingPermission === undefined ? "Soft Pause" : "Permission gate"}</span></header><div className="inspector-scroll"><InspectorSection title="Runtime boundary"><ul className="checkpoint-boundary"><li className="available"><CheckCircle size={13} weight="fill" /><span><strong>Evidence stream</strong><small>{state.status}</small></span></li><li className={state.pendingPermission === undefined ? "" : "available"}>{state.pendingPermission === undefined ? <WarningCircle size={13} weight="fill" /> : <CheckCircle size={13} weight="fill" />}<span><strong>Gate pause</strong><small>{state.pendingPermission === undefined ? "Not reported" : "ACP permission requested"}</small></span></li><li><WarningCircle size={13} weight="fill" /><span><strong>Hard pause</strong><small>Not reported</small></span></li></ul></InspectorSection>{state.pendingPermission !== undefined ? <InspectorSection title="ACP permission"><div className="acp-permission"><strong>{state.pendingPermission.title}</strong><small>Tool call {state.pendingPermission.toolCallId}</small><div>{state.pendingPermission.options.map((option) => <button type="button" key={option.optionId} onClick={() => void onPermission(state.pendingPermission!.requestId, option.optionId)}>{option.name}<span>{option.kind}</span></button>)}</div></div></InspectorSection> : null}<InspectorSection title="Observed state"><dl className="fact-list"><div><dt>Run ID</dt><dd>{state.runId ?? "Pending"}</dd></div><div><dt>Thread ID</dt><dd>{state.threadId ?? "Pending"}</dd></div><div><dt>Tool calls</dt><dd>{state.toolCallCount}</dd></div><div><dt>Warnings</dt><dd>{state.warnings.length}</dd></div>{runtime === "acp" ? <div><dt>ACP frames</dt><dd>{state.protocolEvents.length}</dd></div> : null}</dl></InspectorSection>{runtime === "acp" ? <InspectorSection title="Raw ACP"><div className="acp-protocol-list">{state.protocolEvents.length === 0 ? <p className="inspector-note">Waiting for ACP protocol frames.</p> : state.protocolEvents.slice(-12).map((event, index) => <details key={`${event.direction}:${event.rpcId ?? index}:${index}`}><summary><span>{event.direction}</span><strong>{event.method}</strong></summary><pre>{JSON.stringify(event.payload, null, 2)}</pre></details>)}</div></InspectorSection> : null}<InspectorSection title="Meaning"><p className="inspector-note">{runtime === "acp" ? "ACP frames are redacted, bounded evidence from the server-owned stdio connection. Cancel sends session/cancel to the Agent." : "Soft Pause stops this UI from claiming auto-follow. It does not cancel, gate, or suspend the running Agent."}</p></InspectorSection></div></aside>;
+  const status = liveRunStatusLabel(state);
+  return <aside className="state-inspector live-inspector" aria-label="State Inspector"><header><div><small>State Inspector</small><strong>Live observation</strong></div><span>{status}</span></header><div className="inspector-scroll"><InspectorSection title="Runtime boundary"><ul className="checkpoint-boundary"><li className="available"><CheckCircle size={13} weight="fill" /><span><strong>Event stream</strong><small>{status}</small></span></li><li className={state.pendingPermission === undefined ? "" : "available"}>{state.pendingPermission === undefined ? <WarningCircle size={13} weight="fill" /> : <CheckCircle size={13} weight="fill" />}<span><strong>Permission</strong><small>{state.pendingPermission === undefined ? "No request" : "Action required"}</small></span></li></ul></InspectorSection>{state.pendingPermission !== undefined ? <InspectorSection title="ACP permission"><div className="acp-permission"><strong>{state.pendingPermission.title}</strong><small>Tool call {state.pendingPermission.toolCallId}</small><div>{state.pendingPermission.options.map((option) => <button type="button" key={option.optionId} onClick={() => void onPermission(state.pendingPermission!.requestId, option.optionId)}>{option.name}<span>{option.kind}</span></button>)}</div></div></InspectorSection> : null}<InspectorSection title="Observed state"><dl className="fact-list"><div><dt>Run ID</dt><dd>{state.runId ?? "Pending"}</dd></div><div><dt>Thread ID</dt><dd>{state.threadId ?? "Pending"}</dd></div><div><dt>Tool calls</dt><dd>{state.toolCallCount}</dd></div><div><dt>Warnings</dt><dd>{state.warnings.length}</dd></div>{runtime === "acp" ? <div><dt>ACP frames</dt><dd>{state.protocolEvents.length}</dd></div> : null}</dl></InspectorSection>{runtime === "acp" ? <><InspectorSection title="Raw ACP"><div className="acp-protocol-list">{state.protocolEvents.length === 0 ? <p className="inspector-note">Waiting for ACP protocol frames.</p> : state.protocolEvents.slice(-12).map((event, index) => <details key={`${event.direction}:${event.rpcId ?? index}:${index}`}><summary><span>{event.direction}</span><strong>{event.method}</strong></summary><pre>{JSON.stringify(event.payload, null, 2)}</pre></details>)}</div></InspectorSection><InspectorSection title="Protocol boundary"><p className="inspector-note">ACP frames are redacted, bounded evidence from the server-owned connection. Cancel requests the Agent to stop the active Session.</p></InspectorSection></> : null}</div></aside>;
 }
 
 function LiveTimeline({ state, bins, eventCount }: { state: AguiRunState; bins: TimelineBin<DebuggerEventKind>[]; eventCount: number }): React.JSX.Element {
-  return <footer className="timeline-minimap live-minimap"><div className="timeline-range"><span>Live</span><strong>Semantic timeline · fixed 64 bins</strong><span>{state.status}</span></div><div className="timeline-track">{bins.length === 0 ? <span className="live-track-empty">Waiting for events</span> : bins.map((bin) => <span key={bin.index} className={`timeline-segment kind-${bin.kind}`} title={`${bin.count} events`} />)}</div><div className="timeline-footer"><strong>{eventCount} retained events</strong></div></footer>;
+  return <footer className="timeline-minimap live-minimap"><div className="timeline-range"><span>Live</span><strong>Live activity timeline</strong><span>{liveRunStatusLabel(state)}</span></div><div className="timeline-track">{bins.length === 0 ? <span className="live-track-empty">Waiting for events</span> : bins.map((bin) => <span key={bin.index} className={`timeline-segment kind-${bin.kind}`} title={`${bin.count} events`} />)}</div><div className="timeline-footer"><strong>{eventCount} retained events</strong></div></footer>;
+}
+
+function liveRunStatusLabel(state: AguiRunState): string {
+  if (state.pendingPermission !== undefined) return "Permission required";
+  if (state.status === "running") return "Running";
+  if (state.status === "finished") return "Finished";
+  if (state.status === "error") return "Failed";
+  return "Ready";
+}
+
+function liveObservationCopy(state: AguiRunState): { title: string; detail: string } {
+  if (state.pendingPermission !== undefined) return { title: "Permission required", detail: "Choose an option in the State Inspector to continue." };
+  if (state.status === "running") return { title: "Live run in progress", detail: "Following messages, tool calls, and server events." };
+  if (state.status === "finished") return { title: "Run finished", detail: "Review the completed messages and tool calls. Saved runs appear after retention succeeds." };
+  if (state.status === "error") return { title: "Run failed", detail: "Review the visible error and retained events before retrying." };
+  return { title: "Ready for a live run", detail: "Start a run to observe messages and tool calls." };
 }

--- a/packages/harness-studio/src/app/shell/ProjectSidebar.tsx
+++ b/packages/harness-studio/src/app/shell/ProjectSidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import type { Icon } from "@phosphor-icons/react";
 import { Binoculars } from "@phosphor-icons/react/Binoculars";
 import { BugBeetle } from "@phosphor-icons/react/BugBeetle";
@@ -39,13 +39,25 @@ export function ProjectSidebar(props: {
   onCloseNavigation: () => void;
 }): React.JSX.Element {
   const navigationRefs = useRef(new Map<string, HTMLButtonElement>());
-  const showConfiguredViews = props.projects.length === 0;
-  const orderedIds = props.projects.length === 0
-    ? props.destinations.map((destination) => `view:${destination.id}`)
-    : props.projects.flatMap((project) => [
+  const showUnscopedViews = props.activeProjectId === undefined;
+  const orderedIds = [
+    ...props.projects.flatMap((project) => [
       `project:${project.id}`,
       ...(project.id === props.activeProjectId ? props.destinations.map((destination) => `view:${destination.id}`) : []),
-    ]);
+    ]),
+    ...(showUnscopedViews ? props.destinations.map((destination) => `view:${destination.id}`) : []),
+  ];
+  const selectedNavigationId = `view:${props.current}`;
+  const [focusedNavigationId, setFocusedNavigationId] = useState(selectedNavigationId);
+  const tabStopId = orderedIds.includes(focusedNavigationId)
+    ? focusedNavigationId
+    : orderedIds.includes(selectedNavigationId)
+      ? selectedNavigationId
+      : orderedIds[0];
+
+  useEffect(() => {
+    setFocusedNavigationId(selectedNavigationId);
+  }, [props.activeProjectId, selectedNavigationId]);
 
   function onNavigationKeyDown(event: ReactKeyboardEvent<HTMLElement>): void {
     if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
@@ -60,7 +72,9 @@ export function ProjectSidebar(props: {
         : event.key === "ArrowDown"
           ? (currentIndex + 1) % orderedIds.length
           : (currentIndex - 1 + orderedIds.length) % orderedIds.length;
-    navigationRefs.current.get(orderedIds[nextIndex]!)?.focus();
+    const nextId = orderedIds[nextIndex]!;
+    setFocusedNavigationId(nextId);
+    navigationRefs.current.get(nextId)?.focus();
   }
 
   return <aside className="studio-primary-nav studio-project-sidebar" aria-label="Studio Projects">
@@ -73,17 +87,17 @@ export function ProjectSidebar(props: {
           const active = project.id === props.activeProjectId;
           return <div className={`studio-project-entry${active ? " active" : ""}${project.availability === "unavailable" ? " unavailable" : ""}`} key={project.id}>
             <div className="studio-project-row">
-              <button ref={(node) => { if (node) navigationRefs.current.set(`project:${project.id}`, node); else navigationRefs.current.delete(`project:${project.id}`); }} type="button" disabled={props.opening} aria-current={active ? "true" : undefined} onClick={() => props.onActivateProject(project.id)}>
+              <button ref={(node) => { if (node) navigationRefs.current.set(`project:${project.id}`, node); else navigationRefs.current.delete(`project:${project.id}`); }} type="button" tabIndex={tabStopId === `project:${project.id}` ? 0 : -1} disabled={props.opening} aria-current={active ? "true" : undefined} aria-keyshortcuts="Delete" title={`${project.label}. Press Delete to remove this Project.`} onFocus={() => setFocusedNavigationId(`project:${project.id}`)} onKeyDown={(event) => { if (event.key === "Delete") { event.preventDefault(); props.onRemoveProject(project.id); } }} onClick={() => { setFocusedNavigationId(`project:${project.id}`); props.onActivateProject(project.id); }}>
                 <FolderOpen aria-hidden="true" size={15} weight={active ? "fill" : "regular"} />
                 <span><strong>{project.label}</strong><small>{project.availability === "unavailable" ? "Unavailable · refresh failed" : `${project.sessionCount} Sessions · ${project.gitEnabled ? "Git" : "Folder"}`}</small></span>
               </button>
-              <button className="studio-project-remove" type="button" disabled={props.opening} aria-label={`Remove Project: ${project.label}`} title={`Remove ${project.label}`} onClick={() => props.onRemoveProject(project.id)}><X aria-hidden="true" size={13} /></button>
+              <button className="studio-project-remove" type="button" tabIndex={-1} disabled={props.opening} aria-label={`Remove Project: ${project.label}`} title={`Remove ${project.label}`} onClick={() => props.onRemoveProject(project.id)}><X aria-hidden="true" size={13} /></button>
             </div>
             {active && <section className="studio-project-views" aria-label={`${project.label} Views`}>
               <h2>Views</h2>
               {props.destinations.map((destination) => {
                 const ViewIcon = VIEW_ICONS[destination.id];
-                return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={props.current === destination.id ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onClick={() => props.onSelectView(destination.id)}>
+                return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={tabStopId === `view:${destination.id}` ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onFocus={() => setFocusedNavigationId(`view:${destination.id}`)} onClick={() => { setFocusedNavigationId(`view:${destination.id}`); props.onSelectView(destination.id); }}>
                   <ViewIcon aria-hidden="true" size={15} weight={props.current === destination.id ? "fill" : "regular"} />
                   <span><strong>{destination.label}</strong><small>{destination.status}</small></span>
                   <i className={`availability-dot availability-${destination.availability}`} aria-label={destination.availability} />
@@ -93,11 +107,11 @@ export function ProjectSidebar(props: {
           </div>;
         })}
       </section>
-      {showConfiguredViews && <section className="studio-project-views studio-configured-views" aria-label="Configured source Views">
+      {showUnscopedViews && <section className="studio-project-views studio-configured-views" aria-label="Studio Views">
         <h2>Views</h2>
         {props.destinations.map((destination) => {
           const ViewIcon = VIEW_ICONS[destination.id];
-          return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={props.current === destination.id ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onClick={() => props.onSelectView(destination.id)}>
+          return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={tabStopId === `view:${destination.id}` ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onFocus={() => setFocusedNavigationId(`view:${destination.id}`)} onClick={() => { setFocusedNavigationId(`view:${destination.id}`); props.onSelectView(destination.id); }}>
             <ViewIcon aria-hidden="true" size={15} weight={props.current === destination.id ? "fill" : "regular"} />
             <span><strong>{destination.label}</strong><small>{destination.status}</small></span>
             <i className={`availability-dot availability-${destination.availability}`} aria-label={destination.availability} />

--- a/packages/harness-studio/src/app/shell/ProjectSidebar.tsx
+++ b/packages/harness-studio/src/app/shell/ProjectSidebar.tsx
@@ -1,0 +1,109 @@
+import { useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import type { Icon } from "@phosphor-icons/react";
+import { Binoculars } from "@phosphor-icons/react/Binoculars";
+import { BugBeetle } from "@phosphor-icons/react/BugBeetle";
+import { ChatText } from "@phosphor-icons/react/ChatText";
+import { Flask } from "@phosphor-icons/react/Flask";
+import { FolderOpen } from "@phosphor-icons/react/FolderOpen";
+import { GitBranch } from "@phosphor-icons/react/GitBranch";
+import { Package } from "@phosphor-icons/react/Package";
+import { Plus } from "@phosphor-icons/react/Plus";
+import { PuzzlePiece } from "@phosphor-icons/react/PuzzlePiece";
+import { SquaresFour } from "@phosphor-icons/react/SquaresFour";
+import { X } from "@phosphor-icons/react/X";
+import type { StudioProjectDescriptor } from "../../contracts/studio-project.js";
+import type { StudioArea, StudioDestination } from "../studio-shell-model.js";
+
+const VIEW_ICONS: Record<StudioArea, Icon> = {
+  overview: SquaresFour,
+  customizations: PuzzlePiece,
+  inputs: ChatText,
+  sessions: Binoculars,
+  commits: GitBranch,
+  artifacts: Package,
+  debugger: BugBeetle,
+  compare: Flask,
+};
+
+export function ProjectSidebar(props: {
+  projects: readonly StudioProjectDescriptor[];
+  activeProjectId?: string;
+  destinations: readonly StudioDestination[];
+  current: StudioArea;
+  opening: boolean;
+  canOpenProject: boolean;
+  onOpenProject: () => void;
+  onActivateProject: (projectId: string) => void;
+  onRemoveProject: (projectId: string) => void;
+  onSelectView: (area: StudioArea) => void;
+  onCloseNavigation: () => void;
+}): React.JSX.Element {
+  const navigationRefs = useRef(new Map<string, HTMLButtonElement>());
+  const showConfiguredViews = props.projects.length === 0;
+  const orderedIds = props.projects.length === 0
+    ? props.destinations.map((destination) => `view:${destination.id}`)
+    : props.projects.flatMap((project) => [
+      `project:${project.id}`,
+      ...(project.id === props.activeProjectId ? props.destinations.map((destination) => `view:${destination.id}`) : []),
+    ]);
+
+  function onNavigationKeyDown(event: ReactKeyboardEvent<HTMLElement>): void {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    if (orderedIds.length === 0) return;
+    event.preventDefault();
+    const focused = [...navigationRefs.current.entries()].find(([, button]) => button === document.activeElement)?.[0];
+    const currentIndex = Math.max(0, orderedIds.indexOf(focused ?? `project:${props.activeProjectId ?? props.projects[0]?.id ?? ""}`));
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? orderedIds.length - 1
+        : event.key === "ArrowDown"
+          ? (currentIndex + 1) % orderedIds.length
+          : (currentIndex - 1 + orderedIds.length) % orderedIds.length;
+    navigationRefs.current.get(orderedIds[nextIndex]!)?.focus();
+  }
+
+  return <aside className="studio-primary-nav studio-project-sidebar" aria-label="Studio Projects">
+    <header className="studio-product-brand"><span><GitBranch aria-hidden="true" size={18} weight="bold" /></span><div><strong>Better Harness</strong><small>Studio</small></div><button className="studio-project-close" type="button" aria-label="Close Studio navigation" onClick={props.onCloseNavigation}><X aria-hidden="true" size={15} /></button></header>
+    <div className="studio-project-heading"><div><strong>Projects</strong><span>{props.projects.length}</span></div><button type="button" disabled={props.opening || !props.canOpenProject} aria-label={props.opening ? "Opening project" : props.canOpenProject ? "Open project" : "Project opening unavailable"} title={props.canOpenProject ? "Open project" : "This launcher has no local Project discovery provider"} onClick={props.onOpenProject}>{props.opening ? <span className="studio-project-spinner" aria-hidden="true" /> : <Plus aria-hidden="true" size={15} />}</button></div>
+    <nav aria-label="Studio project and View navigation" onKeyDown={onNavigationKeyDown}>
+      <section className="studio-project-list" aria-label="Projects">
+        {props.projects.length === 0 && <p className="studio-project-empty"><FolderOpen aria-hidden="true" size={16} /><span>No Project is open.</span></p>}
+        {props.projects.map((project) => {
+          const active = project.id === props.activeProjectId;
+          return <div className={`studio-project-entry${active ? " active" : ""}${project.availability === "unavailable" ? " unavailable" : ""}`} key={project.id}>
+            <div className="studio-project-row">
+              <button ref={(node) => { if (node) navigationRefs.current.set(`project:${project.id}`, node); else navigationRefs.current.delete(`project:${project.id}`); }} type="button" disabled={props.opening} aria-current={active ? "true" : undefined} onClick={() => props.onActivateProject(project.id)}>
+                <FolderOpen aria-hidden="true" size={15} weight={active ? "fill" : "regular"} />
+                <span><strong>{project.label}</strong><small>{project.availability === "unavailable" ? "Unavailable · refresh failed" : `${project.sessionCount} Sessions · ${project.gitEnabled ? "Git" : "Folder"}`}</small></span>
+              </button>
+              <button className="studio-project-remove" type="button" disabled={props.opening} aria-label={`Remove Project: ${project.label}`} title={`Remove ${project.label}`} onClick={() => props.onRemoveProject(project.id)}><X aria-hidden="true" size={13} /></button>
+            </div>
+            {active && <section className="studio-project-views" aria-label={`${project.label} Views`}>
+              <h2>Views</h2>
+              {props.destinations.map((destination) => {
+                const ViewIcon = VIEW_ICONS[destination.id];
+                return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={props.current === destination.id ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onClick={() => props.onSelectView(destination.id)}>
+                  <ViewIcon aria-hidden="true" size={15} weight={props.current === destination.id ? "fill" : "regular"} />
+                  <span><strong>{destination.label}</strong><small>{destination.status}</small></span>
+                  <i className={`availability-dot availability-${destination.availability}`} aria-label={destination.availability} />
+                </button>;
+              })}
+            </section>}
+          </div>;
+        })}
+      </section>
+      {showConfiguredViews && <section className="studio-project-views studio-configured-views" aria-label="Configured source Views">
+        <h2>Views</h2>
+        {props.destinations.map((destination) => {
+          const ViewIcon = VIEW_ICONS[destination.id];
+          return <button key={destination.id} ref={(node) => { if (node) navigationRefs.current.set(`view:${destination.id}`, node); else navigationRefs.current.delete(`view:${destination.id}`); }} type="button" tabIndex={props.current === destination.id ? 0 : -1} aria-current={props.current === destination.id ? "page" : undefined} onClick={() => props.onSelectView(destination.id)}>
+            <ViewIcon aria-hidden="true" size={15} weight={props.current === destination.id ? "fill" : "regular"} />
+            <span><strong>{destination.label}</strong><small>{destination.status}</small></span>
+            <i className={`availability-dot availability-${destination.availability}`} aria-label={destination.availability} />
+          </button>;
+        })}
+      </section>}
+    </nav>
+  </aside>;
+}

--- a/packages/harness-studio/src/app/shell/project-routing.ts
+++ b/packages/harness-studio/src/app/shell/project-routing.ts
@@ -1,0 +1,24 @@
+import type { StudioArea } from "../studio-shell-model.js";
+
+export interface StudioLocation {
+  area: StudioArea;
+  projectId?: string;
+}
+
+const PROJECT_ID = /^project_[a-f0-9]{32}$/u;
+
+export function parseStudioLocation(hash: string | undefined, areas: ReadonlySet<string>): StudioLocation {
+  const route = (hash ?? "").replace(/^#\/?/u, "");
+  const parts = route.split("/").filter(Boolean);
+  if (parts[0] === "projects" && parts.length === 3 && PROJECT_ID.test(parts[1]!) && areas.has(parts[2]!)) {
+    return { projectId: parts[1], area: parts[2] as StudioArea };
+  }
+  const area = parts[0];
+  return { area: area !== undefined && areas.has(area) ? area as StudioArea : "overview" };
+}
+
+export function studioLocationHash(location: StudioLocation): string {
+  return location.projectId === undefined
+    ? `#/${location.area}`
+    : `#/projects/${location.projectId}/${location.area}`;
+}

--- a/packages/harness-studio/src/app/studio-shell-model.ts
+++ b/packages/harness-studio/src/app/studio-shell-model.ts
@@ -26,6 +26,8 @@ export interface StudioConfig {
   workspaceWorkbenchEnabled: boolean;
   workspaceDiscoveryEnabled: boolean;
   workspaceConnected: boolean;
+  activeProjectId?: string;
+  projectRevision?: number;
   sessionCount: number;
   inputCount: number;
   intentAnalysisEnabled: boolean;
@@ -69,6 +71,7 @@ export interface StudioOverviewModel {
 
 export function studioDestinations(config: StudioConfig): readonly StudioDestination[] {
   const compareAvailable = config.experimentEnabled || config.evidenceEnabled;
+  const debuggerReady = isDebuggerReady(config);
   return [
     { id: "overview", label: "Overview", group: "Control", availability: "ready", status: "Control plane" },
     {
@@ -91,21 +94,21 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
         ? `${config.inputCount} input${config.inputCount === 1 ? "" : "s"}`
         : config.workspaceConnected
           ? "No retained trace"
-          : "Workspace required",
+          : "Project required",
     },
     {
       id: "sessions",
       label: "Sessions",
       group: "Observe",
       availability: config.workspaceConnected ? "ready" : "partial",
-      status: config.workspaceConnected ? `${config.sessionCount} session${config.sessionCount === 1 ? "" : "s"}` : "Open workspace",
+      status: config.workspaceConnected ? `${config.sessionCount} session${config.sessionCount === 1 ? "" : "s"}` : "Open Project",
     },
     {
       id: "commits",
       label: "Commits",
       group: "Observe",
       availability: config.gitEnabled ? "ready" : config.workspaceConnected ? "partial" : "foundation",
-      status: config.gitEnabled ? "Repository history" : config.workspaceConnected ? "Not a Git repository" : "Workspace required",
+      status: config.gitEnabled ? "Repository history" : config.workspaceConnected ? "Not a Git repository" : "Project required",
     },
     {
       id: "artifacts",
@@ -116,21 +119,21 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
         ? config.artifactCount === undefined
           ? "Compatibility catalog"
           : `${config.artifactCount} artifact${config.artifactCount === 1 ? "" : "s"}`
-        : config.workspaceConnected ? "No observed outputs" : "Workspace required",
+        : config.workspaceConnected ? "No observed outputs" : "Project required",
     },
     {
       id: "debugger",
       label: "Debugger",
       group: "Run",
-      availability: config.aguiEnabled ? "ready" : "foundation",
-      status: config.aguiEnabled ? config.harnessMode === "workspace-default" ? "Local default" : "Live runs" : "Harness required",
+      availability: debuggerReady ? "ready" : "foundation",
+      status: debuggerReady ? config.harnessMode === "workspace-default" ? "Project default" : "Live runs" : config.harnessMode === "workspace-default" ? "Project required" : "Harness required",
     },
     {
       id: "compare",
       label: "Compare",
       group: "Validate",
       availability: compareAvailable || config.sessionCount >= 2 ? "ready" : config.workspaceConnected ? "partial" : "foundation",
-      status: config.sessionCount >= 2 ? "Session compare" : config.experimentEnabled ? "Harness Bench" : config.evidenceEnabled ? "Frozen results" : config.workspaceConnected ? "Choose 2 sessions" : "Workspace required",
+      status: config.sessionCount >= 2 ? "Session compare" : config.experimentEnabled ? "Harness Bench" : config.evidenceEnabled ? "Frozen results" : config.workspaceConnected ? "Choose 2 sessions" : "Project required",
     },
   ];
 }
@@ -151,10 +154,10 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
   if (config.workspaceConnected) {
     return {
       mode: "workspace",
-      title: "Workspace evidence is ready.",
+      title: "Project evidence is ready.",
       detail: config.sessionCount === 0
-        ? "No retained Sessions were discovered for this workspace yet."
-        : `${config.sessionCount} retained Session${config.sessionCount === 1 ? "" : "s"} can be inspected without changing the project.`,
+        ? "No retained Sessions were discovered for this Project yet."
+        : `${config.sessionCount} retained Session${config.sessionCount === 1 ? "" : "s"} can be inspected without changing the Project.`,
       primaryAction: { area: "sessions", label: "Open Sessions" },
       secondaryActions: [
         ...(config.workspaceWorkbenchEnabled ? [{ area: "inputs" as const, label: "Review Inputs" }] : []),
@@ -194,8 +197,8 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
   if (config.workspaceDiscoveryEnabled) {
     return {
       mode: "workspace-required",
-      title: "Choose a project workspace to begin.",
-      detail: "The workspace chooser is open. Select a project directory to discover its retained agent evidence.",
+      title: "Choose a Project to begin.",
+      detail: "The Project chooser is open. Select a directory to discover its retained agent evidence.",
       secondaryActions: [],
       facts: [],
     };
@@ -204,7 +207,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
   const configuredFacts: StudioOverviewFact[] = [
     ...(config.experimentEnabled ? [{ id: "experiment", label: "Harness Bench", value: "Ready", detail: "Experiment manifest loaded" }] : []),
     ...(config.evidenceEnabled ? [{ id: "evidence", label: "Evidence results", value: "Ready", detail: "Frozen verdict loaded" }] : []),
-    ...(config.aguiEnabled ? [{ id: "debugger", label: "Debugger", value: "Ready", detail: config.harnessMode === "workspace-default" ? "Local default harness" : "Harness runtime loaded" }] : []),
+    ...(isDebuggerReady(config) ? [{ id: "debugger", label: "Debugger", value: "Ready", detail: config.harnessMode === "workspace-default" ? "Project default harness" : "Harness runtime loaded" }] : []),
     ...(config.artifactsEnabled ? [{ id: "artifacts", label: "Artifacts", value: config.artifactCount === undefined ? "Ready" : String(config.artifactCount), detail: config.artifactCount === undefined ? "Catalog loaded" : "Retained outputs" }] : []),
     ...(config.inspectorEnabled ? [{ id: "inspector", label: "Inspector", value: "Loaded", detail: "Read-only evidence source" }] : []),
     ...(config.customizationAnalysisEnabled ? [{ id: "customizations", label: "Customizations", value: config.customizationAnalyzed ? String(config.customizationDefinitionCount) : "Available", detail: config.customizationAnalyzed ? "Definitions discovered" : "Local collector ready" }] : []),
@@ -214,7 +217,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
     return {
       mode: "empty",
       title: "No working context is loaded.",
-      detail: "Start Studio with a workspace-enabled launcher or a configured Harness, experiment, evidence, or artifact source.",
+      detail: "Start Studio with a Project-enabled launcher or a configured Harness, experiment, evidence, or artifact source.",
       secondaryActions: [],
       facts: [],
     };
@@ -222,7 +225,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
 
   const primaryAction: StudioOverviewAction | undefined = config.experimentEnabled || config.evidenceEnabled
     ? { area: "compare", label: "Open Compare" }
-    : config.aguiEnabled
+    : isDebuggerReady(config)
       ? { area: "debugger", label: "Open Debugger" }
       : config.artifactsEnabled
         ? { area: "artifacts", label: "Open Artifacts" }
@@ -236,7 +239,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
       ? "Comparison setup is ready."
       : config.evidenceEnabled
         ? "Evidence results are ready."
-        : config.aguiEnabled
+        : isDebuggerReady(config)
           ? "Live debugging is ready."
           : config.artifactsEnabled
             ? "Artifact evidence is ready."
@@ -247,12 +250,28 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
     ...(primaryAction === undefined ? {} : { primaryAction }),
     secondaryActions: [
       ...(config.experimentEnabled || config.evidenceEnabled ? [{ area: "compare" as const, label: "Open Compare" }] : []),
-      ...(config.aguiEnabled ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
+      ...(isDebuggerReady(config) ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
       ...(config.artifactsEnabled ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
       ...(config.customizationAnalysisEnabled ? [{ area: "customizations" as const, label: config.customizationAnalyzed ? "Open Customizations" : "Analyze Customizations" }] : []),
     ].filter((action) => action.area !== primaryAction?.area),
     facts: configuredFacts,
   };
+}
+
+function isDebuggerReady(config: StudioConfig): boolean {
+  return config.aguiEnabled && (config.harnessMode !== "workspace-default" || config.workspaceConnected);
+}
+
+export function studioProjectGateRequired(config: StudioConfig, hasConfiguredSources: boolean): boolean {
+  const independentContext = hasConfiguredSources
+    || config.inspectorEnabled
+    || config.evidenceEnabled
+    || config.experimentEnabled
+    || config.artifactsEnabled
+    || config.harnessMode === "configured";
+  return config.workspaceDiscoveryEnabled
+    && !config.workspaceConnected
+    && !independentContext;
 }
 
 export function capabilitySummary(config: StudioConfig): { ready: number; partial: number; foundation: number } {

--- a/packages/harness-studio/src/app/studio-shell-model.ts
+++ b/packages/harness-studio/src/app/studio-shell-model.ts
@@ -19,6 +19,7 @@ export interface StudioConfig {
   artifactCount?: number;
   evidenceEnabled: boolean;
   experimentEnabled: boolean;
+  experimentRunnable: boolean;
   gitEnabled: boolean;
   harnessMode: "none" | "configured" | "workspace-default";
   historyEnabled: boolean;
@@ -70,9 +71,14 @@ export interface StudioOverviewModel {
   facts: readonly StudioOverviewFact[];
 }
 
-export function studioDestinations(config: StudioConfig): readonly StudioDestination[] {
+export function studioDestinations(config: StudioConfig, activeCompareSurface?: StudioCompareSurface): readonly StudioDestination[] {
   const compareAvailable = config.experimentEnabled || config.evidenceEnabled;
   const debuggerReady = isDebuggerReady(config);
+  const artifactsReady = hasUsableArtifacts(config);
+  const availableCompareSurfaces = compareSurfaces(config);
+  const effectiveCompareSurface = activeCompareSurface !== undefined && availableCompareSurfaces.includes(activeCompareSurface)
+    ? activeCompareSurface
+    : availableCompareSurfaces[0];
   return [
     { id: "overview", label: "Overview", group: "Control", availability: "ready", status: "Control plane" },
     {
@@ -115,8 +121,8 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
       id: "artifacts",
       label: "Artifacts",
       group: "Observe",
-      availability: config.artifactsEnabled ? "ready" : config.workspaceConnected ? "partial" : "foundation",
-      status: config.artifactsEnabled
+      availability: artifactsReady ? "ready" : config.workspaceConnected ? "partial" : "foundation",
+      status: artifactsReady
         ? config.artifactCount === undefined
           ? "Compatibility catalog"
           : `${config.artifactCount} artifact${config.artifactCount === 1 ? "" : "s"}`
@@ -137,8 +143,16 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
       id: "compare",
       label: "Compare",
       group: "Validate",
-      availability: compareAvailable || config.sessionCount >= 2 ? "ready" : config.workspaceConnected ? "partial" : "foundation",
-      status: config.sessionCount >= 2 ? "Session compare" : config.experimentEnabled ? "Harness Bench" : config.evidenceEnabled ? "Frozen results" : config.workspaceConnected ? "Choose 2 sessions" : "Project required",
+      availability: effectiveCompareSurface === "bench" && !config.experimentRunnable
+        ? "partial"
+        : compareAvailable || config.sessionCount >= 2 ? "ready" : config.workspaceConnected ? "partial" : "foundation",
+      status: effectiveCompareSurface === "bench"
+        ? config.experimentRunnable ? "Harness Bench" : "Comparison blocked"
+        : effectiveCompareSurface === "results"
+          ? "Frozen results"
+          : effectiveCompareSurface === "sessions"
+            ? "Session compare"
+            : config.workspaceConnected ? "Choose 2 sessions" : "Project required",
     },
   ];
 }
@@ -156,6 +170,7 @@ export function inspectorSurfaces(config: StudioConfig): readonly StudioInspecto
 }
 
 export function studioOverview(config: StudioConfig): StudioOverviewModel {
+  const artifactsReady = hasUsableArtifacts(config);
   if (config.workspaceConnected) {
     return {
       mode: "workspace",
@@ -168,7 +183,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
         ...(config.workspaceWorkbenchEnabled ? [{ area: "inputs" as const, label: "Review Inputs" }] : []),
         ...(config.sessionCount >= 2 || config.experimentEnabled || config.evidenceEnabled ? [{ area: "compare" as const, label: "Open Compare" }] : []),
         ...(isDebuggerReady(config) ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
-        ...(config.artifactsEnabled ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
+        ...(artifactsReady ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
       ],
       facts: [
         {
@@ -186,8 +201,8 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
         {
           id: "artifacts",
           label: "Artifacts",
-          value: config.artifactsEnabled && config.artifactCount !== undefined ? String(config.artifactCount) : "—",
-          detail: config.artifactsEnabled ? "Retained outputs" : "No observed outputs",
+          value: config.artifactCount !== undefined ? String(config.artifactCount) : "—",
+          detail: artifactsReady ? "Retained outputs" : "No observed outputs",
         },
         {
           id: "repository",
@@ -210,10 +225,15 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
   }
 
   const configuredFacts: StudioOverviewFact[] = [
-    ...(config.experimentEnabled ? [{ id: "experiment", label: "Harness Bench", value: "Ready", detail: "Experiment manifest loaded" }] : []),
+    ...(config.experimentEnabled ? [{
+      id: "experiment",
+      label: "Harness Bench",
+      value: config.experimentRunnable ? "Ready" : "Blocked",
+      detail: config.experimentRunnable ? "Runnable experiment loaded" : "Checkpoint source unavailable",
+    }] : []),
     ...(config.evidenceEnabled ? [{ id: "evidence", label: "Evidence results", value: "Ready", detail: "Frozen verdict loaded" }] : []),
     ...(isDebuggerReady(config) ? [{ id: "debugger", label: "Debugger", value: "Ready", detail: config.harnessMode === "workspace-default" ? "Project default harness" : "Harness runtime loaded" }] : []),
-    ...(config.artifactsEnabled ? [{ id: "artifacts", label: "Artifacts", value: config.artifactCount === undefined ? "Ready" : String(config.artifactCount), detail: config.artifactCount === undefined ? "Catalog loaded" : "Retained outputs" }] : []),
+    ...(artifactsReady ? [{ id: "artifacts", label: "Artifacts", value: config.artifactCount === undefined ? "Ready" : String(config.artifactCount), detail: config.artifactCount === undefined ? "Catalog loaded" : "Retained outputs" }] : []),
     ...(config.inspectorEnabled ? [{ id: "inspector", label: "Inspector", value: "Loaded", detail: "Read-only evidence source" }] : []),
     ...(config.customizationAnalysisEnabled ? [{ id: "customizations", label: "Customizations", value: config.customizationAnalyzed ? String(config.customizationDefinitionCount) : "Available", detail: config.customizationAnalyzed ? "Definitions discovered" : "Local collector ready" }] : []),
   ];
@@ -232,7 +252,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
     ? { area: "compare", label: "Open Compare" }
     : isDebuggerReady(config)
       ? { area: "debugger", label: "Open Debugger" }
-      : config.artifactsEnabled
+      : artifactsReady
         ? { area: "artifacts", label: "Open Artifacts" }
         : config.customizationAnalysisEnabled
           ? { area: "customizations", label: config.customizationAnalyzed ? "Open Customizations" : "Analyze Customizations" }
@@ -241,12 +261,12 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
   return {
     mode: "configured",
     title: config.experimentEnabled
-      ? "Comparison setup is ready."
+      ? config.experimentRunnable ? "Comparison setup is ready." : "Comparison setup needs attention."
       : config.evidenceEnabled
         ? "Evidence results are ready."
         : isDebuggerReady(config)
           ? "Live debugging is ready."
-          : config.artifactsEnabled
+          : artifactsReady
             ? "Artifact evidence is ready."
             : config.customizationAnalysisEnabled
               ? "Customization analysis is available."
@@ -256,7 +276,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
     secondaryActions: [
       ...(config.experimentEnabled || config.evidenceEnabled ? [{ area: "compare" as const, label: "Open Compare" }] : []),
       ...(isDebuggerReady(config) ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
-      ...(config.artifactsEnabled ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
+      ...(artifactsReady ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
       ...(config.customizationAnalysisEnabled ? [{ area: "customizations" as const, label: config.customizationAnalyzed ? "Open Customizations" : "Analyze Customizations" }] : []),
     ].filter((action) => action.area !== primaryAction?.area),
     facts: configuredFacts,
@@ -267,12 +287,16 @@ function isDebuggerReady(config: StudioConfig): boolean {
   return config.aguiEnabled && (config.harnessMode !== "workspace-default" || config.projectExecutionEnabled);
 }
 
+function hasUsableArtifacts(config: StudioConfig): boolean {
+  return config.artifactsEnabled && (config.artifactCount === undefined || config.artifactCount > 0);
+}
+
 export function studioProjectGateRequired(config: StudioConfig, hasConfiguredSources: boolean): boolean {
   const independentContext = hasConfiguredSources
     || config.inspectorEnabled
     || config.evidenceEnabled
     || config.experimentEnabled
-    || config.artifactsEnabled
+    || hasUsableArtifacts(config)
     || config.harnessMode === "configured";
   return config.workspaceDiscoveryEnabled
     && !config.workspaceConnected

--- a/packages/harness-studio/src/app/studio-shell-model.ts
+++ b/packages/harness-studio/src/app/studio-shell-model.ts
@@ -26,6 +26,7 @@ export interface StudioConfig {
   workspaceWorkbenchEnabled: boolean;
   workspaceDiscoveryEnabled: boolean;
   workspaceConnected: boolean;
+  projectExecutionEnabled: boolean;
   activeProjectId?: string;
   projectRevision?: number;
   sessionCount: number;
@@ -101,7 +102,7 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
       label: "Sessions",
       group: "Observe",
       availability: config.workspaceConnected ? "ready" : "partial",
-      status: config.workspaceConnected ? `${config.sessionCount} session${config.sessionCount === 1 ? "" : "s"}` : "Open Project",
+      status: config.workspaceConnected ? `${config.sessionCount} session${config.sessionCount === 1 ? "" : "s"}` : "Project required",
     },
     {
       id: "commits",
@@ -126,7 +127,11 @@ export function studioDestinations(config: StudioConfig): readonly StudioDestina
       label: "Debugger",
       group: "Run",
       availability: debuggerReady ? "ready" : "foundation",
-      status: debuggerReady ? config.harnessMode === "workspace-default" ? "Project default" : "Live runs" : config.harnessMode === "workspace-default" ? "Project required" : "Harness required",
+      status: debuggerReady
+        ? config.harnessMode === "workspace-default" ? "Project default" : "Live runs"
+        : config.harnessMode === "workspace-default"
+          ? config.workspaceConnected ? "Read-only Project" : "Project required"
+          : "Harness required",
     },
     {
       id: "compare",
@@ -162,7 +167,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
       secondaryActions: [
         ...(config.workspaceWorkbenchEnabled ? [{ area: "inputs" as const, label: "Review Inputs" }] : []),
         ...(config.sessionCount >= 2 || config.experimentEnabled || config.evidenceEnabled ? [{ area: "compare" as const, label: "Open Compare" }] : []),
-        ...(config.aguiEnabled ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
+        ...(isDebuggerReady(config) ? [{ area: "debugger" as const, label: "Open Debugger" }] : []),
         ...(config.artifactsEnabled ? [{ area: "artifacts" as const, label: "Open Artifacts" }] : []),
       ],
       facts: [
@@ -259,7 +264,7 @@ export function studioOverview(config: StudioConfig): StudioOverviewModel {
 }
 
 function isDebuggerReady(config: StudioConfig): boolean {
-  return config.aguiEnabled && (config.harnessMode !== "workspace-default" || config.workspaceConnected);
+  return config.aguiEnabled && (config.harnessMode !== "workspace-default" || config.projectExecutionEnabled);
 }
 
 export function studioProjectGateRequired(config: StudioConfig, hasConfiguredSources: boolean): boolean {

--- a/packages/harness-studio/src/app/styles/shell.css
+++ b/packages/harness-studio/src/app/styles/shell.css
@@ -21,6 +21,7 @@
 }
 
 .studio-loading p { margin: 0; }
+.studio-loading > button { margin-top: var(--space-sm); }
 
 .studio-workspace-gate {
   position: fixed;
@@ -516,6 +517,7 @@
 .empty-workspace > span { width: var(--space-xxxl); height: var(--space-xxxl); margin-bottom: var(--space-md); display: grid; place-items: center; border: 1px solid var(--color-border-strong); border-radius: var(--radius-xs); color: var(--color-primary); background: var(--color-primary-soft); }
 .empty-workspace h1 { margin: var(--space-xs) 0; }
 .empty-workspace p { max-width: 64ch; margin: 0; color: var(--color-text-muted); }
+.empty-workspace > button { margin-top: var(--space-lg); }
 .empty-workspace code { margin-top: var(--space-lg); border: 1px solid var(--color-border); border-radius: var(--radius-xs); padding: var(--space-xs) var(--space-sm); color: var(--color-primary); background: var(--color-surface); }
 
 .evidence-results { width: 100%; height: 100%; margin: 0; padding: 0; overflow: auto; }
@@ -592,6 +594,9 @@
      word would otherwise squeeze the title down to a single letter, and the
      same state is already labelled on the navigation row it came from. */
   .studio-context-state strong { display: none; }
+  .studio-source-switcher > button { width: var(--toolbar-target); height: var(--toolbar-target); min-height: var(--toolbar-target); justify-content: center; padding: 0; }
+  .studio-source-switcher > button > span { display: none; }
+  .studio-source-switcher > button em { position: absolute; top: 1px; right: 1px; min-width: var(--space-md); min-height: var(--space-md); }
   .studio-theme-toggle { width: var(--toolbar-target); height: var(--toolbar-target); min-height: var(--toolbar-target); justify-content: center; padding: 0; }
   .studio-theme-toggle span { display: none; }
   .studio-context-bar.has-surface-navigation .studio-context-title { display: none; }

--- a/packages/harness-studio/src/app/styles/shell.css
+++ b/packages/harness-studio/src/app/styles/shell.css
@@ -150,6 +150,7 @@
 .studio-product-brand > div { min-width: 0; display: flex; align-items: baseline; gap: var(--space-xs); }
 .studio-product-brand strong { font-size: var(--type-label-size); line-height: var(--type-label-line); }
 .studio-product-brand small { color: var(--color-text-subtle); }
+.studio-project-close { display: none; width: var(--toolbar-target); height: var(--toolbar-target); margin-left: auto; place-items: center; padding: 0; }
 
 .studio-primary-nav > nav {
   min-height: 0;
@@ -158,28 +159,69 @@
   padding: var(--space-xs) 0;
 }
 
-.studio-nav-group { padding: var(--space-xs) 0; }
-.studio-nav-group + .studio-nav-group { border-top: 1px solid var(--color-border); }
-
-.studio-nav-group h2 {
-  height: var(--pane-header-height);
-  margin: 0;
+.studio-project-heading {
+  min-height: var(--pane-header-height);
+  flex: none;
   padding: 0 var(--space-sm);
   display: flex;
   align-items: center;
-  color: var(--color-text-subtle);
-  font-size: var(--type-pane-size);
-  font-weight: var(--weight-semibold);
-  line-height: var(--type-pane-line);
-  letter-spacing: var(--type-pane-track);
+  justify-content: space-between;
+  gap: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-sidebar);
 }
 
-.studio-nav-group button {
+.studio-project-heading > div { min-width: 0; display: flex; align-items: center; gap: var(--space-xs); }
+.studio-project-heading strong { font-size: var(--type-pane-size); line-height: var(--type-pane-line); }
+.studio-project-heading span { color: var(--color-text-subtle); font-size: var(--type-meta-size); font-variant-numeric: tabular-nums; }
+.studio-project-heading > button { width: var(--toolbar-target); height: var(--toolbar-target); display: grid; place-items: center; padding: 0; border: 0; color: var(--color-text-muted); background: transparent; }
+.studio-project-heading > button:hover { color: var(--color-text); background: var(--color-surface-hover); }
+.studio-project-heading > button:disabled { color: var(--color-text-subtle); }
+.studio-project-spinner { width: var(--space-md); height: var(--space-md); border: 2px solid var(--color-border-strong); border-top-color: var(--color-primary); border-radius: var(--radius-full); animation: workspace-progress-spin 720ms linear infinite; }
+
+.studio-project-list { padding-bottom: var(--space-md); }
+.studio-project-entry { border-bottom: 1px solid var(--color-border); }
+.studio-project-entry.active { background: var(--color-surface-subtle); }
+.studio-project-entry.unavailable .studio-project-row > button:first-child { color: var(--color-text-muted); }
+.studio-project-entry.unavailable .studio-project-row small { color: var(--color-danger); }
+.studio-project-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) var(--toolbar-target); align-items: center; }
+.studio-project-row > button:first-child {
+  min-width: 0;
+  min-height: var(--navigation-row-height);
+  display: grid;
+  grid-template-columns: var(--toolbar-target) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-xs);
+  border: 0;
+  border-left: 2px solid transparent;
+  border-radius: var(--radius-none);
+  padding: var(--space-xs) 0 var(--space-xs) var(--space-xs);
+  color: var(--color-text);
+  background: transparent;
+  text-align: left;
+}
+.studio-project-row > button:first-child:hover { background: var(--color-surface-hover); }
+.studio-project-row > button:first-child[aria-current="true"] { border-left-color: var(--color-primary); color: var(--color-primary); background: var(--color-surface-selected); }
+.studio-project-row > button:first-child > svg { justify-self: center; }
+.studio-project-row > button:first-child > span { min-width: 0; display: grid; }
+.studio-project-row strong,
+.studio-project-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.studio-project-row strong { color: inherit; font-size: var(--type-label-size); font-weight: var(--weight-medium); }
+.studio-project-row small { color: var(--color-text-muted); font-size: var(--type-meta-size); }
+.studio-project-remove { width: var(--toolbar-target); height: var(--toolbar-target); display: grid; place-items: center; border: 0; padding: 0; color: var(--color-text-subtle); background: transparent; opacity: 0; }
+.studio-project-row:hover .studio-project-remove,
+.studio-project-remove:focus-visible { opacity: 1; }
+.studio-project-remove:hover { color: var(--color-danger); background: var(--color-danger-surface); }
+.studio-project-empty { margin: 0; padding: var(--space-lg) var(--space-md); display: flex; align-items: center; gap: var(--space-sm); color: var(--color-text-muted); }
+
+.studio-project-views { padding: var(--space-xs) 0 var(--space-sm); border-top: 1px solid var(--color-border); }
+.studio-project-views h2 { height: var(--pane-header-height); margin: 0; padding: 0 var(--space-md); display: flex; align-items: center; color: var(--color-text-subtle); font-size: var(--type-pane-size); font-weight: var(--weight-semibold); line-height: var(--type-pane-line); letter-spacing: var(--type-pane-track); }
+.studio-project-views > button {
   width: 100%;
   min-height: var(--navigation-row-height);
   display: grid;
   grid-template-columns: var(--toolbar-target) minmax(0, 1fr) var(--space-sm);
-  gap: var(--space-sm);
+  gap: var(--space-xs);
   align-items: center;
   border: 0;
   border-left: 2px solid transparent;
@@ -188,19 +230,16 @@
   color: var(--color-text);
   background: transparent;
   text-align: left;
-  font-weight: var(--weight-regular);
 }
-
-.studio-nav-group button:hover { background: var(--color-surface-hover); }
-.studio-nav-group button:active { background: var(--color-surface-active); }
-.studio-nav-group button[aria-current="page"] { border-left-color: var(--color-primary); color: var(--color-primary); background: var(--color-surface-selected); }
-.studio-nav-group button > svg { justify-self: center; }
-.studio-nav-group button > span { min-width: 0; display: grid; }
-.studio-nav-group button strong,
-.studio-nav-group button small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.studio-nav-group button strong { font-size: var(--type-label-size); font-weight: var(--weight-medium); line-height: var(--type-label-line); }
-.studio-nav-group button[aria-current="page"] strong { font-weight: var(--weight-semibold); }
-.studio-nav-group button small { color: var(--color-text-muted); }
+.studio-project-views > button:hover { background: var(--color-surface-hover); }
+.studio-project-views > button[aria-current="page"] { border-left-color: var(--color-primary); color: var(--color-primary); background: var(--color-surface-selected); }
+.studio-project-views > button > svg { justify-self: center; }
+.studio-project-views > button > span { min-width: 0; display: grid; }
+.studio-project-views > button strong,
+.studio-project-views > button small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.studio-project-views > button strong { font-size: var(--type-label-size); font-weight: var(--weight-medium); }
+.studio-project-views > button[aria-current="page"] strong { font-weight: var(--weight-semibold); }
+.studio-project-views > button small { color: var(--color-text-muted); font-size: var(--type-meta-size); }
 
 .availability-dot {
   width: var(--space-sm);
@@ -226,6 +265,7 @@
 }
 
 .studio-context-bar {
+  position: relative;
   min-width: 0;
   z-index: 20;
   padding: 0 var(--space-sm);
@@ -245,6 +285,7 @@
 }
 
 .studio-context-title { min-width: 0; flex: 1; display: flex; align-items: baseline; gap: var(--space-sm); }
+.studio-context-title small { max-width: min(32vw, 320px); overflow: hidden; color: var(--color-text-muted); text-overflow: ellipsis; white-space: nowrap; }
 .studio-context-title h1 {
   overflow: hidden;
   margin: 0;
@@ -256,7 +297,7 @@
   line-height: var(--type-subhead-line);
 }
 
-.studio-context-navigation { min-width: 0; flex: 1; display: none; }
+.studio-context-navigation { min-width: 0; flex: 1; display: block; }
 .studio-theme-toggle {
   min-height: var(--control-height);
   flex: none;
@@ -330,6 +371,7 @@
 .studio-source-menu span { color: var(--color-text-muted); font-size: var(--type-meta-size); }
 .studio-context-state { display: flex; align-items: center; gap: var(--space-sm); color: var(--color-text-muted); font-size: var(--type-meta-size); }
 .studio-context-state strong { color: var(--color-text); font-size: var(--type-meta-size); }
+.studio-project-failure { position: absolute; top: calc(var(--titlebar-height) + var(--space-xs)); right: var(--space-sm); z-index: 60; max-width: min(460px, calc(100vw - var(--space-lg))); border: 1px solid var(--color-danger); border-radius: var(--radius-sm); padding: var(--space-sm) var(--space-md); color: var(--color-danger); background: var(--color-danger-surface); box-shadow: var(--shadow-popover); font-size: var(--type-meta-size); }
 
 .studio-surface { min-width: 0; min-height: 0; overflow: auto; background: var(--color-workspace); }
 .studio-surface-inspector,
@@ -528,6 +570,8 @@
   .studio-nav-backdrop { position: fixed; inset: 0; z-index: 25; border: 0; border-radius: var(--radius-none); background: var(--color-overlay); }
   .studio-control-plane.navigation-open .studio-nav-backdrop { display: block; }
   .studio-nav-toggle { display: grid; }
+  .studio-project-close { display: grid; }
+  .studio-project-remove { opacity: 1; }
   .studio-context-bar.has-surface-navigation .studio-context-navigation { display: block; }
   .studio-surface .builder-topbar .studio-tabs,
   .studio-surface .notebook-navigation .studio-tabs,
@@ -548,8 +592,6 @@
      word would otherwise squeeze the title down to a single letter, and the
      same state is already labelled on the navigation row it came from. */
   .studio-context-state strong { display: none; }
-  .studio-context-bar > .workspace-folder-controls.is-compact button { width: var(--toolbar-target); height: var(--toolbar-target); min-height: var(--toolbar-target); justify-content: center; padding: 0; }
-  .studio-context-bar > .workspace-folder-controls.is-compact button span { display: none; }
   .studio-theme-toggle { width: var(--toolbar-target); height: var(--toolbar-target); min-height: var(--toolbar-target); justify-content: center; padding: 0; }
   .studio-theme-toggle span { display: none; }
   .studio-context-bar.has-surface-navigation .studio-context-title { display: none; }
@@ -580,4 +622,5 @@
 
 @media (prefers-reduced-motion: reduce) {
   .studio-primary-nav { transition: none; }
+  .studio-project-spinner { animation: none; }
 }

--- a/packages/harness-studio/src/app/styles/workbench.css
+++ b/packages/harness-studio/src/app/styles/workbench.css
@@ -1473,6 +1473,13 @@
 .artifact-runtime-tabs button:focus-visible { outline: 2px solid var(--color-focus); outline-offset: -2px; }
 .artifact-runtime-panel { min-width: 0; min-height: 0; display: grid; grid-template-rows: minmax(0, 1fr); overflow: hidden; }
 .artifact-runtime-frame { width: 100%; height: 100%; background: var(--color-surface); }
+.agent-react-runtime-panel { position: relative; display: block; }
+.agent-react-frame,
+.agent-react-runtime-panel > .artifact-code-preview,
+.agent-react-runtime-panel > .agent-react-starting { position: absolute; inset: 0; }
+.agent-react-frame.is-staging { visibility: hidden; pointer-events: none; }
+.agent-react-frame.is-current { visibility: visible; }
+.agent-react-runtime-panel > .agent-react-starting { display: grid; place-items: center; }
 .artifact-runtime-status { min-width: 0; margin: 0; padding: 0 var(--space-sm); display: flex; align-items: center; gap: var(--space-sm); overflow: hidden; border-top: 1px solid var(--color-border); color: var(--color-text-muted); background: var(--color-titlebar); font-size: var(--type-meta-size); }
 .artifact-runtime-status > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .artifact-runtime-retry { margin-left: auto; padding: 0 var(--space-sm); flex: none; align-self: center; border: 1px solid var(--color-border-strong); border-radius: var(--radius-xs); color: var(--color-text); background: var(--color-surface); font-size: var(--type-meta-size); }

--- a/packages/harness-studio/src/app/styles/workbench.css
+++ b/packages/harness-studio/src/app/styles/workbench.css
@@ -1919,6 +1919,7 @@
 .session-compare-table > div > * { display: flex; align-items: center; padding: var(--space-sm) var(--space-md); border-left: 1px solid var(--color-border); }
 .session-compare-table > div > :first-child { border-left: 0; }
 .session-compare-table > div > :nth-child(n + 2) { justify-content: flex-end; background: var(--color-surface-subtle); font-variant-numeric: tabular-nums; }
+.session-compare-table > .session-compare-columns > * { color: var(--color-text-muted); background: var(--color-titlebar); font-size: var(--type-meta-size); font-weight: var(--weight-medium); }
 .session-tool-sequences { display: grid; grid-template-columns: 1fr 1fr; }
 .session-tool-sequences section { min-width: 0; }
 .session-tool-sequences section + section { border-left: 1px solid var(--color-border); }
@@ -2136,6 +2137,8 @@
   .session-compare-picker,
   .session-compare-heads,
   .session-tool-sequences { grid-template-columns: minmax(0, 1fr); }
+  .session-compare-table > div { min-width: 0; grid-template-columns: minmax(0, 1fr) minmax(56px, 72px) minmax(56px, 72px); }
+  .session-compare-table > div > * { min-width: 0; padding: var(--space-sm); }
   .session-compare-picker label + label,
   .session-compare-heads article + article,
   .session-tool-sequences section + section { border-left: 0; border-top: 1px solid var(--color-border); }

--- a/packages/harness-studio/src/app/styles/workbench.css
+++ b/packages/harness-studio/src/app/styles/workbench.css
@@ -1205,9 +1205,9 @@
   .debugger-toolbar { padding-inline: var(--space-xs); }
   .step-controls button span { display: none; }
   .pause-boundary { margin-left: 0; }
-  .debugger-shell { grid-template-rows: var(--titlebar-height) 56px minmax(0, 1fr) 64px; }
-  .live-observation-bar { padding: var(--space-xs) var(--space-sm); align-items: flex-start; flex-direction: column; justify-content: center; gap: 0; }
-  .live-observation-bar strong { max-width: none; overflow: visible; white-space: normal; }
+  .debugger-shell { grid-template-rows: var(--titlebar-height) var(--pane-header-height) minmax(0, 1fr) 48px; }
+  .live-observation-bar { padding-inline: var(--space-sm); align-items: center; flex-direction: row; gap: var(--space-xs); }
+  .live-observation-bar strong { display: none; }
   .debugger-event { grid-template-columns: var(--toolbar-target) minmax(0, 1fr); }
   .notebook-viewbar > span,
   .notebook-viewbar button:not(.active) { display: none; }
@@ -1462,6 +1462,7 @@
 .artifact-empty > small { color: var(--color-primary); font-weight: var(--weight-semibold); }
 .artifact-empty h1 { margin: var(--space-xs) 0 0; font-size: var(--type-section-size); line-height: var(--type-section-line); }
 .artifact-empty p { max-width: 64ch; margin: 0; color: var(--color-text-muted); }
+.artifact-empty > button { margin-top: var(--space-md); }
 
 /* Existing Artifact Surface implementations remain mounted inside the right pane. */
 .artifact-frame { width: 100%; height: 100%; min-width: 0; min-height: 0; border: 0; background: var(--color-surface); }

--- a/packages/harness-studio/src/app/styles/workbench.css
+++ b/packages/harness-studio/src/app/styles/workbench.css
@@ -61,6 +61,8 @@
   font: inherit;
 }
 .simple-project-control > span { overflow: hidden; color: var(--color-text-muted); font-size: var(--type-meta-size); text-overflow: ellipsis; white-space: nowrap; }
+.simple-project-control > span:first-child { color: var(--color-text); font-size: var(--type-label-size); font-weight: var(--weight-semibold); }
+.simple-project-control > strong { min-height: var(--control-height); display: flex; align-items: center; overflow: hidden; border: 1px solid var(--color-border); border-radius: var(--radius-xs); padding: 0 var(--space-sm); color: var(--color-text); background: var(--color-surface-subtle); text-overflow: ellipsis; white-space: nowrap; }
 .simple-agent-controls { min-width: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-sm); }
 .simple-agent-control { min-width: 0; display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 2px var(--space-sm); }
 .simple-agent-control > span { font-size: var(--type-label-size); font-weight: var(--weight-semibold); }
@@ -1100,6 +1102,10 @@
   .simple-agent-controls,
   .simple-prompt-control,
   .simple-run-control { grid-column: 1; }
+  .simple-compare-composer.has-agent-catalog .simple-project-control,
+  .simple-compare-composer.has-agent-catalog .simple-agent-controls,
+  .simple-compare-composer.has-agent-catalog .simple-prompt-control,
+  .simple-compare-composer.has-agent-catalog .simple-run-control { grid-column: 1; }
   .simple-agent-controls { grid-template-columns: minmax(0, 1fr); }
   .simple-agent-control { grid-template-columns: minmax(0, 1fr); }
   .simple-agent-control small { grid-column: 1; white-space: normal; }
@@ -1839,11 +1845,6 @@
 }
 .workspace-open-progress > small { color: inherit; }
 @keyframes workspace-progress-spin { to { transform: rotate(360deg); } }
-.workspace-folder-controls.is-compact { display: flex; align-items: center; }
-.workspace-folder-controls.is-compact button { min-height: var(--control-height); padding-inline: var(--space-xs); font-size: var(--type-meta-size); }
-.workspace-folder-controls.is-compact > small { width: 220px; position: absolute; z-index: 3; right: 0; bottom: calc(100% + var(--space-xs)); border: 1px solid var(--color-border); padding: var(--space-xs) var(--space-sm); background: var(--color-surface); box-shadow: var(--shadow-overlay); white-space: normal; }
-.workspace-folder-controls.is-compact > .workspace-open-progress { width: 260px; position: absolute; z-index: 3; right: 0; bottom: calc(100% + var(--space-xs)); justify-content: flex-start; border: 1px solid var(--color-border); padding: var(--space-xs) var(--space-sm); background: var(--color-surface); box-shadow: var(--shadow-overlay); white-space: normal; }
-.workspace-folder-controls.is-compact > .workspace-folder-error { border-color: var(--color-danger); color: var(--color-danger); background: var(--color-danger-surface); }
 
 @media (prefers-reduced-motion: reduce) {
   .workspace-open-progress > i { animation: none; }

--- a/packages/harness-studio/src/client.ts
+++ b/packages/harness-studio/src/client.ts
@@ -19,6 +19,14 @@ export {
 } from "./app/compare-model.js";
 export { createSseParser, type SseParser } from "./app/sse-client.js";
 export {
+  isStudioProjectCatalog,
+  STUDIO_PROJECT_CATALOG_KIND,
+  type ActiveStudioProject,
+  type StudioProjectCatalog,
+  type StudioProjectDescriptor,
+  type StudioProjectKind,
+} from "./contracts/studio-project.js";
+export {
   alignToolCalls,
   compareToolCalls,
   localToolChain,

--- a/packages/harness-studio/src/contracts/experiment-setup.ts
+++ b/packages/harness-studio/src/contracts/experiment-setup.ts
@@ -106,6 +106,10 @@ export function deriveRequestProvenance(
     : "unverified-history";
 }
 
-export function canLockCompare(setup: ExperimentSetupPreview): boolean {
+export function isExperimentRunnable(setup: ExperimentSetupPreview): boolean {
   return setup.checkpointSource.status === "ready" && setup.checkpointSource.materialization.count > 0;
+}
+
+export function canLockCompare(setup: ExperimentSetupPreview): boolean {
+  return isExperimentRunnable(setup);
 }

--- a/packages/harness-studio/src/contracts/studio-project.ts
+++ b/packages/harness-studio/src/contracts/studio-project.ts
@@ -1,4 +1,5 @@
 export const STUDIO_PROJECT_CATALOG_KIND = "HarnessStudioProjectCatalogV1" as const;
+export const MAX_STUDIO_PROJECTS = 32;
 
 export type StudioProjectKind = "local" | "imported";
 
@@ -38,6 +39,7 @@ export function isStudioProjectCatalog(value: unknown): value is StudioProjectCa
     && (candidate.activeProjectId === undefined || (typeof candidate.activeProjectId === "string" && PROJECT_ID.test(candidate.activeProjectId)))
     && ["idle", "choosing", "discovering", "removing"].includes(String(candidate.stage))
     && Array.isArray(candidate.projects)
+    && candidate.projects.length <= MAX_STUDIO_PROJECTS
     && candidate.projects.every(isStudioProjectDescriptor))) return false;
   const ids = new Set(candidate.projects.map((project) => project.id));
   return ids.size === candidate.projects.length

--- a/packages/harness-studio/src/contracts/studio-project.ts
+++ b/packages/harness-studio/src/contracts/studio-project.ts
@@ -1,0 +1,59 @@
+export const STUDIO_PROJECT_CATALOG_KIND = "HarnessStudioProjectCatalogV1" as const;
+
+export type StudioProjectKind = "local" | "imported";
+
+export interface StudioProjectDescriptor {
+  id: string;
+  label: string;
+  kind: StudioProjectKind;
+  availability: "ready" | "unavailable";
+  lastOpenedAt: string;
+  sessionCount: number;
+  inputCount: number;
+  artifactCount: number;
+  gitEnabled: boolean;
+  workspaceWorkbenchEnabled: boolean;
+}
+
+export interface StudioProjectCatalog {
+  kind: typeof STUDIO_PROJECT_CATALOG_KIND;
+  revision: number;
+  activeProjectId?: string;
+  projects: StudioProjectDescriptor[];
+  stage: "idle" | "choosing" | "discovering" | "removing";
+}
+
+export interface ActiveStudioProject extends StudioProjectDescriptor {
+  revision: number;
+}
+
+const PROJECT_ID = /^project_[a-f0-9]{32}$/u;
+
+export function isStudioProjectCatalog(value: unknown): value is StudioProjectCatalog {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  if (!(candidate.kind === STUDIO_PROJECT_CATALOG_KIND
+    && Number.isInteger(candidate.revision)
+    && Number(candidate.revision) >= 0
+    && (candidate.activeProjectId === undefined || (typeof candidate.activeProjectId === "string" && PROJECT_ID.test(candidate.activeProjectId)))
+    && ["idle", "choosing", "discovering", "removing"].includes(String(candidate.stage))
+    && Array.isArray(candidate.projects)
+    && candidate.projects.every(isStudioProjectDescriptor))) return false;
+  const ids = new Set(candidate.projects.map((project) => project.id));
+  return ids.size === candidate.projects.length
+    && (candidate.activeProjectId === undefined || ids.has(candidate.activeProjectId));
+}
+
+function isStudioProjectDescriptor(value: unknown): value is StudioProjectDescriptor {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.id === "string" && PROJECT_ID.test(candidate.id)
+    && typeof candidate.label === "string" && candidate.label.length > 0 && candidate.label.length <= 160
+    && (candidate.kind === "local" || candidate.kind === "imported")
+    && (candidate.availability === "ready" || candidate.availability === "unavailable")
+    && typeof candidate.lastOpenedAt === "string"
+    && Number.isFinite(Date.parse(candidate.lastOpenedAt))
+    && ["sessionCount", "inputCount", "artifactCount"].every((key) => Number.isInteger(candidate[key]) && Number(candidate[key]) >= 0)
+    && typeof candidate.gitEnabled === "boolean"
+    && typeof candidate.workspaceWorkbenchEnabled === "boolean";
+}

--- a/packages/harness-studio/src/server/artifacts/registry/agent-react-production-runtime.ts
+++ b/packages/harness-studio/src/server/artifacts/registry/agent-react-production-runtime.ts
@@ -1,0 +1,206 @@
+import { access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { build, type Plugin } from "esbuild-wasm";
+import type { ArtifactBuildDiagnostic } from "../../../contracts/artifact.js";
+import type { BuildSnapshot, Diagnostic } from "../../../agent-react/contracts/index.js";
+import {
+  createBuildCoordinator,
+  createWorkerOxcCompiler,
+  loadAgentReactProject,
+  type AgentReactSourceStamp,
+} from "../../../agent-react/host/index.js";
+import type { TrustedRuntimePackage } from "../../../agent-react/linker/index.js";
+
+const PRODUCTION_RUNTIME_PACKAGES: readonly TrustedRuntimePackage[] = Object.freeze([
+  { specifier: "react", external: "react" },
+  { specifier: "@studio/agent-react", external: "@studio/agent-react" },
+  { specifier: "@studio/agent-react/jsx-dev-runtime", external: "@studio/agent-react/jsx-dev-runtime" },
+]);
+
+export interface AgentReactProductionCompileOptions {
+  readonly artifactRoot: string;
+  readonly entryPath: string;
+  readonly viewId: string;
+  readonly maxModules: number;
+  readonly maxSourceBytes: number;
+  readonly maxOutputBytes: number;
+  readonly timeoutMs: number;
+}
+
+export interface AgentReactProductionCompileResult {
+  readonly status: "ready" | "failed";
+  /** False for deadline failures, which must be retried instead of cached. */
+  readonly cacheable: boolean;
+  readonly code?: string;
+  readonly diagnostics: readonly ArtifactBuildDiagnostic[];
+  readonly sources: ReadonlyMap<string, AgentReactSourceStamp>;
+  readonly snapshot?: BuildSnapshot;
+}
+
+/** Compile, profile, link, and package one explicit AgentReact project. */
+export async function compileAgentReactProduction(
+  options: AgentReactProductionCompileOptions,
+): Promise<AgentReactProductionCompileResult> {
+  const compiler = createWorkerOxcCompiler({ timeoutMs: Math.min(options.timeoutMs, 5_000) });
+  try {
+    return await withinDeadline((async () => {
+      const loaded = await loadAgentReactProject({
+        root: options.artifactRoot,
+        entry: options.entryPath,
+        artifactId: options.viewId,
+        compiler,
+        allowedPackages: PRODUCTION_RUNTIME_PACKAGES.map((entry) => entry.specifier),
+        maxModules: options.maxModules,
+        maxSourceBytes: options.maxSourceBytes,
+      });
+      if (loaded.diagnostics.some((diagnostic) => diagnostic.level === "error")) {
+        return {
+          status: "failed" as const,
+          cacheable: !hasCompileDeadline(loaded.diagnostics),
+          diagnostics: loaded.diagnostics.map(artifactDiagnostic),
+          sources: loaded.sources,
+        };
+      }
+      const snapshot = await createBuildCoordinator({
+        compiler,
+        runtimePackages: PRODUCTION_RUNTIME_PACKAGES,
+        maxModules: options.maxModules,
+        maxOutputBytes: options.maxOutputBytes,
+      }).build(loaded.revision);
+      if (snapshot.status !== "ready") {
+        return {
+          status: "failed" as const,
+          cacheable: !hasCompileDeadline(snapshot.diagnostics),
+          diagnostics: snapshot.diagnostics.map(artifactDiagnostic),
+          sources: loaded.sources,
+          snapshot,
+        };
+      }
+      const code = await packageAgentReactBundle(snapshot, options.maxOutputBytes);
+      return {
+        status: "ready" as const,
+        cacheable: true,
+        code,
+        diagnostics: snapshot.diagnostics.map(artifactDiagnostic),
+        sources: loaded.sources,
+        snapshot,
+      };
+    })(), options.timeoutMs);
+  } catch (error) {
+    return {
+      status: "failed",
+      cacheable: !(error instanceof AgentReactBuildDeadlineExceeded),
+      diagnostics: [{
+        level: "error",
+        message: error instanceof AgentReactBuildDeadlineExceeded
+          ? `AgentReact build exceeded the ${options.timeoutMs}ms deadline.`
+          : error instanceof Error ? error.message : String(error),
+      }],
+      sources: new Map(),
+    };
+  } finally {
+    await compiler.close();
+  }
+}
+
+function hasCompileDeadline(diagnostics: readonly Diagnostic[]): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.code === "limit/compile-timeout");
+}
+
+async function packageAgentReactBundle(snapshot: BuildSnapshot, maxOutputBytes: number): Promise<string> {
+  const result = await build({
+    entryPoints: ["agent-react:production-entry"],
+    bundle: true,
+    write: false,
+    format: "iife",
+    platform: "browser",
+    target: "es2022",
+    sourcemap: false,
+    legalComments: "none",
+    logLevel: "silent",
+    outfile: "agent-react-preview.js",
+    define: { "process.env.NODE_ENV": '"production"' },
+    plugins: [productionBundlePlugin(snapshot)],
+  });
+  const output = result.outputFiles.find((file) => file.path.endsWith(".js"));
+  if (output === undefined) throw new Error("AgentReact production packager emitted no JavaScript.");
+  if (output.contents.byteLength > maxOutputBytes) {
+    throw new Error(`AgentReact production bundle exceeds the ${maxOutputBytes}-byte output limit.`);
+  }
+  return output.text;
+}
+
+function productionBundlePlugin(snapshot: BuildSnapshot): Plugin {
+  return {
+    name: "studio-agent-react-production",
+    setup(api) {
+      api.onResolve({ filter: /^agent-react:production-entry$/ }, () => ({ path: "production-entry", namespace: "studio-agent-react" }));
+      api.onResolve({ filter: /^agent-react:validated-bundle$/ }, () => ({ path: "validated-bundle", namespace: "studio-agent-react" }));
+      api.onLoad({ filter: /^production-entry$/, namespace: "studio-agent-react" }, () => ({
+        loader: "js",
+        contents: productionEntrySource(),
+      }));
+      api.onLoad({ filter: /^validated-bundle$/, namespace: "studio-agent-react" }, () => ({
+        loader: "js",
+        contents: snapshot.bundle,
+        resolveDir: "/",
+      }));
+      api.onResolve({ filter: /^@studio\/agent-react$/ }, async () => ({ path: await runtimeModule("index") }));
+      api.onResolve({ filter: /^@studio\/agent-react\/jsx-dev-runtime$/ }, async () => ({ path: await runtimeModule("jsx-dev-runtime") }));
+      api.onResolve({ filter: /^(?:react|react-dom)(?:\/.*)?$/ }, (args) => ({ path: fileURLToPath(import.meta.resolve(args.path)) }));
+    },
+  };
+}
+
+function productionEntrySource(): string {
+  return [
+    'import React from "react";',
+    'import {createRoot} from "react-dom/client";',
+    'import {createBrowserArtifactRuntimeSession} from "@studio/agent-react";',
+    'import * as ValidatedBundle from "agent-react:validated-bundle";',
+    "let activeSession;let activeRoot;",
+    "globalThis.__HARNESS_ARTIFACT_MOUNT__=(root,context)=>new Promise((settle)=>{",
+    "if(!(context.port instanceof MessagePort))throw new Error('AgentReact requires a transferred MessagePort.');",
+    "activeSession?.dispose();activeRoot?.unmount();",
+    "activeSession=createBrowserArtifactRuntimeSession({artifactDigest:context.agentReact.artifactDigest,buildDigest:context.agentReact.buildDigest,frameToken:context.frameToken,actionMode:context.actionMode,state:context.state},context.port);",
+    "const view=ValidatedBundle.activateArtifactRuntime(activeSession.bridge);",
+    "const Committed=()=>{React.useEffect(()=>settle(),[]);return React.createElement(view.component);};",
+    "activeRoot=createRoot(root,{onUncaughtError:(error)=>{globalThis.__HARNESS_ARTIFACT_FAIL__(error);settle();}});",
+    "activeRoot.render(React.createElement(Committed));",
+    "});",
+    "addEventListener('beforeunload',()=>{activeSession?.dispose();ValidatedBundle.deactivateArtifactRuntime();activeRoot?.unmount();},{once:true});",
+  ].join("\n");
+}
+
+async function runtimeModule(name: "index" | "jsx-dev-runtime"): Promise<string> {
+  const emitted = new URL(`../../../agent-react/runtime/${name}.js`, import.meta.url);
+  try {
+    await access(fileURLToPath(emitted));
+    return fileURLToPath(emitted);
+  } catch {
+    return fileURLToPath(new URL(`../../../agent-react/runtime/${name}.ts`, import.meta.url));
+  }
+}
+
+function artifactDiagnostic(diagnostic: Diagnostic): ArtifactBuildDiagnostic {
+  return {
+    level: diagnostic.level,
+    message: `[${diagnostic.code}] ${diagnostic.message}`,
+    ...(diagnostic.module === undefined ? {} : { source: diagnostic.module.replace(/^\//u, "") }),
+    ...(diagnostic.line === undefined ? {} : { line: diagnostic.line }),
+    ...(diagnostic.column === undefined ? {} : { column: diagnostic.column }),
+  };
+}
+
+class AgentReactBuildDeadlineExceeded extends Error {}
+
+async function withinDeadline<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([work, new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new AgentReactBuildDeadlineExceeded()), timeoutMs);
+    })]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/harness-studio/src/server/artifacts/registry/artifact-build-runtimes.ts
+++ b/packages/harness-studio/src/server/artifacts/registry/artifact-build-runtimes.ts
@@ -6,6 +6,12 @@ export const REACT_SOURCE_BUILD_RUNTIME: ArtifactBuildRuntimeImplementation = Ob
   module: { kind: "source" },
 } satisfies ArtifactBuildRuntimeImplementation);
 
+export const AGENT_REACT_BUILD_RUNTIME: ArtifactBuildRuntimeImplementation = Object.freeze({
+  id: "studio.agent-react",
+  version: "1",
+  module: { kind: "agent-react" },
+} satisfies ArtifactBuildRuntimeImplementation);
+
 export const SVG_REACT_BUILD_RUNTIME: ArtifactBuildRuntimeImplementation = Object.freeze({
   id: "studio.svg-react",
   version: "1",

--- a/packages/harness-studio/src/server/artifacts/registry/artifact-catalog.ts
+++ b/packages/harness-studio/src/server/artifacts/registry/artifact-catalog.ts
@@ -98,6 +98,7 @@ const DOCUMENT_EXTENSIONS = new Set([".pptx", ".xlsx", ".docx", ".pdf"]);
  * server-side format selector: the browser consumes only the selected Surface.
  */
 export const PROVIDER_HOSTED_CANVAS_TSX_FORMAT = "cursor-canvas-tsx";
+export const AGENT_REACT_TSX_FORMAT = "agent-react-tsx";
 
 export class ArtifactCatalogContractError extends Error {
   constructor(message: string) {
@@ -482,6 +483,7 @@ export function resolveArtifactFamily(path: string, kind = resolveArtifactKind(p
  * the wire and gives translators nothing to work with.
  */
 export function resolveArtifactFormatCode(path: string): string {
+  if (path.toLowerCase().endsWith(".agent.canvas.tsx")) return AGENT_REACT_TSX_FORMAT;
   if (path.toLowerCase().endsWith(".canvas.tsx")) return PROVIDER_HOSTED_CANVAS_TSX_FORMAT;
   const extension = extname(path).toLowerCase();
   return extension === "" ? "file" : extension.slice(1);

--- a/packages/harness-studio/src/server/artifacts/registry/artifact-compile-runtime.ts
+++ b/packages/harness-studio/src/server/artifacts/registry/artifact-compile-runtime.ts
@@ -13,9 +13,13 @@ import {
 } from "../../../contracts/artifact.js";
 import type { ArtifactBuildRuntimeImplementation } from "../../../contracts/artifact.js";
 import { REACT_SOURCE_BUILD_RUNTIME } from "./artifact-build-runtimes.js";
+import { compileAgentReactProduction } from "./agent-react-production-runtime.js";
 import { digestHex, type ArtifactEntry } from "./artifact-catalog.js";
 
-const COMPILE_RUNTIME_VERSION = "3";
+// This version participates in immutable build/preview URLs. Bump it whenever
+// generated preview HTML or its Host protocol changes so deployed clients can
+// never reuse an incompatible cached frame document.
+const COMPILE_RUNTIME_VERSION = "5";
 const MAX_DIAGNOSTICS = 32;
 const MAX_DIAGNOSTIC_LENGTH = 600;
 const MAX_RETAINED_BUILDS = 64;
@@ -153,7 +157,36 @@ async function compileArtifactRevision(
   let diagnostics: ArtifactBuildDiagnostic[] = [];
   let status: ArtifactBuildSnapshot["status"] = "ready";
   let timedOut = false;
-  try {
+  let agentReact: ArtifactBuildSnapshot["agentReact"];
+  if (buildRuntime.module.kind === "agent-react") {
+    const result = await compileAgentReactProduction({
+      artifactRoot: root,
+      entryPath,
+      viewId: agentReactViewId(options.entry.label),
+      maxModules: limits.maxSourceFiles,
+      maxSourceBytes: limits.maxSourceBytes,
+      maxOutputBytes: limits.maxOutputBytes,
+      timeoutMs: limits.timeoutMs,
+    });
+    for (const [path, stamp] of result.sources) sources.set(path, stamp);
+    status = result.status;
+    timedOut = !result.cacheable;
+    diagnostics = [...result.diagnostics];
+    code = result.code;
+    if (result.snapshot?.status === "ready" && result.snapshot.viewDeclaration !== undefined) {
+      agentReact = {
+        protocolVersion: "agent-react/1",
+        artifactDigest: result.snapshot.artifactDigest,
+        buildDigest: result.snapshot.buildDigest,
+        buildPolicyDigest: result.snapshot.buildPolicyDigest,
+        view: {
+          id: result.snapshot.viewDeclaration.id,
+          state: result.snapshot.viewDeclaration.state,
+          capabilities: result.snapshot.viewDeclaration.capabilities,
+        },
+      };
+    }
+  } else try {
     const result = await withCompileTimeout(build({
       absWorkingDir: root,
       entryPoints: ["artifact-runtime:entry"],
@@ -198,6 +231,7 @@ async function compileArtifactRevision(
     runtime: { id: "studio.sandboxed-react", version: COMPILE_RUNTIME_VERSION },
     ...(status === "ready" ? { previewUri: `${base}/builds/${digestHex(buildId)}/preview` } : {}),
     diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
+    ...(agentReact === undefined ? {} : { agentReact }),
   };
   const compiled = { snapshot, ...(code === undefined ? {} : { code }), css, sources };
   // An abandoned build is still running and still mutating `sources`, so its
@@ -226,6 +260,7 @@ export function artifactPreviewHtml(compiled: CompiledArtifactPreview): string {
     revisionId: compiled.snapshot.revisionId,
     buildId: compiled.snapshot.buildId,
     runtimeId: compiled.snapshot.runtime.id,
+    ...(compiled.snapshot.agentReact === undefined ? {} : { agentReact: compiled.snapshot.agentReact }),
   });
   const code = escapeInlineScript(compiled.code);
   const css = compiled.css.replaceAll("</style", "<\\/style");
@@ -246,12 +281,12 @@ function previewBootstrap(identity: string): string {
   return [
     "(()=>{",
     `const expected=${identity};`,
-    "let port;let started=false;let reported=false;",
+    "let port;let frameToken;let readyTimer;let started=false;let reported=false;",
     "const fail=(error)=>{",
     "if(reported||port===undefined)return;",
     "reported=true;",
     "const detail=(error&&error.message)||error;",
-    'port.postMessage({...expected,type:"renderFailed",message:String(detail===undefined||detail===null?"Artifact preview failed at runtime.":detail).slice(0,600)});',
+    'port.postMessage({...expected,...(frameToken===undefined?{}:{frameToken}),type:"renderFailed",message:String(detail===undefined||detail===null?"Artifact preview failed at runtime.":detail).slice(0,600)});',
     "};",
     "globalThis.__HARNESS_ARTIFACT_FAIL__=fail;",
     'addEventListener("error",(event)=>fail(event.error||event.message));',
@@ -268,21 +303,35 @@ function previewBootstrap(identity: string): string {
     'script.onerror=()=>{URL.revokeObjectURL(url);rejectBundle(new Error("Artifact bundle could not start."))};',
     "document.head.append(script)",
     "});",
+    "const waitForRenderBoundary=()=>new Promise((resolveBoundary)=>{",
+    "let settled=false;",
+    "const finish=()=>{if(settled)return;settled=true;clearTimeout(fallback);resolveBoundary()};",
+    "const fallback=setTimeout(finish,250);",
+    'if(document.visibilityState!=="visible"){finish();return}',
+    "requestAnimationFrame(()=>requestAnimationFrame(finish));",
+    "});",
     'addEventListener("message",(event)=>{',
     "const message=event.data;const incoming=event.ports&&event.ports[0];",
-    'if(started||!incoming||!message||message.type!=="runtime.init")return;',
+    'if(event.source!==parent||started||!incoming||!message||message.type!=="runtime.init")return;',
     "if(message.artifactId!==expected.artifactId||message.revisionId!==expected.revisionId",
     "||message.buildId!==expected.buildId||message.runtimeId!==expected.runtimeId)return;",
-    "started=true;port=incoming;",
+    "if(expected.agentReact&&(message.agentReact?.buildDigest!==expected.agentReact.buildDigest||typeof message.frameToken!=='string'||!['dry-run','live'].includes(message.actionMode)||!message.state||typeof message.state!=='object'))return;",
+    "started=true;clearTimeout(readyTimer);port=incoming;frameToken=message.frameToken;",
     "applyTheme(message.theme);",
     'port.onmessage=(update)=>{if(update.data&&update.data.type==="runtime.theme")applyTheme(update.data.theme)};',
     "port.start();",
     "executeBundle()",
-    '.then(()=>globalThis.__HARNESS_ARTIFACT_MOUNT__(document.getElementById("artifact-root"),{...expected,theme:document.documentElement.dataset.artifactTheme}))',
-    ".then(()=>new Promise(resolveFrame=>requestAnimationFrame(()=>requestAnimationFrame(resolveFrame))))",
-    '.then(()=>{if(!reported)port.postMessage({...expected,type:"renderCompleted"})})',
+    '.then(()=>globalThis.__HARNESS_ARTIFACT_MOUNT__(document.getElementById("artifact-root"),{...expected,theme:document.documentElement.dataset.artifactTheme,port,frameToken:message.frameToken,actionMode:message.actionMode,state:message.state||{}}))',
+    ".then(waitForRenderBoundary)",
+    '.then(()=>{if(!reported)port.postMessage({...expected,...(frameToken===undefined?{}:{frameToken}),type:"renderCompleted"})})',
     ".catch(fail);",
     "},{once:false});",
+    "const announceReady=(attempt=0)=>{",
+    "if(started||!expected.agentReact||parent===self||attempt>=40)return;",
+    'parent.postMessage({...expected,type:"runtime.ready"},"*");',
+    "readyTimer=setTimeout(()=>announceReady(attempt+1),250);",
+    "};",
+    "announceReady();",
     "})();",
   ].join("");
 }
@@ -539,4 +588,17 @@ function isWithin(root: string, path: string): boolean {
 
 function escapeInlineScript(source: string): string {
   return source.replaceAll("</script", "<\\/script").replaceAll("<!--", "<\\!--");
+}
+
+function agentReactViewId(label: string): string {
+  const suffix = ".agent.canvas.tsx";
+  const basenameLabel = basename(label);
+  if (!basenameLabel.toLowerCase().endsWith(suffix)) {
+    throw new Error("AgentReact build runtime requires a '*.agent.canvas.tsx' entry.");
+  }
+  const id = basenameLabel.slice(0, -suffix.length);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(id)) {
+    throw new Error("AgentReact view id must be a portable filename stem.");
+  }
+  return id;
 }

--- a/packages/harness-studio/src/server/artifacts/registry/artifact-plugin-registry.ts
+++ b/packages/harness-studio/src/server/artifacts/registry/artifact-plugin-registry.ts
@@ -25,12 +25,14 @@ import type {
 } from "../../../contracts/artifact.js";
 import {
   PROVIDER_HOSTED_CANVAS_TSX_FORMAT,
+  AGENT_REACT_TSX_FORMAT,
   resolveArtifactFormatCode,
   resolveArtifactKind,
   type ArtifactEntry,
   type ArtifactKind,
 } from "./artifact-catalog.js";
 import {
+  AGENT_REACT_BUILD_RUNTIME,
   MERMAID_REACT_BUILD_RUNTIME,
   REACT_SOURCE_BUILD_RUNTIME,
   SVG_REACT_BUILD_RUNTIME,
@@ -181,6 +183,28 @@ function studioCodePreviewResolution(entry: ArtifactEntry): ArtifactPluginBindin
   };
 }
 
+function studioAgentReactResolution(entry: ArtifactEntry): ArtifactPluginBinding | undefined {
+  if (entry.kind !== "code" || resolveArtifactFormatCode(entry.label) !== AGENT_REACT_TSX_FORMAT) return undefined;
+  return {
+    backing: "code",
+    adapter: RAW_ARTIFACT_ADAPTER,
+    buildRuntime: AGENT_REACT_BUILD_RUNTIME,
+    renderer: {
+      id: "studio.agent-react-preview",
+      label: "Studio AgentReact Preview",
+      provider: "studio",
+      type: "sandboxed-web",
+      status: "ready",
+    },
+    surface: {
+      kind: "studio-sandbox",
+      rendererId: "studio.agent-react-preview",
+      runtimeId: AGENT_REACT_BUILD_RUNTIME.id,
+    },
+    capabilities: ["execute", "live-update", "state", "actions"],
+  };
+}
+
 function studioDocumentPreviewResolution(entry: ArtifactEntry): ArtifactPluginBinding | undefined {
   const buildRuntime = entry.kind === "svg"
     ? SVG_REACT_BUILD_RUNTIME
@@ -216,6 +240,7 @@ function nativeRendererLabel(kind: Exclude<ArtifactKind, "unknown" | "docx" | "p
 }
 
 const PROTECTED_PLUGINS: readonly ArtifactPlugin[] = Object.freeze([
+  { id: "studio-agent-react", resolve: studioAgentReactResolution },
   { id: "studio-code-preview", resolve: studioCodePreviewResolution },
 ]);
 

--- a/packages/harness-studio/src/server/cli.ts
+++ b/packages/harness-studio/src/server/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, realpath, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { startHarnessStudioServer } from "./server.js";
 import { readSourceCatalogFile } from "./workspace/source-catalog.js";
 import { runWalnutBootstrapCli } from "./providers/walnut/cli.js";
@@ -9,6 +9,7 @@ import { runArtifactProviderCli } from "./artifacts/registry/artifact-provider-c
 import { createBundledAgentCustomizationCollector } from "./customization-collector.js";
 import { loadArtifactProviderModules } from "./artifacts/registry/artifact-provider-modules.js";
 import { discoverAcpAgentProfiles } from "./acp-agent-catalog.js";
+import { createBundledInspectorWorkspaceSessionProvider } from "./workspace/bundled-session-provider.js";
 import type { StudioAcpAgentOptions } from "./studio-types.js";
 
 const HELP = `harness-studio — local studio for harness runs and compare evidence
@@ -18,6 +19,7 @@ Usage:
   harness-studio walnut <probe|install|verify|remove> [options]
   harness-studio artifact-provider <list|activate|deactivate> [options]
   harness-studio --help
+  harness-studio --version
 
 Options:
   --inspector <file>  self-contained Harness Inspector HTML (enables Inspector)
@@ -62,7 +64,17 @@ Options:
                       Permit a non-loopback --host. The studio's /agui endpoint is
                       unauthenticated and runs a coding agent in --cwd.
   -h, --help          Print help without reading any file or opening a port
+  -v, --version       Print the package version without opening a port
 `;
+
+const KNOWN_OPTIONS = new Set([
+  "-h", "--help", "-v", "--version", "--inspector", "--evidence", "--harness",
+  "--experiment", "--experiment-out", "--history-catalog", "--experiment-locks",
+  "--runs", "--artifacts", "--canvas-viewers", "--canvas-sdk-root", "--canvas-sdk-media",
+  "--provider-state", "--artifact-provider-module", "--walnut-cache", "--source-catalog",
+  "--harness-id", "--runtime", "--acp-agent", "--acp-arg", "--port", "--host", "--cwd",
+  "--source-root", "--unsafe-allow-remote",
+]);
 
 export interface HarnessStudioCliIo {
   stdout: (text: string) => void;
@@ -85,6 +97,17 @@ export async function discoverDefaultInspectorReport(cwd: string): Promise<strin
     return candidate;
   } catch {
     return undefined;
+  }
+}
+
+async function validateCliPath(option: string, value: string | undefined, kind: "file" | "directory"): Promise<string | undefined> {
+  if (value === undefined) return undefined;
+  try {
+    const observed = await stat(resolve(value));
+    const valid = kind === "file" ? observed.isFile() : observed.isDirectory();
+    return valid ? undefined : `${option} must name a ${kind}: ${value}`;
+  } catch {
+    return `${option} ${kind} was not found: ${value}`;
   }
 }
 
@@ -115,6 +138,7 @@ interface ParsedArgs {
   cwd?: string;
   sourceRoot?: string;
   help: boolean;
+  version: boolean;
   error?: string;
 }
 
@@ -124,19 +148,32 @@ export function parseHarnessStudioArgs(argv: string[]): ParsedArgs {
     host: "127.0.0.1",
     allowRemote: false,
     help: false,
+    version: false,
     acpArgs: [],
     artifactProviderModules: [],
   };
+  const setError = (message: string): void => {
+    parsed.error ??= message;
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    const takeValue = (): string | undefined => {
+    const takeValue = (missingMessage = `${arg} requires a value.`): string | undefined => {
+      const next = argv[index + 1];
+      if (next === undefined || KNOWN_OPTIONS.has(next)) {
+        setError(missingMessage);
+        return undefined;
+      }
       index += 1;
-      return argv[index];
+      return next;
     };
     switch (arg) {
       case "-h":
       case "--help":
         parsed.help = true;
+        break;
+      case "-v":
+      case "--version":
+        parsed.version = true;
         break;
       case "--evidence":
         parsed.evidence = takeValue();
@@ -192,9 +229,8 @@ export function parseHarnessStudioArgs(argv: string[]): ParsedArgs {
         parsed.providerState = takeValue();
         break;
       case "--artifact-provider-module": {
-        const value = takeValue();
-        if (value === undefined) parsed.error = "--artifact-provider-module requires a package name or filesystem path.";
-        else parsed.artifactProviderModules.push(value);
+        const value = takeValue("--artifact-provider-module requires a package name or filesystem path.");
+        if (value !== undefined) parsed.artifactProviderModules.push(value);
         break;
       }
       case "--walnut-cache":
@@ -216,16 +252,18 @@ export function parseHarnessStudioArgs(argv: string[]): ParsedArgs {
         parsed.sourceRoot = takeValue();
         break;
       case "--port": {
-        const value = Number(takeValue());
+        const rawValue = takeValue();
+        if (rawValue === undefined) break;
+        const value = Number(rawValue);
         if (!Number.isInteger(value) || value < 0 || value > 65535) {
-          parsed.error = "--port must be an integer between 0 and 65535.";
+          setError("--port must be an integer between 0 and 65535.");
         } else {
           parsed.port = value;
         }
         break;
       }
       default:
-        parsed.error = `Unknown option '${arg}'.`;
+        setError(`Unknown option '${arg}'.`);
     }
   }
   return parsed;
@@ -245,9 +283,34 @@ export async function runHarnessStudioCli(argv: string[], io: HarnessStudioCliIo
     io.stdout(HELP);
     return 0;
   }
+  if (parsed.version) {
+    const manifest = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8")) as { version?: unknown };
+    io.stdout(`${typeof manifest.version === "string" ? manifest.version : "unknown"}\n`);
+    return 0;
+  }
   if (parsed.error !== undefined) {
     io.stderr(`${parsed.error}\n`);
     return 2;
+  }
+  for (const [option, value, kind] of [
+    ["--inspector", parsed.inspector, "file"],
+    ["--evidence", parsed.evidence, "directory"],
+    ["--harness", parsed.harness, "file"],
+    ["--experiment", parsed.experiment, "file"],
+    ["--history-catalog", parsed.historyCatalog, "file"],
+    ["--source-catalog", parsed.sourceCatalog, "file"],
+    ["--artifacts", parsed.artifacts, "directory"],
+    ["--canvas-viewers", parsed.canvasViewers, "directory"],
+    ["--canvas-sdk-root", parsed.canvasSdkRoot, "directory"],
+    ["--canvas-sdk-media", parsed.canvasSdkMedia, "directory"],
+    ["--cwd", parsed.cwd, "directory"],
+    ["--source-root", parsed.sourceRoot, "directory"],
+  ] as const) {
+    const pathFailure = await validateCliPath(option, value, kind);
+    if (pathFailure !== undefined) {
+      io.stderr(`${pathFailure}\n`);
+      return 2;
+    }
   }
   // The Inspector CLI writes to one conventional local path; discovering it
   // keeps `harness-studio` usable in a repository without restating flags.
@@ -255,8 +318,15 @@ export async function runHarnessStudioCli(argv: string[], io: HarnessStudioCliIo
     ? await discoverDefaultInspectorReport(parsed.cwd ?? process.cwd())
     : undefined;
   const inspectorPath = parsed.inspector ?? discoveredInspector;
-  const sourceCatalog = parsed.sourceCatalog === undefined ? [] : await readSourceCatalogFile(parsed.sourceCatalog);
-  const harnessSource = parsed.harness !== undefined ? await readFile(parsed.harness, "utf8") : undefined;
+  let sourceCatalog;
+  let harnessSource;
+  try {
+    sourceCatalog = parsed.sourceCatalog === undefined ? [] : await readSourceCatalogFile(parsed.sourceCatalog);
+    harnessSource = parsed.harness !== undefined ? await readFile(parsed.harness, "utf8") : undefined;
+  } catch (error) {
+    io.stderr(`Studio could not load its startup inputs: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
   if (parsed.acpAgent !== undefined && harnessSource === undefined && parsed.experiment === undefined) {
     io.stderr("--acp-agent requires --harness or --experiment so the ACP runtime contract is explicit.\n");
     return 2;
@@ -287,35 +357,50 @@ export async function runHarnessStudioCli(argv: string[], io: HarnessStudioCliIo
     io.stderr(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const started = await startHarnessStudioServer({
-    appDir: defaultAppDir(),
-    port: parsed.port,
-    host: parsed.host,
-    allowRemote: parsed.allowRemote,
-    customizationCollector: createBundledAgentCustomizationCollector(),
-    ...(inspectorPath !== undefined ? { inspectorReportPath: resolve(inspectorPath) } : {}),
-    ...(parsed.evidence !== undefined ? { evidenceDir: resolve(parsed.evidence) } : {}),
-    ...(harnessSource !== undefined ? { harnessSource } : {}),
-    ...(parsed.harnessId !== undefined ? { harnessId: parsed.harnessId } : {}),
-    ...(parsed.runtime !== undefined ? { runtimeId: parsed.runtime } : {}),
-    ...(preferredAcpAgent === undefined ? {} : { acpAgent: preferredAcpAgent }),
-    ...(acpAgents.length === 0 ? {} : { acpAgents }),
-    ...(parsed.runs !== undefined ? { runDirectory: resolve(parsed.runs) } : {}),
-    ...(parsed.artifacts !== undefined ? { artifactDirectory: resolve(parsed.artifacts) } : {}),
-    ...(parsed.canvasViewers !== undefined ? { canvasViewerRoot: resolve(parsed.canvasViewers) } : {}),
-    ...(parsed.canvasSdkRoot !== undefined ? { canvasSdkRoot: resolve(parsed.canvasSdkRoot) } : {}),
-    ...(parsed.canvasSdkMedia !== undefined ? { canvasSdkMedia: resolve(parsed.canvasSdkMedia) } : {}),
-    ...(parsed.providerState !== undefined ? { artifactProviderStateRoot: resolve(parsed.providerState) } : {}),
-    ...(artifactProviders.length > 0 ? { artifactProviders } : {}),
-    ...(parsed.walnutCache !== undefined ? { walnutCacheRoot: resolve(parsed.walnutCache) } : {}),
-    ...(sourceCatalog.length > 0 ? { sourceCatalog } : {}),
-    ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-    ...(sourceRoot !== undefined ? { sourceRoot } : {}),
-    ...(parsed.experiment !== undefined ? { experimentManifestPath: resolve(parsed.experiment) } : {}),
-    ...(parsed.experimentOut !== undefined ? { experimentOutputDirectory: resolve(parsed.experimentOut) } : {}),
-    ...(parsed.historyCatalog !== undefined ? { checkpointHistoryCatalogPath: resolve(parsed.historyCatalog) } : {}),
-    ...(parsed.experimentLocks !== undefined ? { experimentLockDirectory: resolve(parsed.experimentLocks) } : {}),
-  });
+  let started;
+  try {
+    started = await startHarnessStudioServer({
+      appDir: defaultAppDir(),
+      port: parsed.port,
+      host: parsed.host,
+      allowRemote: parsed.allowRemote,
+      customizationCollector: createBundledAgentCustomizationCollector(),
+      workspaceSessionProvider: createBundledInspectorWorkspaceSessionProvider(),
+      ...(inspectorPath !== undefined ? { inspectorReportPath: resolve(inspectorPath) } : {}),
+      ...(parsed.evidence !== undefined ? { evidenceDir: resolve(parsed.evidence) } : {}),
+      ...(harnessSource !== undefined ? { harnessSource } : {}),
+      ...(parsed.harnessId !== undefined ? { harnessId: parsed.harnessId } : {}),
+      ...(parsed.runtime !== undefined ? { runtimeId: parsed.runtime } : {}),
+      ...(preferredAcpAgent === undefined ? {} : { acpAgent: preferredAcpAgent }),
+      ...(acpAgents.length === 0 ? {} : { acpAgents }),
+      ...(parsed.runs !== undefined ? { runDirectory: resolve(parsed.runs) } : {}),
+      ...(parsed.artifacts !== undefined ? { artifactDirectory: resolve(parsed.artifacts) } : {}),
+      ...(parsed.canvasViewers !== undefined ? { canvasViewerRoot: resolve(parsed.canvasViewers) } : {}),
+      ...(parsed.canvasSdkRoot !== undefined ? { canvasSdkRoot: resolve(parsed.canvasSdkRoot) } : {}),
+      ...(parsed.canvasSdkMedia !== undefined ? { canvasSdkMedia: resolve(parsed.canvasSdkMedia) } : {}),
+      ...(parsed.providerState !== undefined ? { artifactProviderStateRoot: resolve(parsed.providerState) } : {}),
+      ...(artifactProviders.length > 0 ? { artifactProviders } : {}),
+      ...(parsed.walnutCache !== undefined ? { walnutCacheRoot: resolve(parsed.walnutCache) } : {}),
+      ...(sourceCatalog.length > 0 ? { sourceCatalog } : {}),
+      ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+      ...(sourceRoot !== undefined ? { sourceRoot } : {}),
+      ...(parsed.experiment !== undefined ? { experimentManifestPath: resolve(parsed.experiment) } : {}),
+      ...(parsed.experimentOut !== undefined ? { experimentOutputDirectory: resolve(parsed.experimentOut) } : {}),
+      ...(parsed.historyCatalog !== undefined ? { checkpointHistoryCatalogPath: resolve(parsed.historyCatalog) } : {}),
+      ...(parsed.experimentLocks !== undefined ? { experimentLockDirectory: resolve(parsed.experimentLocks) } : {}),
+    });
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
+    if (code === "EADDRINUSE") {
+      io.stderr(`Port ${parsed.port} is already in use on ${parsed.host}. Choose another with --port <n>.\n`);
+      return 2;
+    }
+    if (code === "EACCES") {
+      io.stderr(`Studio cannot listen on ${parsed.host}:${parsed.port}. Choose an unprivileged port with --port <n>.\n`);
+      return 2;
+    }
+    throw error;
+  }
   if (parsed.allowRemote) {
     io.stderr(
       `Warning: ${started.url} is reachable beyond loopback and has no authentication. ` +
@@ -329,8 +414,11 @@ export async function runHarnessStudioCli(argv: string[], io: HarnessStudioCliIo
   return 0;
 }
 
-const invokedDirectly =
-  typeof process.argv[1] === "string" && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedPath = typeof process.argv[1] === "string"
+  ? await realpath(process.argv[1]).catch(() => resolve(process.argv[1]!))
+  : undefined;
+const invokedDirectly = invokedPath !== undefined
+  && await realpath(fileURLToPath(import.meta.url)).catch(() => fileURLToPath(import.meta.url)) === invokedPath;
 
 if (invokedDirectly) {
   runHarnessStudioCli(process.argv.slice(2), {

--- a/packages/harness-studio/src/server/customization-collector.ts
+++ b/packages/harness-studio/src/server/customization-collector.ts
@@ -71,14 +71,14 @@ export function createAgentCustomizationCollector(options: AgentCustomizationCol
         try {
           const raw = await options.collectInventory({ provider: hostId, workspace: workspaceRoot, includeUserHome: true });
           return { hostId, raw } as const;
-        } catch {
-          return { hostId, error: true } as const;
+        } catch (error) {
+          return { hostId, error: customizationFailureReason(error) } as const;
         }
       }));
 
       for (const result of results) {
         if ("error" in result) {
-          addHostFailure(accumulator, result.hostId, generatedAt);
+          addHostFailure(accumulator, result.hostId, generatedAt, result.error);
           continue;
         }
         await addHostInventory(accumulator, result.hostId, result.raw, generatedAt, resolveSourcePath);
@@ -169,7 +169,12 @@ function createAccumulator(workspaceRoot: string, generatedAt: string): CatalogA
   };
 }
 
-function addHostFailure(accumulator: CatalogAccumulator, hostId: CustomizationHostId, observedAt: string): void {
+function addHostFailure(
+  accumulator: CatalogAccumulator,
+  hostId: CustomizationHostId,
+  observedAt: string,
+  reason = "The Host collector returned an unsupported result.",
+): void {
   const label = hostLabel(hostId);
   accumulator.hosts.set(hostId, { id: hostId, label, status: "error" });
   const observation: HostCollectionObservationV1 = {
@@ -178,7 +183,7 @@ function addHostFailure(accumulator: CatalogAccumulator, hostId: CustomizationHo
     hostId,
     status: "error",
     observedAt,
-    message: `${label} customization collection failed. Other Host results remain available.`,
+    message: `${label} customization collection failed. ${reason} Other Host results remain available; use Analyze again to retry.`,
     counts: { packages: 0, definitions: 0, registrations: 0 },
   };
   accumulator.runtimeObservations.set(observation.id, observation);
@@ -275,6 +280,22 @@ async function addHostInventory(
     },
   };
   accumulator.runtimeObservations.set(observation.id, observation);
+}
+
+function customizationFailureReason(error: unknown): string {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  const message = error instanceof Error ? error.message : String(error);
+  if (code === "EACCES" || code === "EPERM") return "Host metadata could not be read because access was denied.";
+  if (code === "ENOENT") return "A required Host metadata location is unavailable.";
+  if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND" || /dynamic require|cannot find (?:module|package)/iu.test(message)) {
+    return "The packaged collector runtime could not load a required Node module.";
+  }
+  if (error instanceof SyntaxError || /(?:parse|invalid|malformed).*(?:json|yaml|metadata)/iu.test(message)) {
+    return "Host metadata uses an unsupported or malformed format.";
+  }
+  return "The collector runtime failed unexpectedly.";
 }
 
 async function addDefinitions(

--- a/packages/harness-studio/src/server/experiment/routes.ts
+++ b/packages/harness-studio/src/server/experiment/routes.ts
@@ -1,4 +1,4 @@
-import { ResolvedHistoryDraftPreview, canLockCompare, countLaneMaterializations } from "../../contracts/experiment-setup.js";
+import { ResolvedHistoryDraftPreview, canLockCompare, countLaneMaterializations, isExperimentRunnable, type ExperimentSetupPreview } from "../../contracts/experiment-setup.js";
 import { canonicalToolEvents } from "../experiment/events.js";
 import { lockHistoryExperiment } from "../experiment/lock.js";
 import { ResolvedCheckpointHistory } from "../query/checkpoint-history.js";
@@ -36,9 +36,29 @@ export async function serveExperiment(
       lockReceipt: state.lockReceipt,
       observedIndexes: state.observedIndexes,
     });
-    respondJson(response, 200, { ...preview, acpAgents: publicAcpAgentProfiles(options) });
+    respondJson(response, 200, experimentPreviewResponse(preview, options));
   } catch (error) {
     respondJson(response, 400, { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+export async function isActiveExperimentRunnable(
+  options: HarnessStudioServerOptions,
+  state: HarnessStudioState,
+): Promise<boolean> {
+  const manifestPath = state.activeManifestPath;
+  if (manifestPath === undefined) return false;
+  try {
+    const preview = await buildExperimentPreview({
+      manifestPath,
+      trajectoryOverrides: state.trajectoryOverrides,
+      checkpointSourcePreview: state.lockReceipt === undefined ? options.checkpointSourcePreview : undefined,
+      lockReceipt: state.lockReceipt,
+      observedIndexes: state.observedIndexes,
+    });
+    return isExperimentRunnable(experimentSetupForReadiness(preview));
+  } catch {
+    return false;
   }
 }
 export async function serveCheckpointHistory(response: ServerResponse, state: HarnessStudioState): Promise<void> {
@@ -111,7 +131,7 @@ export async function lockCheckpointHistory(
     state.activeManifestPath = locked.manifestPath;
     state.trajectoryOverrides = undefined;
     state.lockReceipt = locked.receipt;
-    respondJson(response, 200, { ...preview, acpAgents: publicAcpAgentProfiles(options) });
+    respondJson(response, 200, experimentPreviewResponse(preview, options));
   } catch (error) {
     respondJson(response, 400, { error: error instanceof Error ? error.message : String(error) });
   }
@@ -209,6 +229,25 @@ export async function streamExperiment(
     return;
   }
   const experimentHost = loadedManifest.value.runtime.host;
+  try {
+    const preview = await buildExperimentPreview({
+      manifestPath,
+      trajectoryOverrides: state.trajectoryOverrides,
+      checkpointSourcePreview: state.lockReceipt === undefined ? options.checkpointSourcePreview : undefined,
+      lockReceipt: state.lockReceipt,
+      observedIndexes: state.observedIndexes,
+    });
+    const setup = experimentSetupForReadiness(preview);
+    if (!isExperimentRunnable(setup)) {
+      respondJson(response, 409, {
+        error: setup.checkpointSource.limitation ?? "The checkpoint source cannot create isolated fresh runs.",
+      });
+      return;
+    }
+  } catch (error) {
+    respondJson(response, 400, { error: error instanceof Error ? error.message : String(error) });
+    return;
+  }
   let agentSelections: Map<string, StudioAcpAgentOptions> | undefined;
   let agentSelectionEvidence: Record<string, {
     agentId: string;
@@ -216,6 +255,10 @@ export async function streamExperiment(
     protocol: "acp-v1-stdio";
     modelPolicy: "lane" | "agent-default";
   }> | undefined;
+  if (experimentHost !== "acp" && body.agentIds !== undefined) {
+    respondJson(response, 400, { error: "agentIds is available only for ACP-hosted experiments." });
+    return;
+  }
   if (experimentHost === "acp") {
     try {
       const selected = selectExperimentAcpAgents(
@@ -286,6 +329,38 @@ export async function streamExperiment(
     experimentRuns.delete(experimentId);
     response.end();
   }
+}
+
+function experimentPreviewResponse(
+  preview: Record<string, unknown>,
+  options: HarnessStudioServerOptions,
+): Record<string, unknown> {
+  const manifest = preview.manifest;
+  const runtime = manifest !== null && typeof manifest === "object" ? (manifest as { runtime?: unknown }).runtime : undefined;
+  const host = runtime !== null && typeof runtime === "object" ? (runtime as { host?: unknown }).host : undefined;
+  return host === "acp"
+    ? { ...preview, acpAgents: publicAcpAgentProfiles(options) }
+    : preview;
+}
+
+function experimentSetupForReadiness(preview: Record<string, unknown>): ExperimentSetupPreview {
+  const setup = preview.setup;
+  const checkpointSource = setup !== null && typeof setup === "object"
+    ? (setup as { checkpointSource?: unknown }).checkpointSource
+    : undefined;
+  const materialization = checkpointSource !== null && typeof checkpointSource === "object"
+    ? (checkpointSource as { materialization?: unknown }).materialization
+    : undefined;
+  const status = checkpointSource !== null && typeof checkpointSource === "object"
+    ? (checkpointSource as { status?: unknown }).status
+    : undefined;
+  const count = materialization !== null && typeof materialization === "object"
+    ? (materialization as { count?: unknown }).count
+    : undefined;
+  if (!(["ready", "unavailable"] as unknown[]).includes(status) || !Number.isInteger(count) || Number(count) < 0) {
+    throw new Error("Experiment preview does not contain a valid checkpoint readiness contract.");
+  }
+  return setup as ExperimentSetupPreview;
 }
 
 export function selectExperimentAcpAgents(

--- a/packages/harness-studio/src/server/git/routes.ts
+++ b/packages/harness-studio/src/server/git/routes.ts
@@ -3,19 +3,22 @@ import { GitHistoryError, readGitCommitAtRoot, readGitFilePatchAtRoot, readGitLo
 import { open } from "node:fs/promises";
 import { ServerResponse } from "node:http";
 import { respondJson } from "../http-utils.js";
-import { HarnessStudioState } from "../studio-types.js";
+import { HarnessStudioState, StudioWorkspace } from "../studio-types.js";
 
-function gitWorkspaceRoot(state: HarnessStudioState): string {
+type GitStudioWorkspace = StudioWorkspace & { gitRoot: string };
+
+function gitWorkspace(state: HarnessStudioState): GitStudioWorkspace {
   const workspace = state.workspace;
   if (workspace?.gitRoot === undefined) {
     throw new GitHistoryError("The open workspace is not a Git repository.", 404, "NOT_GIT_REPOSITORY");
   }
-  return workspace.gitRoot;
+  return workspace as GitStudioWorkspace;
 }
 export async function serveGitRefs(response: ServerResponse, state: HarnessStudioState): Promise<void> {
   try {
-    const refs = await readGitRefsAtRoot(gitWorkspaceRoot(state));
-    if (state.workspace !== undefined) state.workspace.gitRefs = refs;
+    const workspace = gitWorkspace(state);
+    const refs = await readGitRefsAtRoot(workspace.gitRoot);
+    workspace.gitRefs = refs;
     respondJson(response, 200, refs, { "Cache-Control": "no-store" });
   } catch (error) {
     respondGitError(response, error);
@@ -24,10 +27,10 @@ export async function serveGitRefs(response: ServerResponse, state: HarnessStudi
 export async function serveGitLog(response: ServerResponse, state: HarnessStudioState, url: URL): Promise<void> {
   try {
     const limitText = url.searchParams.get("limit");
-    const root = gitWorkspaceRoot(state);
-    const refs = state.workspace?.gitRefs ?? await readGitRefsAtRoot(root);
-    if (state.workspace !== undefined) state.workspace.gitRefs = refs;
-    respondJson(response, 200, await readGitLog(root, {
+    const workspace = gitWorkspace(state);
+    const refs = workspace.gitRefs ?? await readGitRefsAtRoot(workspace.gitRoot);
+    workspace.gitRefs = refs;
+    respondJson(response, 200, await readGitLog(workspace.gitRoot, {
       refs: url.searchParams.getAll("ref"),
       search: url.searchParams.get("search") ?? undefined,
       limit: limitText === null ? undefined : Number(limitText),
@@ -39,7 +42,8 @@ export async function serveGitLog(response: ServerResponse, state: HarnessStudio
 }
 export async function serveGitCommit(response: ServerResponse, state: HarnessStudioState, sha: string): Promise<void> {
   try {
-    respondJson(response, 200, await cachedGitCommit(state, sha), { "Cache-Control": "no-store" });
+    const workspace = gitWorkspace(state);
+    respondJson(response, 200, await cachedGitCommit(workspace, sha), { "Cache-Control": "no-store" });
   } catch (error) {
     respondGitError(response, error);
   }
@@ -52,18 +56,18 @@ export async function serveGitFilePatch(
 ): Promise<void> {
   try {
     if (path === null) throw new GitHistoryError("File path is required.", 400, "INVALID_PATH");
-    const detail = await cachedGitCommit(state, sha);
-    respondJson(response, 200, await readGitFilePatchAtRoot(gitWorkspaceRoot(state), sha, path, detail), { "Cache-Control": "no-store" });
+    const workspace = gitWorkspace(state);
+    const detail = await cachedGitCommit(workspace, sha);
+    respondJson(response, 200, await readGitFilePatchAtRoot(workspace.gitRoot, sha, path, detail), { "Cache-Control": "no-store" });
   } catch (error) {
     respondGitError(response, error);
   }
 }
-async function cachedGitCommit(state: HarnessStudioState, sha: string): Promise<GitCommitDetail> {
-  const workspace = state.workspace;
-  const cached = workspace?.gitCommitCache?.get(sha);
+async function cachedGitCommit(workspace: GitStudioWorkspace, sha: string): Promise<GitCommitDetail> {
+  const cached = workspace.gitCommitCache?.get(sha);
   if (cached !== undefined) return cached;
-  const detail = await readGitCommitAtRoot(gitWorkspaceRoot(state), sha);
-  if (workspace?.gitCommitCache !== undefined) {
+  const detail = await readGitCommitAtRoot(workspace.gitRoot, sha);
+  if (workspace.gitCommitCache !== undefined) {
     workspace.gitCommitCache.set(sha, detail);
     if (workspace.gitCommitCache.size > 64) {
       const oldest = workspace.gitCommitCache.keys().next().value as string | undefined;

--- a/packages/harness-studio/src/server/server.ts
+++ b/packages/harness-studio/src/server/server.ts
@@ -24,7 +24,7 @@ import {
 import { createCheckpointHistoryCatalogAdapter } from "./query/checkpoint-history.js";
 import { discoverArtifactProviderRuntime } from "./artifacts/registry/artifact-provider-discovery.js";
 import type { HarnessStudioServerOptions, HarnessStudioState } from "./studio-types.js";
-import { decodeRouteComponent, respondJson } from "./http-utils.js";
+import { decodeRouteComponent, respondJson, sameOriginRequest } from "./http-utils.js";
 import {
   acpAgentEnabled,
   acpExecutorFactory,
@@ -139,6 +139,7 @@ export function createHarnessStudioServer(options: HarnessStudioServerOptions): 
     artifactEventStreams: 0,
     projects: new Map(),
     projectRevision: 0,
+    projectRevisionContexts: new Map(),
     workspaceImports: new Map(),
     workspaceOpenStage: "idle",
     intentAnalysisRunning: false,
@@ -209,6 +210,7 @@ async function route(
       workspaceWorkbenchEnabled: state.workspace?.inspectorReport !== undefined,
       workspaceDiscoveryEnabled: options.workspaceSessionProvider !== undefined,
       workspaceConnected: state.workspace !== undefined,
+      projectExecutionEnabled: state.workspace?.localDirectory !== undefined,
       activeProjectId: state.activeProjectId,
       projectRevision: state.projectRevision,
       sessionCount: state.workspace?.sessionCount ?? 0,
@@ -354,7 +356,12 @@ async function route(
   const runRead = url.pathname.match(/^\/api\/runs\/([^/]+)(?:\/(session))?$/);
   if (url.pathname === "/api/runs" || runRead !== null) {
     const runId = runRead === null ? undefined : decodeRouteComponent(response, runRead[1]!);
-    if (runRead === null || runId !== undefined) await routeRuns(request, response, activeWorkspaceOptions(options, state), url, runId, runRead?.[2] === "session");
+    if (runRead === null || runId !== undefined) {
+      const scopedOptions = request.method === "POST" && options.harnessMode === "workspace-default"
+        ? retainedRunWorkspaceOptions(request, response, options, state)
+        : activeWorkspaceOptions(options, state);
+      if (scopedOptions !== undefined) await routeRuns(request, response, scopedOptions, url, runId, runRead?.[2] === "session");
+    }
     return;
   }
   if (request.method === "GET" && url.pathname === "/inspector") {
@@ -587,7 +594,36 @@ function acceptProjectBinding(
     respondJson(response, 409, { error: "The selected Project changed before the run started. Review the current Project and retry." });
     return false;
   }
+  if (required && state.workspace?.localDirectory === undefined) {
+    respondJson(response, 422, { error: "The selected Project is read-only evidence and cannot host a live run." });
+    return false;
+  }
   return true;
+}
+
+function retainedRunWorkspaceOptions(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: HarnessStudioServerOptions,
+  state: HarnessStudioState,
+): HarnessStudioServerOptions | undefined {
+  if (!sameOriginRequest(request)) {
+    respondJson(response, 403, { error: "Cross-origin run saving is not allowed." });
+    return undefined;
+  }
+  const requestedProjectId = request.headers["x-harness-project-id"];
+  const requestedRevision = request.headers["x-harness-project-revision"];
+  const parsedRevision = typeof requestedRevision === "string" ? Number(requestedRevision) : Number.NaN;
+  const context = Number.isSafeInteger(parsedRevision) ? state.projectRevisionContexts.get(parsedRevision) : undefined;
+  if (typeof requestedProjectId !== "string" || context === undefined || context.projectId !== requestedProjectId) {
+    respondJson(response, 409, { error: "The starting Project binding is required to retain this run safely." });
+    return undefined;
+  }
+  return {
+    ...options,
+    cwd: context.localDirectory,
+    sourceRoot: options.sourceRoot ?? context.localDirectory,
+  };
 }
 
 function activeWorkspaceOptions(

--- a/packages/harness-studio/src/server/server.ts
+++ b/packages/harness-studio/src/server/server.ts
@@ -77,6 +77,7 @@ import {
 } from "./artifacts/routes.js";
 import {
   lockCheckpointHistory,
+  isActiveExperimentRunnable,
   resolveCheckpointHistory,
   selectSource,
   serveCheckpointHistory,
@@ -203,6 +204,7 @@ async function route(
       artifactCount: state.artifactPaths?.length,
       evidenceEnabled: activeSourcePath(state.sourceCatalog, state.activeSources, "evidence") !== undefined,
       experimentEnabled: state.activeManifestPath !== undefined,
+      experimentRunnable: await isActiveExperimentRunnable(options, state),
       harnessMode: options.harnessSource === undefined ? "none" : options.harnessMode ?? "configured",
       historyEnabled: state.historyAdapter !== undefined,
       inspectorEnabled: activeSourcePath(state.sourceCatalog, state.activeSources, "inspector") !== undefined,

--- a/packages/harness-studio/src/server/server.ts
+++ b/packages/harness-studio/src/server/server.ts
@@ -37,6 +37,7 @@ import {
 import { effectiveAcpAgentProfiles } from "./acp-agent-catalog.js";
 import {
   abortWorkspaceImport,
+  activateProject,
   analyzeWorkspaceCustomizations,
   analyzeWorkspaceIntent,
   cleanupWorkspaceImports,
@@ -45,6 +46,8 @@ import {
   disconnectWorkspace,
   importWorkspaceFile,
   openWorkspace,
+  removeProject,
+  serveProjectCatalog,
   serveSessionComparison,
   serveWorkspaceCustomizations,
   serveWorkspaceInputs,
@@ -134,6 +137,8 @@ export function createHarnessStudioServer(options: HarnessStudioServerOptions): 
     artifactPaths: resolvedOptions.artifactPaths,
     artifactImports: new Map(),
     artifactEventStreams: 0,
+    projects: new Map(),
+    projectRevision: 0,
     workspaceImports: new Map(),
     workspaceOpenStage: "idle",
     intentAnalysisRunning: false,
@@ -204,26 +209,48 @@ async function route(
       workspaceWorkbenchEnabled: state.workspace?.inspectorReport !== undefined,
       workspaceDiscoveryEnabled: options.workspaceSessionProvider !== undefined,
       workspaceConnected: state.workspace !== undefined,
+      activeProjectId: state.activeProjectId,
+      projectRevision: state.projectRevision,
       sessionCount: state.workspace?.sessionCount ?? 0,
       inputCount: state.workspace?.inputTrace?.summary.inputCount ?? 0,
       intentAnalysisEnabled: options.intentAnalyzer !== undefined,
       customizationAnalysisEnabled: options.customizationCollector !== undefined,
       customizationAnalyzed: state.customizationAnalysis !== undefined,
       customizationDefinitionCount: state.customizationAnalysis?.summary.definitionCount ?? 0,
-    });
+    }, { "Cache-Control": "no-store" });
     return;
   }
   if (request.method === "GET" && url.pathname === "/api/workspace") {
     respondJson(response, 200, state.workspace === undefined
-      ? { connected: false, sessionCount: 0, omittedCount: 0 }
-      : { connected: true, label: state.workspace.label, sessionCount: state.workspace.sessionCount, omittedCount: state.workspace.omittedCount, providers: state.workspace.providers });
+      ? { connected: false, revision: state.projectRevision, sessionCount: 0, omittedCount: 0 }
+      : { connected: true, id: state.activeProjectId, revision: state.projectRevision, label: state.workspace.label, sessionCount: state.workspace.sessionCount, omittedCount: state.workspace.omittedCount, providers: state.workspace.providers }, { "Cache-Control": "no-store" });
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/api/projects") {
+    serveProjectCatalog(response, state);
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/api/projects/open") {
+    await openWorkspace(request, response, options, state);
+    return;
+  }
+  const projectActivation = url.pathname.match(/^\/api\/projects\/([^/]+)\/(?:activate|refresh)$/);
+  if (request.method === "POST" && projectActivation !== null) {
+    const projectId = decodeRouteComponent(response, projectActivation[1]!);
+    if (projectId !== undefined) await activateProject(request, response, options, state, projectId);
+    return;
+  }
+  const projectRemoval = url.pathname.match(/^\/api\/projects\/([^/]+)$/);
+  if (request.method === "DELETE" && projectRemoval !== null) {
+    const projectId = decodeRouteComponent(response, projectRemoval[1]!);
+    if (projectId !== undefined) await removeProject(request, response, options, state, projectId);
     return;
   }
   if (request.method === "DELETE" && url.pathname === "/api/workspace") {
     await disconnectWorkspace(request, response, options, state);
     return;
   }
-  if (request.method === "GET" && url.pathname === "/api/workspace/open/status") {
+  if (request.method === "GET" && (url.pathname === "/api/projects/open/status" || url.pathname === "/api/workspace/open/status")) {
     respondJson(response, 200, { stage: state.workspaceOpenStage });
     return;
   }
@@ -244,7 +271,7 @@ async function route(
   const workspaceImportCommit = url.pathname.match(/^\/api\/workspaces\/([^/]+)\/commit$/);
   if (request.method === "POST" && workspaceImportCommit !== null) {
     const sessionId = decodeRouteComponent(response, workspaceImportCommit[1]!);
-    if (sessionId !== undefined) await commitWorkspaceImport(request, response, state, sessionId);
+    if (sessionId !== undefined) await commitWorkspaceImport(request, response, options, state, sessionId);
     return;
   }
   const workspaceImportAbort = url.pathname.match(/^\/api\/workspaces\/([^/]+)$/);
@@ -305,7 +332,7 @@ async function route(
     respondJson(response, 200, {
       sources: describeSources(state.sourceCatalog, state.activeSources),
       active: state.activeSources,
-    });
+    }, { "Cache-Control": "no-store" });
     return;
   }
   if (request.method === "POST" && url.pathname === "/api/sources/select") {
@@ -490,6 +517,7 @@ async function route(
       respondJson(response, 405, { error: "Use POST for /agui/acp." });
       return;
     }
+    if (!acceptProjectBinding(request, response, state, options.harnessMode === "workspace-default")) return;
     const runtimeOptions = activeWorkspaceOptions(options, state);
     const acpAgent = options.acpAgent
       ?? effectiveAcpAgentProfiles(options).find((profile) => profile.agent !== undefined)!.agent!;
@@ -511,6 +539,7 @@ async function route(
       return;
     }
     if (request.method === "POST" && url.pathname === "/agui") {
+      if (!acceptProjectBinding(request, response, state, options.harnessMode === "workspace-default")) return;
       const runtimeOptions = activeWorkspaceOptions(options, state);
       await handleAguiRun(request, response, {
         source: runtimeOptions.harnessSource!,
@@ -532,6 +561,33 @@ async function route(
     return;
   }
   respondJson(response, 404, { error: `No route for ${request.method} ${url.pathname}` });
+}
+
+function acceptProjectBinding(
+  request: IncomingMessage,
+  response: ServerResponse,
+  state: HarnessStudioState,
+  required: boolean,
+): boolean {
+  const requestedProjectId = request.headers["x-harness-project-id"];
+  const requestedRevision = request.headers["x-harness-project-revision"];
+  if (requestedProjectId === undefined && requestedRevision === undefined) {
+    if (!required) return true;
+    respondJson(response, 409, { error: state.activeProjectId === undefined
+      ? "Open a Project before starting a Project-scoped run."
+      : "A Project id and revision are required to start a Project-scoped run." });
+    return false;
+  }
+  if (typeof requestedProjectId !== "string" || typeof requestedRevision !== "string") {
+    respondJson(response, 409, { error: "The requested Project binding is incomplete." });
+    return false;
+  }
+  const parsedRevision = Number(requestedRevision);
+  if (requestedProjectId !== state.activeProjectId || !Number.isSafeInteger(parsedRevision) || parsedRevision !== state.projectRevision) {
+    respondJson(response, 409, { error: "The selected Project changed before the run started. Review the current Project and retry." });
+    return false;
+  }
+  return true;
 }
 
 function activeWorkspaceOptions(

--- a/packages/harness-studio/src/server/studio-types.ts
+++ b/packages/harness-studio/src/server/studio-types.ts
@@ -150,6 +150,8 @@ export interface WorkspaceImportSession {
   paths: Set<string>;
   label: string;
   expiry: NodeJS.Timeout;
+  busy: boolean;
+  expired: boolean;
 }
 export interface StudioWorkspace {
   label: string;
@@ -182,6 +184,11 @@ export interface StoredStudioProject {
   /** Imported workspaces retain their bounded materialization until removal. */
   importedWorkspace?: StudioWorkspace;
 }
+export interface StudioProjectRevisionContext {
+  projectId: string;
+  /** Canonical server-only execution root captured when this revision was active. */
+  localDirectory: string;
+}
 export interface HarnessStudioState {
   sourceCatalog: StudioSourceCandidate[];
   activeSources: Partial<Record<StudioSourceKind, string>>;
@@ -200,6 +207,8 @@ export interface HarnessStudioState {
   projects: Map<string, StoredStudioProject>;
   activeProjectId?: string;
   projectRevision: number;
+  /** Bounded recent revision bindings keep completed runs in their starting Project. */
+  projectRevisionContexts: Map<number, StudioProjectRevisionContext>;
   workspaceImports: Map<string, WorkspaceImportSession>;
   workspaceOpenStage: "idle" | "choosing" | "discovering" | "removing";
   intentAnalysisRunning: boolean;

--- a/packages/harness-studio/src/server/studio-types.ts
+++ b/packages/harness-studio/src/server/studio-types.ts
@@ -2,6 +2,7 @@ import { DebuggerSession } from "../contracts/debugger-session.js";
 import { CheckpointSourcePreview, ExperimentLockReceipt } from "../contracts/experiment-setup.js";
 import { GitCommitDetail, GitRefsSnapshot } from "../contracts/git-history.js";
 import { UserInputTraceV1 } from "../contracts/input-trace.js";
+import { StudioProjectDescriptor, StudioProjectKind } from "../contracts/studio-project.js";
 import { ArtifactCompileLimits } from "./artifacts/registry/artifact-compile-runtime.js";
 import { ExternalArtifactProvider } from "./artifacts/registry/artifact-plugin-registry.js";
 import { StudioCustomizationCollector } from "./customization-collector.js";
@@ -173,6 +174,14 @@ export interface StudioWorkspace {
 export interface StoredWorkspaceSession extends StudioWorkspaceSession {
   retainedRun?: SavedRunRecord;
 }
+export interface StoredStudioProject {
+  descriptor: StudioProjectDescriptor;
+  kind: StudioProjectKind;
+  /** Canonical server-only directory for a remembered local Project. */
+  localDirectory?: string;
+  /** Imported workspaces retain their bounded materialization until removal. */
+  importedWorkspace?: StudioWorkspace;
+}
 export interface HarnessStudioState {
   sourceCatalog: StudioSourceCandidate[];
   activeSources: Partial<Record<StudioSourceKind, string>>;
@@ -188,8 +197,11 @@ export interface HarnessStudioState {
   artifactImports: Map<string, ArtifactImportSession>;
   artifactEventStreams: number;
   workspace?: StudioWorkspace;
+  projects: Map<string, StoredStudioProject>;
+  activeProjectId?: string;
+  projectRevision: number;
   workspaceImports: Map<string, WorkspaceImportSession>;
-  workspaceOpenStage: "idle" | "choosing" | "discovering";
+  workspaceOpenStage: "idle" | "choosing" | "discovering" | "removing";
   intentAnalysisRunning: boolean;
   customizationAnalysisRunning: boolean;
   customizationAnalysis?: CustomizationAnalysisResponseV1;

--- a/packages/harness-studio/src/server/workspace/bundled-session-provider.ts
+++ b/packages/harness-studio/src/server/workspace/bundled-session-provider.ts
@@ -1,0 +1,22 @@
+import type { StudioWorkspaceDiscovery, StudioWorkspaceSessionProvider } from "../studio-types.js";
+
+interface BundledWorkspaceRuntime {
+  createInspectorWorkspaceSessionProvider(): {
+    discover(workspacePath: string): Promise<StudioWorkspaceDiscovery>;
+  };
+}
+
+/**
+ * Published CLI adapter for repository-owned Inspector discovery. The bundled
+ * runtime is loaded only after the user chooses a Project directory.
+ */
+export function createBundledInspectorWorkspaceSessionProvider(): StudioWorkspaceSessionProvider {
+  let runtime: Promise<BundledWorkspaceRuntime> | undefined;
+  return {
+    async discover(workspacePath) {
+      runtime ??= import(new URL("../runtime/inspector-workspace-runtime.mjs", import.meta.url).href) as Promise<BundledWorkspaceRuntime>;
+      const provider = (await runtime).createInspectorWorkspaceSessionProvider();
+      return await provider.discover(workspacePath);
+    },
+  };
+}

--- a/packages/harness-studio/src/server/workspace/native-directory-picker.ts
+++ b/packages/harness-studio/src/server/workspace/native-directory-picker.ts
@@ -15,14 +15,14 @@ export async function pickLocalWorkspaceDirectory(platform = process.platform): 
   if (platform === "darwin") {
     return runPicker("/usr/bin/osascript", [
       "-e",
-      'POSIX path of (choose folder with prompt "Open a project workspace in Harness Studio")',
+      'POSIX path of (choose folder with prompt "Open a Project in Harness Studio")',
     ]);
   }
   if (platform === "win32") {
     const script = [
       "Add-Type -AssemblyName System.Windows.Forms",
       "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
-      "$dialog.Description = 'Open a project workspace in Harness Studio'",
+      "$dialog.Description = 'Open a Project in Harness Studio'",
       "$dialog.ShowNewFolderButton = $false",
       "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($dialog.SelectedPath) }",
     ].join("; ");
@@ -30,8 +30,8 @@ export async function pickLocalWorkspaceDirectory(platform = process.platform): 
   }
   if (platform === "linux") {
     for (const candidate of [
-      { command: "/usr/bin/zenity", args: ["--file-selection", "--directory", "--title=Open a project workspace in Harness Studio"] },
-      { command: "/usr/bin/kdialog", args: ["--getexistingdirectory", ".", "--title", "Open a project workspace in Harness Studio"] },
+      { command: "/usr/bin/zenity", args: ["--file-selection", "--directory", "--title=Open a Project in Harness Studio"] },
+      { command: "/usr/bin/kdialog", args: ["--getexistingdirectory", ".", "--title", "Open a Project in Harness Studio"] },
     ]) {
       if (await access(candidate.command).then(() => true).catch(() => false)) {
         return runPicker(candidate.command, candidate.args);

--- a/packages/harness-studio/src/server/workspace/routes.ts
+++ b/packages/harness-studio/src/server/workspace/routes.ts
@@ -1,6 +1,7 @@
 import { GitCommitDetail } from "../../contracts/git-history.js";
 import { isUserInputTrace, projectUserInputTrace } from "../../contracts/input-trace.js";
 import { IntentCorrelationAnalysisV1, IntentCorrelationContractError, validateIntentCorrelationAnalysis } from "../../contracts/intent-correlation.js";
+import { STUDIO_PROJECT_CATALOG_KIND, type StudioProjectDescriptor } from "../../contracts/studio-project.js";
 import { validateStudioCustomizationAnalysis } from "../customization-collector.js";
 import { sessionFromRetainedRun } from "../debugger-session-transform.js";
 import { resolveGitRepositoryRoot } from "../git-history.js";
@@ -12,9 +13,9 @@ import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, open, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, normalize, resolve } from "node:path";
+import { basename, dirname, join, normalize, posix, resolve, win32 } from "node:path";
 import { IMPORT_SESSION_TTL_MS, MAX_IMPORT_BYTES, MAX_IMPORT_SESSIONS, respondJson, sameOriginRequest } from "../http-utils.js";
-import { HarnessStudioServerOptions, HarnessStudioState, StoredWorkspaceSession, StudioWorkspaceSession, WorkspaceImportSession } from "../studio-types.js";
+import { HarnessStudioServerOptions, HarnessStudioState, StoredStudioProject, StoredWorkspaceSession, StudioWorkspace, StudioWorkspaceSession, WorkspaceImportSession } from "../studio-types.js";
 
 export const MAX_WORKSPACE_FILES = 512;
 export const MAX_WORKSPACE_SESSIONS = 200;
@@ -42,7 +43,7 @@ export async function createWorkspaceImport(
     fileCount: 0,
     totalBytes: 0,
     paths: new Set(),
-    label: portableWorkspaceLabel(requestedLabel),
+    label: portableProjectLabel(requestedLabel),
     expiry,
   });
   respondJson(response, 201, { sessionId, maxFiles: MAX_WORKSPACE_FILES, maxBytes: MAX_IMPORT_BYTES });
@@ -78,55 +79,212 @@ export async function openWorkspace(
       respondJson(response, 422, { error: "The selected workspace is not a directory." });
       return;
     }
-    const discovered = await options.workspaceSessionProvider.discover(workspacePath);
-    const sessions = new Map<string, StoredWorkspaceSession>();
-    for (const candidate of discovered.sessions.slice(0, MAX_WORKSPACE_SESSIONS)) {
-      const normalized = normalizeDiscoveredWorkspaceSession(candidate);
-      if (!sessions.has(normalized.summary.id)) sessions.set(normalized.summary.id, normalized);
-    }
-    const providers = (discovered.providers ?? []).map((provider) => ({
-      provider: portableWorkspaceLabel(provider.provider),
-      status: provider.status,
-      discovered: boundedNonNegativeInteger(provider.discovered),
-      included: boundedNonNegativeInteger(provider.included),
-      ...(provider.status === "error" ? { message: "Provider discovery failed." } : {}),
-    }));
-    const inspectorReport = discovered.inspectorReport === undefined
-      ? undefined
-      : validWorkspaceInspectorReport(discovered.inspectorReport)
-        ? discovered.inspectorReport
-        : (() => { throw new Error("Workspace Inspector report is malformed."); })();
-    const inputTrace = inspectorReport === undefined ? undefined : projectUserInputTrace(inspectorReport);
-    const previous = state.workspace?.ownedDirectory;
-    const gitRoot = await resolveGitRepositoryRoot(workspacePath);
-    const artifactObservations = await collectWorkspaceArtifactObservations(workspacePath, [...sessions.values()]);
-    const artifactPaths = [...new Set(artifactObservations.map((observation) => observation.relativePath))];
-    state.workspace = {
-      label: portableWorkspaceLabel(discovered.label),
-      sessionCount: sessions.size,
-      omittedCount: Math.max(0, discovered.sessions.length - sessions.size),
-      sessions,
-      providers,
-      ...(inspectorReport === undefined ? {} : { inspectorReport, inputTrace }),
+    const workspace = await discoverWorkspace(options, workspacePath);
+    const existing = [...state.projects.entries()].find(([, project]) => project.localDirectory !== undefined && sameNativePath(project.localDirectory, workspacePath));
+    const projectId = existing?.[0] ?? `project_${randomUUID().replaceAll("-", "")}`;
+    const project: StoredStudioProject = {
+      descriptor: descriptorForWorkspace(projectId, "local", workspace),
+      kind: "local",
       localDirectory: workspacePath,
-      artifactObservations,
-      ...(gitRoot === undefined ? {} : { gitRoot, gitCommitCache: new Map<string, GitCommitDetail>() }),
     };
-    state.artifactDirectory = workspacePath;
-    state.artifactPaths = artifactPaths;
-    state.customizationAnalysis = undefined;
-    if (previous !== undefined) await rm(previous, { recursive: true, force: true }).catch(() => undefined);
+    state.projects.set(projectId, project);
+    activateWorkspace(state, options, projectId, workspace);
     respondJson(response, 200, {
       opened: true,
-      label: state.workspace.label,
-      sessionCount: state.workspace.sessionCount,
-      providers,
+      project: project.descriptor,
+      revision: state.projectRevision,
+      label: workspace.label,
+      sessionCount: workspace.sessionCount,
+      providers: workspace.providers,
     });
   } catch {
     respondJson(response, 422, { error: "Studio could not discover Sessions for the selected workspace." });
   } finally {
     state.workspaceOpenStage = "idle";
   }
+}
+
+async function discoverWorkspace(options: HarnessStudioServerOptions, workspacePath: string): Promise<StudioWorkspace> {
+  if (options.workspaceSessionProvider === undefined) throw new Error("Workspace discovery is unavailable.");
+  const discovered = await options.workspaceSessionProvider.discover(workspacePath);
+  const sessions = new Map<string, StoredWorkspaceSession>();
+  for (const candidate of discovered.sessions.slice(0, MAX_WORKSPACE_SESSIONS)) {
+    const normalized = normalizeDiscoveredWorkspaceSession(candidate);
+    if (!sessions.has(normalized.summary.id)) sessions.set(normalized.summary.id, normalized);
+  }
+  const providers = (discovered.providers ?? []).map((provider) => ({
+    provider: portableWorkspaceLabel(provider.provider),
+    status: provider.status,
+    discovered: boundedNonNegativeInteger(provider.discovered),
+    included: boundedNonNegativeInteger(provider.included),
+    ...(provider.status === "error" ? { message: "Provider discovery failed." } : {}),
+  }));
+  const inspectorReport = discovered.inspectorReport === undefined
+    ? undefined
+    : validWorkspaceInspectorReport(discovered.inspectorReport)
+      ? discovered.inspectorReport
+      : (() => { throw new Error("Workspace Inspector report is malformed."); })();
+  const inputTrace = inspectorReport === undefined ? undefined : projectUserInputTrace(inspectorReport);
+  const gitRoot = await resolveGitRepositoryRoot(workspacePath);
+  const artifactObservations = await collectWorkspaceArtifactObservations(workspacePath, [...sessions.values()]);
+  return {
+    label: portableProjectLabel(discovered.label),
+    sessionCount: sessions.size,
+    omittedCount: Math.max(0, discovered.sessions.length - sessions.size),
+    sessions,
+    providers,
+    ...(inspectorReport === undefined ? {} : { inspectorReport, inputTrace }),
+    localDirectory: workspacePath,
+    artifactObservations,
+    ...(gitRoot === undefined ? {} : { gitRoot, gitCommitCache: new Map<string, GitCommitDetail>() }),
+  };
+}
+
+function activateWorkspace(
+  state: HarnessStudioState,
+  options: HarnessStudioServerOptions,
+  projectId: string,
+  workspace: StudioWorkspace,
+): void {
+  state.workspace = workspace;
+  state.activeProjectId = projectId;
+  state.projectRevision += 1;
+  state.artifactDirectory = workspace.localDirectory ?? options.artifactDirectory;
+  state.artifactPaths = workspace.localDirectory === undefined
+    ? options.artifactPaths
+    : [...new Set((workspace.artifactObservations ?? []).map((observation) => observation.relativePath))];
+  state.customizationAnalysis = undefined;
+  const project = state.projects.get(projectId);
+  if (project !== undefined) {
+    project.descriptor = descriptorForWorkspace(projectId, project.kind, workspace);
+  }
+}
+
+function descriptorForWorkspace(
+  id: string,
+  kind: "local" | "imported",
+  workspace: StudioWorkspace,
+  lastOpenedAt = new Date().toISOString(),
+): StudioProjectDescriptor {
+  return {
+    id,
+    label: workspace.label,
+    kind,
+    availability: "ready",
+    lastOpenedAt,
+    sessionCount: workspace.sessionCount,
+    inputCount: workspace.inputTrace?.summary.inputCount ?? 0,
+    artifactCount: new Set((workspace.artifactObservations ?? []).map((observation) => observation.relativePath)).size,
+    gitEnabled: workspace.gitRoot !== undefined,
+    workspaceWorkbenchEnabled: workspace.inspectorReport !== undefined,
+  };
+}
+
+function sameNativePath(left: string, right: string): boolean {
+  const normalizedLeft = normalize(left);
+  const normalizedRight = normalize(right);
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+export function serveProjectCatalog(response: ServerResponse, state: HarnessStudioState): void {
+  respondJson(response, 200, {
+    kind: STUDIO_PROJECT_CATALOG_KIND,
+    revision: state.projectRevision,
+    ...(state.activeProjectId === undefined ? {} : { activeProjectId: state.activeProjectId }),
+    projects: [...state.projects.values()].map((project) => project.descriptor)
+      .sort((left, right) => right.lastOpenedAt.localeCompare(left.lastOpenedAt)),
+    stage: state.workspaceOpenStage,
+  }, { "Cache-Control": "no-store" });
+}
+
+export async function activateProject(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: HarnessStudioServerOptions,
+  state: HarnessStudioState,
+  projectId: string,
+): Promise<void> {
+  if (!sameOriginRequest(request)) {
+    respondJson(response, 403, { error: "Cross-origin Project changes are not allowed." });
+    return;
+  }
+  const project = projectForId(state, projectId);
+  if (project === undefined) {
+    respondJson(response, 404, { error: "The requested Project is not registered." });
+    return;
+  }
+  if (state.workspaceOpenStage !== "idle") {
+    respondJson(response, 409, { error: "Another Project is already being opened." });
+    return;
+  }
+  state.workspaceOpenStage = "discovering";
+  try {
+    let workspace: StudioWorkspace | undefined;
+    if (project.kind === "local") {
+      const workspacePath = await realpath(project.localDirectory!);
+      if (!sameNativePath(workspacePath, project.localDirectory!)) throw new Error("The Project directory identity changed.");
+      if (!(await stat(workspacePath)).isDirectory()) throw new Error("The Project directory is unavailable.");
+      workspace = await discoverWorkspace(options, workspacePath);
+    } else {
+      workspace = project.importedWorkspace;
+    }
+    if (workspace === undefined) throw new Error("The Project workspace is no longer available.");
+    activateWorkspace(state, options, projectId, workspace);
+    respondJson(response, 200, { activated: true, project: project.descriptor, revision: state.projectRevision });
+  } catch {
+    project.descriptor = { ...project.descriptor, availability: "unavailable" };
+    respondJson(response, 422, { error: "Studio could not refresh the requested Project. The previous Project remains active." });
+  } finally {
+    state.workspaceOpenStage = "idle";
+  }
+}
+
+export async function removeProject(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: HarnessStudioServerOptions,
+  state: HarnessStudioState,
+  projectId: string,
+): Promise<void> {
+  if (!sameOriginRequest(request)) {
+    respondJson(response, 403, { error: "Cross-origin Project changes are not allowed." });
+    return;
+  }
+  const project = projectForId(state, projectId);
+  if (project === undefined) {
+    respondJson(response, 404, { error: "The requested Project is not registered." });
+    return;
+  }
+  if (state.workspaceOpenStage !== "idle") {
+    respondJson(response, 409, { error: "Another Project change is already in progress." });
+    return;
+  }
+  state.workspaceOpenStage = "removing";
+  try {
+    if (project.importedWorkspace?.ownedDirectory !== undefined) {
+      await rm(project.importedWorkspace.ownedDirectory, { recursive: true, force: true });
+    }
+    state.projects.delete(projectId);
+    if (state.activeProjectId === projectId) {
+      state.activeProjectId = undefined;
+      state.workspace = undefined;
+      state.projectRevision += 1;
+      state.artifactDirectory = options.artifactDirectory;
+      state.artifactPaths = options.artifactPaths;
+      state.customizationAnalysis = undefined;
+    }
+    respondJson(response, 200, { removed: true, revision: state.projectRevision });
+  } catch {
+    respondJson(response, 500, { error: "Studio could not remove the imported Project materialization." });
+  } finally {
+    state.workspaceOpenStage = "idle";
+  }
+}
+
+function projectForId(state: HarnessStudioState, projectId: string): StoredStudioProject | undefined {
+  return /^project_[a-f0-9]{32}$/u.test(projectId) ? state.projects.get(projectId) : undefined;
 }
 function validWorkspaceInspectorReport(report: Record<string, unknown> | undefined): report is Record<string, unknown> {
   return report !== undefined
@@ -229,6 +387,7 @@ export async function importWorkspaceFile(
 export async function commitWorkspaceImport(
   request: IncomingMessage,
   response: ServerResponse,
+  options: HarnessStudioServerOptions,
   state: HarnessStudioState,
   sessionId: string,
 ): Promise<void> {
@@ -241,6 +400,25 @@ export async function commitWorkspaceImport(
     respondJson(response, 404, { error: "Workspace import session is unavailable." });
     return;
   }
+  if (state.workspaceOpenStage !== "idle") {
+    respondJson(response, 409, { error: "Another Project change is already in progress." });
+    return;
+  }
+  state.workspaceOpenStage = "discovering";
+  try {
+    await commitWorkspaceImportSession(response, options, state, sessionId, session);
+  } finally {
+    state.workspaceOpenStage = "idle";
+  }
+}
+
+async function commitWorkspaceImportSession(
+  response: ServerResponse,
+  options: HarnessStudioServerOptions,
+  state: HarnessStudioState,
+  sessionId: string,
+  session: WorkspaceImportSession,
+): Promise<void> {
   const accepted = new Map<string, StoredWorkspaceSession>();
   let omittedCount = 0;
   for (const relativePath of session.paths) {
@@ -279,8 +457,7 @@ export async function commitWorkspaceImport(
   }
   clearTimeout(session.expiry);
   state.workspaceImports.delete(sessionId);
-  const previous = state.workspace?.ownedDirectory;
-  state.workspace = {
+  const workspace: StudioWorkspace = {
     label: session.label,
     sessionCount: accepted.size,
     omittedCount,
@@ -288,10 +465,14 @@ export async function commitWorkspaceImport(
     providers: [{ provider: "Harness Studio", status: "ok", discovered: accepted.size, included: accepted.size }],
     ownedDirectory: session.directory,
   };
-  state.customizationAnalysis = undefined;
-  if (previous !== undefined && previous !== session.directory) {
-    await rm(previous, { recursive: true, force: true }).catch(() => undefined);
-  }
+  const projectId = `project_${randomUUID().replaceAll("-", "")}`;
+  const project: StoredStudioProject = {
+    descriptor: descriptorForWorkspace(projectId, "imported", workspace),
+    kind: "imported",
+    importedWorkspace: workspace,
+  };
+  state.projects.set(projectId, project);
+  activateWorkspace(state, options, projectId, workspace);
   respondJson(response, 200, { label: session.label, sessionCount: accepted.size, omittedCount });
 }
 export async function abortWorkspaceImport(
@@ -321,12 +502,17 @@ export async function disconnectWorkspace(
     respondJson(response, 403, { error: "Cross-origin workspace changes are not allowed." });
     return;
   }
+  if (state.workspaceOpenStage !== "idle") {
+    respondJson(response, 409, { error: "Another Project change is already in progress." });
+    return;
+  }
   const workspace = state.workspace;
   state.workspace = undefined;
+  state.activeProjectId = undefined;
+  if (workspace !== undefined) state.projectRevision += 1;
   state.artifactDirectory = options.artifactDirectory;
   state.artifactPaths = options.artifactPaths;
   state.customizationAnalysis = undefined;
-  if (workspace?.ownedDirectory !== undefined) await rm(workspace.ownedDirectory, { recursive: true, force: true });
   respondJson(response, 200, { disconnected: workspace !== undefined });
 }
 function workspaceImportSession(state: HarnessStudioState, sessionId: string): WorkspaceImportSession | undefined {
@@ -337,6 +523,12 @@ function workspaceImportSession(state: HarnessStudioState, sessionId: string): W
 function portableWorkspaceLabel(value: string | null): string {
   const label = (value ?? "Selected workspace").trim().replace(/[\u0000-\u001f]/gu, " ").slice(0, 80);
   return label || "Selected workspace";
+}
+function portableProjectLabel(value: string | null): string {
+  const label = portableWorkspaceLabel(value);
+  if (win32.isAbsolute(label)) return portableWorkspaceLabel(win32.basename(label));
+  if (posix.isAbsolute(label)) return portableWorkspaceLabel(posix.basename(label));
+  return label;
 }
 function portableWorkspacePath(value: string | null): string {
   if (value === null || value.trim() === "") throw new Error("Workspace file path is required.");
@@ -362,7 +554,12 @@ async function removeWorkspaceImport(state: HarnessStudioState, sessionId: strin
 }
 export async function cleanupWorkspaceImports(state: HarnessStudioState): Promise<void> {
   await Promise.all([...state.workspaceImports.keys()].map((sessionId) => removeWorkspaceImport(state, sessionId)));
-  if (state.workspace?.ownedDirectory !== undefined) await rm(state.workspace.ownedDirectory, { recursive: true, force: true });
+  const ownedDirectories = new Set([...state.projects.values()]
+    .map((project) => project.importedWorkspace?.ownedDirectory)
+    .filter((directory): directory is string => directory !== undefined));
+  await Promise.all([...ownedDirectories].map((directory) => rm(directory, { recursive: true, force: true }).catch(() => undefined)));
+  state.projects.clear();
+  state.activeProjectId = undefined;
   state.workspace = undefined;
   state.customizationAnalysis = undefined;
 }
@@ -372,7 +569,7 @@ export async function serveWorkspaceSessions(response: ServerResponse, state: Ha
     return;
   }
   respondJson(response, 200, {
-    workspace: { label: state.workspace.label, omittedCount: state.workspace.omittedCount, providers: state.workspace.providers },
+    workspace: { id: state.activeProjectId, revision: state.projectRevision, label: state.workspace.label, omittedCount: state.workspace.omittedCount, providers: state.workspace.providers },
     sessions: [...state.workspace.sessions.values()].map((session) => session.summary)
       .sort((left, right) => right.savedAt.localeCompare(left.savedAt)),
   });
@@ -424,12 +621,17 @@ export async function analyzeWorkspaceCustomizations(
     respondJson(response, 409, { error: "Customization analysis is already running." });
     return;
   }
+  const projectBinding = { id: state.activeProjectId, revision: state.projectRevision };
   state.customizationAnalysisRunning = true;
   try {
     const analysis = validateStudioCustomizationAnalysis(
       await options.customizationCollector.analyze(workspacePath),
       [workspacePath],
     );
+    if (!isCurrentProjectBinding(state, projectBinding)) {
+      respondJson(response, 409, { error: "The active Project changed before customization analysis completed. Run the analysis again for the current Project." });
+      return;
+    }
     state.customizationAnalysis = analysis;
     respondJson(response, 200, analysis, { "Cache-Control": "no-store" });
   } catch {
@@ -460,11 +662,16 @@ export async function analyzeWorkspaceIntent(
     respondJson(response, 409, { error: "An Intent analysis is already running." });
     return;
   }
+  const projectBinding = { id: state.activeProjectId, revision: state.projectRevision };
   state.intentAnalysisRunning = true;
   try {
     const packet = buildIntentCorrelationPacket(state.workspace.inputTrace);
     const proposed = await options.intentAnalyzer.analyze(packet);
     const analysis: IntentCorrelationAnalysisV1 = validateIntentCorrelationAnalysis(packet, proposed);
+    if (!isCurrentProjectBinding(state, projectBinding)) {
+      respondJson(response, 409, { error: "The active Project changed before Intent analysis completed. Run the analysis again for the current Project." }, { "Cache-Control": "no-store" });
+      return;
+    }
     respondJson(response, 200, analysis, { "Cache-Control": "no-store" });
   } catch (error) {
     respondJson(response, error instanceof IntentCorrelationContractError ? 502 : 503, {
@@ -475,6 +682,12 @@ export async function analyzeWorkspaceIntent(
   } finally {
     state.intentAnalysisRunning = false;
   }
+}
+function isCurrentProjectBinding(
+  state: HarnessStudioState,
+  binding: { id: string | undefined; revision: number },
+): boolean {
+  return state.activeProjectId === binding.id && state.projectRevision === binding.revision;
 }
 export async function serveWorkspaceSession(
   response: ServerResponse,

--- a/packages/harness-studio/src/server/workspace/routes.ts
+++ b/packages/harness-studio/src/server/workspace/routes.ts
@@ -1,13 +1,13 @@
 import { GitCommitDetail } from "../../contracts/git-history.js";
 import { isUserInputTrace, projectUserInputTrace } from "../../contracts/input-trace.js";
 import { IntentCorrelationAnalysisV1, IntentCorrelationContractError, validateIntentCorrelationAnalysis } from "../../contracts/intent-correlation.js";
-import { STUDIO_PROJECT_CATALOG_KIND, type StudioProjectDescriptor } from "../../contracts/studio-project.js";
+import { MAX_STUDIO_PROJECTS, STUDIO_PROJECT_CATALOG_KIND, type StudioProjectDescriptor } from "../../contracts/studio-project.js";
 import { validateStudioCustomizationAnalysis } from "../customization-collector.js";
 import { sessionFromRetainedRun } from "../debugger-session-transform.js";
 import { resolveGitRepositoryRoot } from "../git-history.js";
 import { buildIntentCorrelationPacket } from "../intent-correlation.js";
 import { parseSavedRunRecord } from "../run-log.js";
-import { pickLocalWorkspaceDirectory } from "../workspace/native-directory-picker.js";
+import { DirectoryPickerUnavailableError, pickLocalWorkspaceDirectory } from "../workspace/native-directory-picker.js";
 import { collectWorkspaceArtifactObservations } from "../workspace/workspace-artifacts.js";
 import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, open, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
@@ -19,6 +19,7 @@ import { HarnessStudioServerOptions, HarnessStudioState, StoredStudioProject, St
 
 export const MAX_WORKSPACE_FILES = 512;
 export const MAX_WORKSPACE_SESSIONS = 200;
+const MAX_PROJECT_REVISION_CONTEXTS = 128;
 
 export async function createWorkspaceImport(
   request: IncomingMessage,
@@ -36,7 +37,15 @@ export async function createWorkspaceImport(
   }
   const sessionId = randomUUID();
   const directory = await mkdtemp(join(tmpdir(), "harness-studio-workspace-"));
-  const expiry = setTimeout(() => { void removeWorkspaceImport(state, sessionId); }, IMPORT_SESSION_TTL_MS);
+  const expiry = setTimeout(() => {
+    const session = state.workspaceImports.get(sessionId);
+    if (session === undefined) return;
+    if (session.busy) {
+      session.expired = true;
+      return;
+    }
+    void removeWorkspaceImport(state, sessionId);
+  }, IMPORT_SESSION_TTL_MS);
   expiry.unref();
   state.workspaceImports.set(sessionId, {
     directory,
@@ -45,6 +54,8 @@ export async function createWorkspaceImport(
     paths: new Set(),
     label: portableProjectLabel(requestedLabel),
     expiry,
+    busy: false,
+    expired: false,
   });
   respondJson(response, 201, { sessionId, maxFiles: MAX_WORKSPACE_FILES, maxBytes: MAX_IMPORT_BYTES });
 }
@@ -79,8 +90,12 @@ export async function openWorkspace(
       respondJson(response, 422, { error: "The selected workspace is not a directory." });
       return;
     }
-    const workspace = await discoverWorkspace(options, workspacePath);
     const existing = [...state.projects.entries()].find(([, project]) => project.localDirectory !== undefined && sameNativePath(project.localDirectory, workspacePath));
+    if (existing === undefined && state.projects.size >= MAX_STUDIO_PROJECTS) {
+      respondJson(response, 429, { error: `Studio remembers at most ${MAX_STUDIO_PROJECTS} Projects. Remove one before opening another.` });
+      return;
+    }
+    const workspace = await discoverWorkspace(options, workspacePath);
     const projectId = existing?.[0] ?? `project_${randomUUID().replaceAll("-", "")}`;
     const project: StoredStudioProject = {
       descriptor: descriptorForWorkspace(projectId, "local", workspace),
@@ -97,7 +112,11 @@ export async function openWorkspace(
       sessionCount: workspace.sessionCount,
       providers: workspace.providers,
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof DirectoryPickerUnavailableError) {
+      respondJson(response, 501, { error: error.message });
+      return;
+    }
     respondJson(response, 422, { error: "Studio could not discover Sessions for the selected workspace." });
   } finally {
     state.workspaceOpenStage = "idle";
@@ -149,6 +168,14 @@ function activateWorkspace(
   state.workspace = workspace;
   state.activeProjectId = projectId;
   state.projectRevision += 1;
+  if (workspace.localDirectory !== undefined) {
+    state.projectRevisionContexts.delete(state.projectRevision);
+    state.projectRevisionContexts.set(state.projectRevision, { projectId, localDirectory: workspace.localDirectory });
+    if (state.projectRevisionContexts.size > MAX_PROJECT_REVISION_CONTEXTS) {
+      const oldestRevision = state.projectRevisionContexts.keys().next().value as number | undefined;
+      if (oldestRevision !== undefined) state.projectRevisionContexts.delete(oldestRevision);
+    }
+  }
   state.artifactDirectory = workspace.localDirectory ?? options.artifactDirectory;
   state.artifactPaths = workspace.localDirectory === undefined
     ? options.artifactPaths
@@ -338,50 +365,59 @@ export async function importWorkspaceFile(
     respondJson(response, 404, { error: "Workspace import session is unavailable." });
     return;
   }
-  if (session.fileCount >= MAX_WORKSPACE_FILES) {
-    respondJson(response, 413, { error: `Workspace imports are limited to ${MAX_WORKSPACE_FILES} files.` });
+  if (session.busy || session.expired) {
+    respondJson(response, 409, { error: "Another operation is already using this workspace import session." });
     return;
   }
-  let relativePath: string;
+  session.busy = true;
   try {
-    relativePath = portableWorkspacePath(requestedPath);
-    if ([...session.paths].some((candidate) => candidate.toLowerCase() === relativePath.toLowerCase())) {
-      throw new Error("Workspace file paths must be unique on every supported platform.");
+    if (session.fileCount >= MAX_WORKSPACE_FILES) {
+      respondJson(response, 413, { error: `Workspace imports are limited to ${MAX_WORKSPACE_FILES} files.` });
+      return;
     }
-  } catch (error) {
-    respondJson(response, 400, { error: error instanceof Error ? error.message : String(error) });
-    return;
-  }
-  const declaredBytes = Number(request.headers["content-length"]);
-  if (Number.isFinite(declaredBytes) && declaredBytes >= 0 && session.totalBytes + declaredBytes > MAX_IMPORT_BYTES) {
-    request.resume();
-    respondJson(response, 413, { error: "Workspace import exceeds the 128 MiB aggregate limit." });
-    return;
-  }
-  const chunks: Buffer[] = [];
-  let fileBytes = 0;
-  const destination = resolve(session.directory, ...relativePath.split("/"));
-  try {
-    for await (const chunk of request) {
-      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      fileBytes += bytes.length;
-      if (session.totalBytes + fileBytes > MAX_IMPORT_BYTES) throw new Error("Workspace import exceeds the 128 MiB aggregate limit.");
-      chunks.push(bytes);
-    }
-    await mkdir(dirname(destination), { recursive: true });
-    const handle = await open(destination, "wx");
+    let relativePath: string;
     try {
-      await handle.writeFile(Buffer.concat(chunks));
-    } finally {
-      await handle.close();
+      relativePath = portableWorkspacePath(requestedPath);
+      if ([...session.paths].some((candidate) => candidate.toLowerCase() === relativePath.toLowerCase())) {
+        throw new Error("Workspace file paths must be unique on every supported platform.");
+      }
+    } catch (error) {
+      respondJson(response, 400, { error: error instanceof Error ? error.message : String(error) });
+      return;
     }
-    session.fileCount += 1;
-    session.totalBytes += fileBytes;
-    session.paths.add(relativePath);
-    respondJson(response, 201, { path: relativePath, size: fileBytes });
-  } catch (error) {
-    await rm(destination, { force: true });
-    respondJson(response, 413, { error: error instanceof Error ? error.message : String(error) });
+    const declaredBytes = Number(request.headers["content-length"]);
+    if (Number.isFinite(declaredBytes) && declaredBytes >= 0 && session.totalBytes + declaredBytes > MAX_IMPORT_BYTES) {
+      request.resume();
+      respondJson(response, 413, { error: "Workspace import exceeds the 128 MiB aggregate limit." });
+      return;
+    }
+    const chunks: Buffer[] = [];
+    let fileBytes = 0;
+    const destination = resolve(session.directory, ...relativePath.split("/"));
+    try {
+      for await (const chunk of request) {
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        fileBytes += bytes.length;
+        if (session.totalBytes + fileBytes > MAX_IMPORT_BYTES) throw new Error("Workspace import exceeds the 128 MiB aggregate limit.");
+        chunks.push(bytes);
+      }
+      await mkdir(dirname(destination), { recursive: true });
+      const handle = await open(destination, "wx");
+      try {
+        await handle.writeFile(Buffer.concat(chunks));
+      } finally {
+        await handle.close();
+      }
+      session.fileCount += 1;
+      session.totalBytes += fileBytes;
+      session.paths.add(relativePath);
+      respondJson(response, 201, { path: relativePath, size: fileBytes });
+    } catch (error) {
+      await rm(destination, { force: true });
+      respondJson(response, 413, { error: error instanceof Error ? error.message : String(error) });
+    }
+  } finally {
+    await releaseWorkspaceImportSession(state, sessionId, session);
   }
 }
 export async function commitWorkspaceImport(
@@ -400,15 +436,25 @@ export async function commitWorkspaceImport(
     respondJson(response, 404, { error: "Workspace import session is unavailable." });
     return;
   }
+  if (session.busy || session.expired) {
+    respondJson(response, 409, { error: "Another operation is already using this workspace import session." });
+    return;
+  }
   if (state.workspaceOpenStage !== "idle") {
     respondJson(response, 409, { error: "Another Project change is already in progress." });
     return;
   }
+  if (state.projects.size >= MAX_STUDIO_PROJECTS) {
+    respondJson(response, 429, { error: `Studio remembers at most ${MAX_STUDIO_PROJECTS} Projects. Remove one before importing another.` });
+    return;
+  }
+  session.busy = true;
   state.workspaceOpenStage = "discovering";
   try {
     await commitWorkspaceImportSession(response, options, state, sessionId, session);
   } finally {
     state.workspaceOpenStage = "idle";
+    await releaseWorkspaceImportSession(state, sessionId, session);
   }
 }
 
@@ -485,10 +531,16 @@ export async function abortWorkspaceImport(
     respondJson(response, 403, { error: "Cross-origin workspace imports are not allowed." });
     return;
   }
-  if (workspaceImportSession(state, sessionId) === undefined) {
+  const session = workspaceImportSession(state, sessionId);
+  if (session === undefined) {
     respondJson(response, 404, { error: "Workspace import session is unavailable." });
     return;
   }
+  if (session.busy) {
+    respondJson(response, 409, { error: "Another operation is already using this workspace import session." });
+    return;
+  }
+  session.busy = true;
   await removeWorkspaceImport(state, sessionId);
   respondJson(response, 200, { aborted: true });
 }
@@ -552,6 +604,16 @@ async function removeWorkspaceImport(state: HarnessStudioState, sessionId: strin
   state.workspaceImports.delete(sessionId);
   await rm(session.directory, { recursive: true, force: true });
 }
+async function releaseWorkspaceImportSession(
+  state: HarnessStudioState,
+  sessionId: string,
+  session: WorkspaceImportSession,
+): Promise<void> {
+  session.busy = false;
+  if (session.expired && state.workspaceImports.get(sessionId) === session) {
+    await removeWorkspaceImport(state, sessionId);
+  }
+}
 export async function cleanupWorkspaceImports(state: HarnessStudioState): Promise<void> {
   await Promise.all([...state.workspaceImports.keys()].map((sessionId) => removeWorkspaceImport(state, sessionId)));
   const ownedDirectories = new Set([...state.projects.values()]
@@ -559,6 +621,7 @@ export async function cleanupWorkspaceImports(state: HarnessStudioState): Promis
     .filter((directory): directory is string => directory !== undefined));
   await Promise.all([...ownedDirectories].map((directory) => rm(directory, { recursive: true, force: true }).catch(() => undefined)));
   state.projects.clear();
+  state.projectRevisionContexts.clear();
   state.activeProjectId = undefined;
   state.workspace = undefined;
   state.customizationAnalysis = undefined;

--- a/packages/harness-studio/test/agent-react/build-coordinator.test.ts
+++ b/packages/harness-studio/test/agent-react/build-coordinator.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { createBuildCoordinator } from "../../src/agent-react/host/build-coordinator.js";
+import { BuildGenerationSuperseded, type ObservationInput } from "../../src/agent-react/contracts/index.js";
+import { createOxcCompiler } from "../../src/agent-react/kernel/compiler.js";
+import { ORDERS_VIEW_MODULE, revisionOf, STAT_ROW_MODULE, TEST_RUNTIME_PACKAGES } from "./pipeline-fixture.js";
+
+function coordinator(observations: ObservationInput[] = [], runtimeVersion = "1") {
+  return createBuildCoordinator({
+    compiler: createOxcCompiler(),
+    runtimePackages: TEST_RUNTIME_PACKAGES,
+    runtimeVersion,
+    onObservation: (observation) => observations.push(observation),
+  });
+}
+
+const ordersRevision = () => revisionOf("orders.dashboard", "/view.tsx", [ORDERS_VIEW_MODULE, STAT_ROW_MODULE]);
+
+describe("AgentReactBuildCoordinator (AR-AC-4)", () => {
+  it("links a multi-module Revision into a frozen, runnable Build Snapshot", async () => {
+    const snapshot = await coordinator().build(ordersRevision());
+
+    expect(snapshot.status).toBe("ready");
+    expect(snapshot.diagnostics).toEqual([]);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(snapshot.buildGeneration).toBe(1);
+    expect(snapshot.artifactId).toBe("orders.dashboard");
+    expect(snapshot.viewDeclaration?.capabilities).toEqual(["orders.read", "orders.refresh"]);
+    expect(snapshot.semanticIndex.map((index) => index.module).sort()).toEqual(["/stat-row.tsx", "/view.tsx"]);
+    expect(snapshot.sourceMaps.map((entry) => entry.module).sort()).toEqual(["/stat-row.tsx", "/view.tsx"]);
+    expect(Object.isFrozen(snapshot.sourceMaps[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.semanticIndex[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.semanticIndex[0]?.jsxNodes[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.viewDeclaration?.state[0])).toBe(true);
+  });
+
+  it("keeps the build digest stable across identical builds", async () => {
+    const revision = ordersRevision();
+    const first = await coordinator().build(revision);
+    const second = await coordinator().build(revision);
+
+    expect(second.buildDigest).toBe(first.buildDigest);
+    expect(second.bundle).toBe(first.bundle);
+  });
+
+  it("changes the build digest when the runtime version changes", async () => {
+    const revision = ordersRevision();
+    const first = await coordinator([], "1").build(revision);
+    const second = await coordinator([], "2").build(revision);
+
+    expect(second.buildDigest).not.toBe(first.buildDigest);
+    expect(second.artifactDigest).toBe(first.artifactDigest);
+  });
+
+  it("changes build identity when effective compile limits change", async () => {
+    const revision = ordersRevision();
+    const first = await createBuildCoordinator({
+      compiler: createOxcCompiler(),
+      runtimePackages: TEST_RUNTIME_PACKAGES,
+    }).build(revision);
+    const second = await createBuildCoordinator({
+      compiler: createOxcCompiler({ maxModuleBytes: 600 * 1024 }),
+      runtimePackages: TEST_RUNTIME_PACKAGES,
+    }).build(revision);
+
+    expect(second.status).toBe("ready");
+    expect(second.bundle).toBe(first.bundle);
+    expect(second.buildPolicyDigest).not.toBe(first.buildPolicyDigest);
+    expect(second.buildDigest).not.toBe(first.buildDigest);
+  });
+
+  it("changes build policy identity when an unused Bootstrap permission changes", async () => {
+    const revision = ordersRevision();
+    const first = await coordinator().build(revision);
+    const second = await createBuildCoordinator({
+      compiler: createOxcCompiler(),
+      runtimePackages: [
+        ...TEST_RUNTIME_PACKAGES,
+        { specifier: "@studio/catalog", external: "./catalog-v1.js" },
+      ],
+    }).build(revision);
+
+    expect(second.status).toBe("ready");
+    expect(second.bundle).toBe(first.bundle);
+    expect(second.buildPolicyDigest).not.toBe(first.buildPolicyDigest);
+    expect(second.buildDigest).not.toBe(first.buildDigest);
+  });
+
+  it("changes the build digest when the Revision changes", async () => {
+    const first = await coordinator().build(ordersRevision());
+    const edited = revisionOf("orders.dashboard", "/view.tsx", [
+      ORDERS_VIEW_MODULE,
+      { ...STAT_ROW_MODULE, text: STAT_ROW_MODULE.text.replace("stat", "stat-row") },
+    ]);
+    const second = await coordinator().build(edited);
+
+    expect(second.artifactDigest).not.toBe(first.artifactDigest);
+    expect(second.buildDigest).not.toBe(first.buildDigest);
+  });
+
+  it("rejects a superseded generation instead of returning its bundle", async () => {
+    const build = coordinator();
+    const first = build.build(ordersRevision());
+    const second = build.build(ordersRevision());
+
+    await expect(first).rejects.toBeInstanceOf(BuildGenerationSuperseded);
+    expect((await second).buildGeneration).toBe(2);
+  });
+
+  it("fails the build and observes a profile violation without emitting a bundle", async () => {
+    const observations: ObservationInput[] = [];
+    const revision = revisionOf("orders.dashboard", "/view.tsx", [
+      { ...ORDERS_VIEW_MODULE, text: `${ORDERS_VIEW_MODULE.text}\nconsole.log("boot");\n` },
+      STAT_ROW_MODULE,
+    ]);
+
+    const snapshot = await coordinator(observations).build(revision);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.bundle).toBe("");
+    expect(snapshot.viewDeclaration).toBeDefined();
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("profile/top-level-effect");
+    expect(observations.map((observation) => observation.kind)).toContain("profileViolation");
+  });
+
+  it("fails a Revision whose entry declares no Artifact View", async () => {
+    const revision = revisionOf("orders.dashboard", "/view.tsx", [
+      { path: "/view.tsx", text: "export const Panel = () => <div />;\n" },
+    ]);
+
+    const snapshot = await coordinator().build(revision);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("abi/missing-view");
+  });
+
+  it("enforces the module-count budget before compiling", async () => {
+    const build = createBuildCoordinator({
+      compiler: createOxcCompiler(),
+      runtimePackages: TEST_RUNTIME_PACKAGES,
+      maxModules: 1,
+    });
+
+    const snapshot = await build.build(ordersRevision());
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["limit/module-count"]);
+  });
+
+  it("requires the Trusted Bootstrap to provide the runtime specifiers", async () => {
+    const build = createBuildCoordinator({
+      compiler: createOxcCompiler(),
+      runtimePackages: [{ specifier: "react", external: "react" }],
+    });
+
+    await expect(build.build(ordersRevision())).rejects.toThrow(/Trusted Bootstrap must provide/);
+  });
+
+  it("refuses a Revision whose digest does not name its current bytes", async () => {
+    const revision = ordersRevision();
+    const forged = { ...revision, digest: "sha256:forged" as const };
+
+    const snapshot = await coordinator().build(forged);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["revision/digest-mismatch"]);
+  });
+
+  it("refuses duplicate and non-normalized module paths from a manually constructed Revision", async () => {
+    const revision = ordersRevision();
+    const duplicate = { ...revision, modules: [...revision.modules, revision.modules[0]!] };
+    const invalidPath = {
+      ...revision,
+      modules: [{ ...revision.modules[0]!, path: "/a/../view.tsx" }, ...revision.modules.slice(1)],
+    };
+
+    expect((await coordinator().build(duplicate)).diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "revision/duplicate-module",
+    ]);
+    expect((await coordinator().build(invalidPath)).diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "revision/path-invalid",
+    ]);
+  });
+
+  it("requires the static Artifact View id to match the descriptor id", async () => {
+    const revision = revisionOf("catalog.orders", "/view.tsx", [ORDERS_VIEW_MODULE, STAT_ROW_MODULE]);
+
+    const snapshot = await coordinator().build(revision);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("abi/view-id-mismatch");
+  });
+});
+
+describe("Linker allowlist (AR-AC-6)", () => {
+  it("fails the link stage for a package the Profile never saw", async () => {
+    const compiler = createOxcCompiler();
+    // A compiler that accepts everything stands in for a bypassed Profile: the
+    // linker must still refuse, so one defeated check does not produce a bundle.
+    const permissive = {
+      compilerVersion: compiler.compilerVersion,
+      profileVersion: compiler.profileVersion,
+      policyFingerprint: compiler.policyFingerprint,
+      compileModule: (input: Parameters<typeof compiler.compileModule>[0]) =>
+        compiler.compileModule({ ...input, allowedPackages: [...input.allowedPackages, "lodash"] }),
+    };
+    const build = createBuildCoordinator({ compiler: permissive, runtimePackages: TEST_RUNTIME_PACKAGES });
+    const revision = revisionOf("orders.dashboard", "/view.tsx", [
+      // The binding is used, because Oxc elides an unused import the way
+      // TypeScript does and an elided import would never reach the linker.
+      { ...ORDERS_VIEW_MODULE, text: `import { chunk } from "lodash";\n${ORDERS_VIEW_MODULE.text}\nexport const chunked = chunk;\n` },
+      STAT_ROW_MODULE,
+    ]);
+
+    const snapshot = await build.build(revision);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.bundle).toBe("");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("link/package-not-allowed");
+  });
+
+  it("fails the link stage for an import outside the Revision", async () => {
+    const revision = revisionOf("orders.dashboard", "/view.tsx", [
+      { ...ORDERS_VIEW_MODULE, text: ORDERS_VIEW_MODULE.text.replace("./stat-row.js", "./missing.js") },
+      STAT_ROW_MODULE,
+    ]);
+
+    const snapshot = await coordinator().build(revision);
+
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("link/failed");
+  });
+});

--- a/packages/harness-studio/test/agent-react/capability-and-actions.test.ts
+++ b/packages/harness-studio/test/agent-react/capability-and-actions.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Digest } from "../../src/agent-react/contracts/index.js";
+import { createActionGateway } from "../../src/agent-react/host/action-gateway.js";
+import { createCapabilityBroker, createCapabilityPolicy } from "../../src/agent-react/host/capability.js";
+import { createObservationBridge } from "../../src/agent-react/host/observation-bridge.js";
+
+const BUILD: Digest = "sha256:build";
+const DECLARED = { capabilities: ["orders.read", "orders.refresh", "orders.delete"] };
+
+function host(options: { readonly approvals?: readonly string[] } = {}) {
+  const policy = createCapabilityPolicy({
+    allowedCapabilities: ["orders.read", "orders.refresh"],
+    requiresApproval: ["orders.refresh"],
+  });
+  const broker = createCapabilityBroker({ policy, approvals: options.approvals });
+  const observations = createObservationBridge();
+  const gateway = createActionGateway({ broker, policy, observations, artifactDigest: "sha256:artifact" });
+  return { policy, broker, observations, gateway };
+}
+
+describe("CapabilityBroker grants (AR-AC-7)", () => {
+  it("grants the intersection of request, policy, and approval", () => {
+    const { broker } = host({ approvals: ["orders.refresh"] });
+
+    expect(broker.computeGrant(DECLARED)).toEqual({
+      granted: ["orders.read", "orders.refresh"],
+      refused: [{ capability: "orders.delete", reason: "not-in-policy" }],
+    });
+  });
+
+  it("withholds a policy-allowed capability that is awaiting approval", () => {
+    const { broker } = host();
+
+    expect(broker.computeGrant(DECLARED)).toEqual({
+      granted: ["orders.read"],
+      refused: [
+        { capability: "orders.delete", reason: "not-in-policy" },
+        { capability: "orders.refresh", reason: "awaiting-approval" },
+      ],
+    });
+  });
+
+  it("grants a capability once it is approved and withdraws it again", () => {
+    const { broker } = host();
+
+    broker.approve("orders.refresh");
+    expect(broker.computeGrant(DECLARED).granted).toEqual(["orders.read", "orders.refresh"]);
+
+    broker.revokeApproval("orders.refresh");
+    expect(broker.computeGrant(DECLARED).granted).toEqual(["orders.read"]);
+  });
+
+  it("deduplicates repeated requests", () => {
+    const { broker } = host();
+
+    expect(broker.computeGrant({ capabilities: ["orders.read", "orders.read"] }).granted).toEqual(["orders.read"]);
+  });
+});
+
+describe("ActionGateway dispatch (AR-AC-7)", () => {
+  it("runs a granted Action once in a live frame", async () => {
+    const { broker, gateway } = host();
+    const handler = vi.fn(() => "refreshed");
+    gateway.register("orders.read", handler);
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read", payload: { page: 1 } });
+
+    expect(outcome).toEqual({ status: "completed", result: "refreshed" });
+    expect(handler).toHaveBeenCalledExactlyOnceWith({ page: 1 });
+  });
+
+  it("records the attempt but never invokes the handler in a dry-run frame", async () => {
+    const { broker, gateway, observations } = host();
+    const handler = vi.fn();
+    gateway.register("orders.read", handler);
+    const token = broker.issueFrameToken(BUILD, "dry-run", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "dry-run" });
+    expect(handler).not.toHaveBeenCalled();
+    expect(observations.recorded().map((event) => event.kind)).toEqual(["actionAttempted"]);
+  });
+
+  it("denies every Action in a denied frame", async () => {
+    const { broker, gateway } = host();
+    gateway.register("orders.read", () => "never");
+    const token = broker.issueFrameToken(BUILD, "denied", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Frame is not permitted to run Actions." });
+  });
+
+  it("denies an ungranted capability even though the code declared it", async () => {
+    const { broker, gateway, observations } = host();
+    gateway.register("orders.delete", () => "never");
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.delete" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Capability 'orders.delete' is not currently granted to this frame." });
+    expect(observations.recorded().map((event) => event.kind)).toEqual(["actionAttempted", "actionDenied"]);
+  });
+
+  it("denies an unknown capability", async () => {
+    const { broker, gateway } = host();
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.export" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Capability 'orders.export' is not currently granted to this frame." });
+  });
+
+  it("denies a revoked frame token for a previously granted capability", async () => {
+    const { broker, gateway } = host();
+    gateway.register("orders.read", () => "ok");
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+    expect(await gateway.dispatch({ frameToken: token.token, capability: "orders.read" })).toEqual({
+      status: "completed",
+      result: "ok",
+    });
+
+    broker.revokeFrameToken(token.token);
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Frame token is unknown or has been revoked." });
+  });
+
+  it("applies approval revocation to tokens that were already issued", async () => {
+    const { broker, gateway } = host({ approvals: ["orders.refresh"] });
+    gateway.register("orders.refresh", () => "refreshed");
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    expect((await gateway.dispatch({ frameToken: token.token, capability: "orders.refresh" })).status).toBe("completed");
+    broker.revokeApproval("orders.refresh");
+
+    expect(await gateway.dispatch({ frameToken: token.token, capability: "orders.refresh" })).toEqual({
+      status: "denied",
+      reason: "Capability 'orders.refresh' is not currently granted to this frame.",
+    });
+  });
+
+  it("fails closed when a custom token generator collides", () => {
+    const policy = createCapabilityPolicy({ allowedCapabilities: ["orders.read"] });
+    const broker = createCapabilityBroker({ policy, newToken: () => "duplicate" });
+    const grant = broker.computeGrant({ capabilities: ["orders.read"] });
+    broker.issueFrameToken(BUILD, "live", grant);
+
+    expect(() => broker.issueFrameToken(BUILD, "live", grant)).toThrow(/duplicate token/);
+  });
+
+  it("denies an unknown frame token without recording an attempt", async () => {
+    const { gateway, observations } = host();
+
+    const outcome = await gateway.dispatch({ frameToken: "forged", capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Frame token is unknown or has been revoked." });
+    expect(observations.recorded().map((event) => event.kind)).toEqual(["actionDenied"]);
+  });
+
+  it("re-validates the payload through policy on every call", async () => {
+    const policy = createCapabilityPolicy({
+      allowedCapabilities: ["orders.read"],
+      validate: (_capability, payload) => (typeof payload === "object" ? true : "Payload must be an object."),
+    });
+    const broker = createCapabilityBroker({ policy });
+    const observations = createObservationBridge();
+    const gateway = createActionGateway({ broker, policy, observations });
+    gateway.register("orders.read", () => "ok");
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant({ capabilities: ["orders.read"] }));
+
+    expect(await gateway.dispatch({ frameToken: token.token, capability: "orders.read", payload: {} })).toEqual({
+      status: "completed",
+      result: "ok",
+    });
+    expect(await gateway.dispatch({ frameToken: token.token, capability: "orders.read", payload: 7 })).toEqual({
+      status: "denied",
+      reason: "Payload must be an object.",
+    });
+  });
+
+  it("denies a granted capability that has no Host handler", async () => {
+    const { broker, gateway } = host();
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "No Host handler is registered for 'orders.read'." });
+  });
+
+  it("reports a throwing handler as a runtime exception without leaking its message", async () => {
+    const { broker, gateway, observations } = host();
+    gateway.register("orders.read", () => {
+      throw new Error("connection string postgres://secret@host");
+    });
+    const token = broker.issueFrameToken(BUILD, "live", broker.computeGrant(DECLARED));
+
+    const outcome = await gateway.dispatch({ frameToken: token.token, capability: "orders.read" });
+
+    expect(outcome).toEqual({ status: "denied", reason: "Action 'orders.read' failed in the Host." });
+    expect(observations.recorded().map((event) => event.kind)).toEqual(["actionAttempted", "runtimeException"]);
+  });
+});

--- a/packages/harness-studio/test/agent-react/frame-controller.test.ts
+++ b/packages/harness-studio/test/agent-react/frame-controller.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  BuildSnapshot,
+  Digest,
+  FrameHandle,
+  FrameMountOptions,
+  FrameToken,
+  FrameVerification,
+} from "../../src/agent-react/contracts/index.js";
+import { createSandboxFrameController } from "../../src/agent-react/host/frames/frame-controller.js";
+import { createActionGateway } from "../../src/agent-react/host/action-gateway.js";
+import { createCapabilityBroker, createCapabilityPolicy } from "../../src/agent-react/host/capability.js";
+import { createObservationBridge } from "../../src/agent-react/host/observation-bridge.js";
+import { createArtifactStateStore } from "../../src/agent-react/host/state-store.js";
+
+type Script = FrameVerification | "attempt-action" | "throw-on-mount" | "never-settle";
+
+/**
+ * A scripted frame stands in for a real sandbox so the transaction itself can be
+ * driven through outcomes a browser would only produce by accident: a timeout, a
+ * post-mount throw, an Action attempt from an untrusted build.
+ */
+class ScriptedFrame implements FrameHandle {
+  disposeCount = 0;
+  #token: FrameToken;
+
+  constructor(
+    readonly snapshot: BuildSnapshot,
+    readonly options: FrameMountOptions,
+    private readonly script: Script,
+    private readonly onMount: (frame: ScriptedFrame) => void,
+  ) {
+    this.#token = options.frameToken;
+  }
+
+  get actionMode(): FrameToken["actionMode"] {
+    return this.#token.actionMode;
+  }
+
+  get frameToken(): FrameToken {
+    return this.#token;
+  }
+
+  get disposed(): boolean {
+    return this.disposeCount > 0;
+  }
+
+  async mount(): Promise<void> {
+    if (this.script === "throw-on-mount") throw new Error("bundle would not start");
+    this.onMount(this);
+  }
+
+  async waitForRenderCompleted(timeoutMs: number): Promise<FrameVerification> {
+    if (this.script === "never-settle") {
+      await new Promise((resolve) => setTimeout(resolve, timeoutMs + 5));
+      return { status: "timedOut" };
+    }
+    if (this.script === "attempt-action" || this.script === "throw-on-mount") return { status: "renderCompleted" };
+    return this.script;
+  }
+
+  activate(token: FrameToken): void {
+    this.#token = token;
+  }
+
+  dispose(): void {
+    this.disposeCount += 1;
+  }
+}
+
+function snapshotOf(id: string): BuildSnapshot {
+  return Object.freeze({
+    buildDigest: `sha256:${id}` as Digest,
+    artifactDigest: "sha256:artifact" as Digest,
+    artifactId: "orders.dashboard",
+    buildGeneration: 1,
+    compilerVersion: "oxc-test",
+    profileVersion: "1",
+    runtimeVersion: "1",
+    buildPolicyDigest: "sha256:policy" as Digest,
+    status: "ready",
+    bundle: `// ${id}`,
+    sourceMaps: [],
+    semanticIndex: [],
+    viewDeclaration: {
+      id: "orders.dashboard",
+      state: [],
+      capabilities: ["orders.refresh"],
+      componentName: "Panel",
+      module: "/view.tsx",
+    },
+    diagnostics: [],
+  });
+}
+
+function harness(options: {
+  readonly blockOnDeniedAction?: boolean;
+  readonly maxRetainedObservations?: number;
+} = {}) {
+  const observations = createObservationBridge({ maxRetained: options.maxRetainedObservations });
+  const policy = createCapabilityPolicy({ allowedCapabilities: ["orders.refresh"] });
+  const broker = createCapabilityBroker({ policy });
+  const state = createArtifactStateStore({ declarations: [], schemas: [], observations });
+  const gateway = createActionGateway({ broker, policy, observations });
+  const created: ScriptedFrame[] = [];
+  let script: Script = { status: "renderCompleted" };
+
+  const controller = createSandboxFrameController({
+    frames: {
+      isolation: "in-process",
+      create(snapshot, mountOptions) {
+        const frame = new ScriptedFrame(snapshot, mountOptions, script, (mounted) => {
+          if (script !== "attempt-action") return;
+          // The staging build tries to act before it is trusted.
+          void gateway.dispatch({ frameToken: mounted.frameToken.token, capability: "orders.refresh" });
+        });
+        created.push(frame);
+        return frame;
+      },
+    },
+    broker,
+    observations,
+    state,
+    allowInProcessVerification: true,
+    verificationTimeoutMs: 20,
+    ...(options.blockOnDeniedAction === undefined ? {} : { blockOnDeniedAction: options.blockOnDeniedAction }),
+  });
+
+  return {
+    controller,
+    observations,
+    broker,
+    created,
+    setScript(next: Script) {
+      script = next;
+    },
+  };
+}
+
+describe("SandboxFrameController transactions (AR-AC-9)", () => {
+  it("stages a verified build as dry-run with a frozen state snapshot", async () => {
+    const { controller, created } = harness();
+
+    const staged = await controller.stage(snapshotOf("one"));
+
+    expect(staged.status).toBe("staged");
+    expect(controller.staging?.actionMode).toBe("dry-run");
+    expect(controller.current).toBeUndefined();
+    expect(Object.isFrozen(created[0]?.options.state)).toBe(true);
+    expect(staged.status === "staged" && staged.grant.granted).toEqual(["orders.refresh"]);
+  });
+
+  it("promotes the staged frame to live and leaves no staging frame behind", async () => {
+    const { controller, broker } = harness();
+    const staged = await controller.stage(snapshotOf("one"));
+    const stagingToken = staged.status === "staged" ? staged.frame.frameToken.token : "";
+
+    const promoted = controller.activate();
+
+    expect(controller.current).toBe(promoted);
+    expect(controller.staging).toBeUndefined();
+    expect(promoted.actionMode).toBe("live");
+    expect(promoted.disposed).toBe(false);
+    expect(broker.resolveFrameToken(stagingToken)).toBeUndefined();
+    expect(broker.resolveFrameToken(promoted.frameToken.token)?.actionMode).toBe("live");
+  });
+
+  it("disposes the outgoing Current exactly once on commit", async () => {
+    const { controller, created } = harness();
+    await controller.stage(snapshotOf("one"));
+    controller.activate();
+    await controller.stage(snapshotOf("two"));
+    controller.activate();
+
+    expect(created).toHaveLength(2);
+    expect(created[0]?.disposeCount).toBe(1);
+    expect(created[1]?.disposed).toBe(false);
+    expect(controller.current?.snapshot.buildDigest).toBe("sha256:two");
+  });
+
+  it("keeps Current mounted when the new build reports renderFailed", async () => {
+    const { controller, created, setScript, observations } = harness();
+    await controller.stage(snapshotOf("one"));
+    const original = controller.activate();
+
+    setScript({ status: "renderFailed", message: "component threw" });
+    const staged = await controller.stage(snapshotOf("broken"));
+
+    expect(staged).toEqual({
+      status: "rejected",
+      reason: "component threw",
+      verification: { status: "renderFailed", message: "component threw" },
+    });
+    expect(controller.current).toBe(original);
+    expect(original.disposed).toBe(false);
+    expect(created[1]?.disposeCount).toBe(1);
+    expect(observations.recorded().some((event) => event.kind === "renderFailed")).toBe(true);
+  });
+
+  it("keeps Current mounted when staging verification times out", async () => {
+    const { controller, setScript } = harness();
+    await controller.stage(snapshotOf("one"));
+    const original = controller.activate();
+
+    setScript("never-settle");
+    const staged = await controller.stage(snapshotOf("slow"));
+
+    expect(staged.status).toBe("rejected");
+    expect(staged.status === "rejected" && staged.verification).toEqual({ status: "timedOut" });
+    expect(controller.current).toBe(original);
+    expect(controller.staging).toBeUndefined();
+  });
+
+  it("treats a mount throw as a staging failure", async () => {
+    const { controller, setScript } = harness();
+    setScript("throw-on-mount");
+
+    const staged = await controller.stage(snapshotOf("one"));
+
+    expect(staged).toMatchObject({ status: "rejected", reason: "bundle would not start" });
+    expect(controller.current).toBeUndefined();
+  });
+
+  it("blocks the commit when a staging build attempts an Action and the policy says so", async () => {
+    const { controller, setScript, observations } = harness({ blockOnDeniedAction: true });
+    await controller.stage(snapshotOf("one"));
+    const original = controller.activate();
+
+    setScript("attempt-action");
+    const staged = await controller.stage(snapshotOf("eager"));
+
+    expect(staged).toMatchObject({
+      status: "rejected",
+      reason: "Build attempted an Action during staging verification.",
+    });
+    expect(controller.current).toBe(original);
+    expect(observations.recorded().some((event) => event.kind === "actionAttempted")).toBe(true);
+  });
+
+  it("blocks an attempted Action even when the observation retention buffer is empty", async () => {
+    const { controller, setScript, observations } = harness({
+      blockOnDeniedAction: true,
+      maxRetainedObservations: 0,
+    });
+    setScript("attempt-action");
+
+    const staged = await controller.stage(snapshotOf("eager"));
+
+    expect(staged).toMatchObject({
+      status: "rejected",
+      reason: "Build attempted an Action during staging verification.",
+    });
+    expect(observations.recorded()).toEqual([]);
+  });
+
+  it("allows the commit when an Action attempt is informational only", async () => {
+    const { controller, setScript } = harness();
+    setScript("attempt-action");
+
+    const staged = await controller.stage(snapshotOf("eager"));
+
+    expect(staged.status).toBe("staged");
+    expect(controller.activate().snapshot.buildDigest).toBe("sha256:eager");
+  });
+
+  it("rejects a snapshot that is not runnable or carries no declaration", async () => {
+    const { controller } = harness();
+    const failed = { ...snapshotOf("one"), status: "failed" as const };
+    const undeclared = { ...snapshotOf("one"), viewDeclaration: undefined };
+
+    expect(await controller.stage(failed)).toEqual({ status: "rejected", reason: "Build Snapshot is not runnable." });
+    expect(await controller.stage(undeclared)).toEqual({
+      status: "rejected",
+      reason: "Build Snapshot carries no Artifact View declaration.",
+    });
+  });
+
+  it("restores the previous snapshot on rollback", async () => {
+    const { controller } = harness();
+    await controller.stage(snapshotOf("one"));
+    controller.activate();
+    await controller.stage(snapshotOf("two"));
+    controller.activate();
+    expect(controller.current?.snapshot.buildDigest).toBe("sha256:two");
+
+    const rolled = await controller.rollback();
+
+    expect(rolled.status).toBe("staged");
+    expect(controller.current?.snapshot.buildDigest).toBe("sha256:one");
+    expect(controller.current?.actionMode).toBe("live");
+  });
+
+  it("refuses rollback before any commit has been superseded", async () => {
+    const { controller } = harness();
+    await controller.stage(snapshotOf("one"));
+    controller.activate();
+
+    expect(await controller.rollback()).toEqual({
+      status: "rejected",
+      reason: "No previous Build Snapshot is retained to roll back to.",
+    });
+  });
+
+  it("refuses to activate without a verified staging frame", async () => {
+    const { controller } = harness();
+
+    expect(() => controller.activate()).toThrow(/No verified staging frame/);
+  });
+
+  it("discards a staged frame and revokes its token", async () => {
+    const { controller, broker } = harness();
+    const staged = await controller.stage(snapshotOf("one"));
+    const token = staged.status === "staged" ? staged.frame.frameToken.token : "";
+
+    controller.discard();
+
+    expect(controller.staging).toBeUndefined();
+    expect(broker.resolveFrameToken(token)).toBeUndefined();
+  });
+
+  it("replaces an earlier staging frame when a newer build is staged", async () => {
+    const { controller, created } = harness();
+    await controller.stage(snapshotOf("one"));
+    await controller.stage(snapshotOf("two"));
+
+    expect(created[0]?.disposeCount).toBe(1);
+    expect(controller.staging?.snapshot.buildDigest).toBe("sha256:two");
+  });
+
+  it("does not let an older overlapping stage dispose or replace the newer frame", async () => {
+    const observations = createObservationBridge();
+    const policy = createCapabilityPolicy({ allowedCapabilities: ["orders.refresh"] });
+    const broker = createCapabilityBroker({ policy });
+    const state = createArtifactStateStore({ declarations: [], schemas: [], observations });
+    const completions = new Map<string, (verification: FrameVerification) => void>();
+    const frames: ScriptedFrame[] = [];
+    const controller = createSandboxFrameController({
+      frames: {
+        isolation: "in-process",
+        create(snapshot, mountOptions) {
+          const frame = new ScriptedFrame(snapshot, mountOptions, { status: "renderCompleted" }, () => {});
+          frame.waitForRenderCompleted = () => new Promise((resolve) => completions.set(snapshot.buildDigest, resolve));
+          frames.push(frame);
+          return frame;
+        },
+      },
+      broker,
+      observations,
+      state,
+      allowInProcessVerification: true,
+    });
+
+    const older = controller.stage(snapshotOf("one"));
+    await vi.waitFor(() => expect(completions.has("sha256:one")).toBe(true));
+    const newer = controller.stage(snapshotOf("two"));
+    await vi.waitFor(() => expect(completions.has("sha256:two")).toBe(true));
+
+    completions.get("sha256:one")!({ status: "renderFailed", message: "late failure" });
+    await expect(older).resolves.toEqual({
+      status: "rejected",
+      reason: "Staging build was superseded by a newer generation.",
+    });
+    expect(controller.staging?.snapshot.buildDigest).toBe("sha256:two");
+    expect(frames[1]?.disposed).toBe(false);
+
+    completions.get("sha256:two")!({ status: "renderCompleted" });
+    await expect(newer).resolves.toMatchObject({ status: "staged" });
+  });
+
+  it("rejects in-process execution unless verification-only mode is explicit", () => {
+    const observations = createObservationBridge();
+    const policy = createCapabilityPolicy({ allowedCapabilities: [] });
+    const broker = createCapabilityBroker({ policy });
+    const state = createArtifactStateStore({ declarations: [], schemas: [] });
+
+    expect(() => createSandboxFrameController({
+      frames: {
+        isolation: "in-process",
+        create() {
+          throw new Error("must not create a frame");
+        },
+      },
+      broker,
+      observations,
+      state,
+    })).toThrow(/verification-only/);
+  });
+});

--- a/packages/harness-studio/test/agent-react/frame-protocol.test.ts
+++ b/packages/harness-studio/test/agent-react/frame-protocol.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { Digest } from "../../src/agent-react/contracts/index.js";
+import {
+  createFrameInitMessage,
+  FRAME_PROTOCOL_VERSION,
+  isMatchingInit,
+  isReportFor,
+  renderFailedReport,
+} from "../../src/agent-react/host/frames/frame-protocol.js";
+
+const snapshot = {
+  buildDigest: "sha256:build" as Digest,
+  artifactDigest: "sha256:artifact" as Digest,
+  artifactId: "orders.dashboard",
+  buildGeneration: 1,
+  compilerVersion: "oxc-test",
+  profileVersion: "1",
+  runtimeVersion: "1",
+  buildPolicyDigest: "sha256:policy" as Digest,
+  status: "ready" as const,
+  bundle: "",
+  sourceMaps: [],
+  semanticIndex: [],
+  diagnostics: [],
+};
+
+describe("AgentReact frame protocol", () => {
+  it("owns the init state and matches the complete frame identity", () => {
+    const state = { "/orders": { rows: [] as unknown[] } };
+    const message = createFrameInitMessage({
+      snapshot,
+      actionMode: "dry-run",
+      frameToken: "token",
+      state,
+    });
+    state["/orders"].rows.push("late mutation");
+
+    expect(Object.isFrozen(message)).toBe(true);
+    expect(message.state).toEqual({ "/orders": { rows: [] } });
+    expect(isMatchingInit(message, {
+      buildDigest: snapshot.buildDigest,
+      artifactDigest: snapshot.artifactDigest,
+      frameToken: "token",
+      actionMode: "dry-run",
+    })).toBe(true);
+    expect(isMatchingInit({ ...message, actionMode: "live" }, {
+      buildDigest: snapshot.buildDigest,
+      artifactDigest: snapshot.artifactDigest,
+      frameToken: "token",
+      actionMode: "dry-run",
+    })).toBe(false);
+  });
+
+  it("rejects malformed failure reports instead of trusting their shape", () => {
+    expect(isReportFor({
+      type: "renderFailed",
+      protocol: FRAME_PROTOCOL_VERSION,
+      buildDigest: snapshot.buildDigest,
+    }, snapshot.buildDigest)).toBe(false);
+    expect(isReportFor({
+      type: "renderFailed",
+      protocol: FRAME_PROTOCOL_VERSION,
+      buildDigest: snapshot.buildDigest,
+      message: "x".repeat(601),
+    }, snapshot.buildDigest)).toBe(false);
+    expect(isReportFor(renderFailedReport(snapshot.buildDigest, "x".repeat(700)), snapshot.buildDigest)).toBe(true);
+  });
+});

--- a/packages/harness-studio/test/agent-react/host-services.test.ts
+++ b/packages/harness-studio/test/agent-react/host-services.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  grantedAgentReactCapabilities,
+  isAgentReactFrameRequest,
+  stageAgentReactState,
+  validateAgentReactStateValue,
+  type AgentReactStateSlot,
+} from "../../src/app/artifacts/AgentReactHostServices.js";
+
+describe("AgentReact Host services", () => {
+  it("retains state only across an exact schema and version match", () => {
+    const current = new Map<string, AgentReactStateSlot>([
+      ["/orders", { schema: "list", version: 1, value: ["A-1"] }],
+      ["/stale", { schema: "record", version: 1, value: { kept: false } }],
+    ]);
+    const staged = stageAgentReactState([
+      { path: "/orders", schema: "list", version: 1 },
+      { path: "/stale", schema: "list", version: 1 },
+      { path: "/options", schema: "record", version: 1 },
+    ], current);
+
+    expect(staged.values).toEqual({ "/orders": ["A-1"], "/stale": [], "/options": {} });
+    expect(staged.values["/orders"]).not.toBe(current.get("/orders")?.value);
+  });
+
+  it.each([
+    ["list", [1, "two", null]],
+    ["record", { enabled: true, count: 2 }],
+    ["json", { nested: [1, 2] }],
+  ])("accepts bounded %s@1 JSON state", (schema, value) => {
+    expect(validateAgentReactStateValue(schema, 1, value)).toEqual({ ok: true, value });
+  });
+
+  it.each([
+    ["list", 1, {}, "requires an array"],
+    ["record", 1, [], "requires an object"],
+    ["custom", 1, null, "is not provided"],
+    ["json", 2, null, "is not provided"],
+    ["json", 1, Number.NaN, "finite JSON"],
+    ["json", 1, { value: undefined }, "finite JSON"],
+  ])("refuses invalid %s@%s values", (schema, version, value, reason) => {
+    expect(validateAgentReactStateValue(schema, version, value)).toEqual({ ok: false, reason: expect.stringContaining(reason) });
+  });
+
+  it("grants only the explicit Host action and deduplicates requests", () => {
+    expect(grantedAgentReactCapabilities([
+      "orders.delete",
+      "studio.show-source",
+      "studio.show-source",
+    ])).toEqual(["studio.show-source"]);
+  });
+
+  it("accepts only correlated, positive-id state and action requests", () => {
+    expect(isAgentReactFrameRequest({
+      type: "state.set",
+      buildDigest: "sha256:build",
+      frameToken: "frame",
+      requestId: 1,
+      path: "/orders",
+      value: [],
+    })).toBe(true);
+    expect(isAgentReactFrameRequest({
+      type: "action.request",
+      buildDigest: "sha256:build",
+      frameToken: "frame",
+      requestId: 0,
+    })).toBe(false);
+    expect(isAgentReactFrameRequest({
+      type: "runtime.promote",
+      buildDigest: "sha256:build",
+      frameToken: "frame",
+      requestId: 1,
+    })).toBe(false);
+  });
+});

--- a/packages/harness-studio/test/agent-react/layering.test.ts
+++ b/packages/harness-studio/test/agent-react/layering.test.ts
@@ -1,0 +1,278 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, posix, relative, resolve, sep } from "node:path";
+import { parseSync } from "oxc-parser";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Architecture fitness functions for the AgentReact layering.
+ *
+ * These assert against the real import graph, parsed with oxc, rather than against
+ * source text. Two of them are load-bearing rather than stylistic:
+ *
+ * - The runtime layer executes inside the sandbox frame. If it ever imports the
+ *   kernel, a browser bundle pulls in `oxc-parser`'s native binding and fails to
+ *   load at all — a diagram cannot catch that, an import edge can.
+ * - The compiler and the runtime must compute a JSX element's address with the
+ *   *same* function. Both importing `contracts/addressing.ts` is what makes a
+ *   second, drifting copy impossible.
+ */
+
+const ROOT = resolve(import.meta.dirname, "..", "..", "src", "agent-react");
+
+/** Layers in dependency order; `contracts` is the sink, `host` the orchestrator. */
+const LAYERS = ["contracts", "kernel", "linker", "runtime", "host"] as const;
+type Layer = (typeof LAYERS)[number];
+
+/** Which layers each layer may import. A layer may always import itself. */
+const ALLOWED_DEPENDENCIES: Readonly<Record<Layer, readonly Layer[]>> = {
+  contracts: [],
+  kernel: ["contracts"],
+  linker: ["contracts"],
+  runtime: ["contracts"],
+  host: ["contracts", "kernel", "linker", "runtime"],
+};
+
+/** External npm packages each layer may depend on. */
+const ALLOWED_PACKAGES: Readonly<Record<Layer, readonly string[]>> = {
+  contracts: [],
+  kernel: ["oxc-parser", "oxc-transform"],
+  linker: ["esbuild-wasm"],
+  runtime: ["react", "react/jsx-runtime"],
+  host: ["react", "@qoder-ai/harness-ui/protocol"],
+};
+
+/**
+ * Layers that may use Node built-ins. `contracts` and `runtime` may not: both are
+ * loaded inside the sandbox frame, where `node:crypto` does not exist. That
+ * exclusion is why hashing enters the pipeline as an injected `DigestFn` and why
+ * `contracts/addressing.ts` inlines its own hash.
+ */
+const NODE_BUILTINS_ALLOWED: ReadonlySet<Layer> = new Set(["kernel", "linker", "host"]);
+
+interface ModuleRecord {
+  /** Path relative to `src/agent-react`, POSIX-separated. */
+  readonly id: string;
+  readonly layer: Layer | "root";
+  /** Resolved ids of same-package imports, in source order. */
+  readonly localImports: readonly string[];
+  /** Bare specifiers, including `node:` built-ins. */
+  readonly packageImports: readonly string[];
+  /** Export names defined in this module (not re-exports). */
+  readonly ownExports: readonly string[];
+}
+
+async function tsFilesUnder(directory: string): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...(await tsFilesUnder(path)));
+    else if (entry.isFile() && entry.name.endsWith(".ts")) found.push(path);
+  }
+  return found;
+}
+
+function layerOf(id: string): Layer | "root" {
+  const [first] = id.split("/");
+  return LAYERS.find((layer) => layer === first) ?? "root";
+}
+
+/**
+ * Maps a specifier to a module id. Source imports use the emitted `.js`
+ * extension, so `./x.js` resolves to the `./x.ts` on disk.
+ */
+function resolveLocal(fromId: string, specifier: string): string {
+  const joined = posix.join(posix.dirname(fromId), specifier);
+  return joined.replace(/\.js$/, ".ts");
+}
+
+async function readModule(absolutePath: string): Promise<ModuleRecord> {
+  const id = relative(ROOT, absolutePath).split(sep).join(posix.sep);
+  const text = await readFile(absolutePath, "utf8");
+  const parsed = parseSync(absolutePath, text, { lang: "tsx" });
+  expect(parsed.errors, `${id} must parse`).toEqual([]);
+
+  const specifiers = [
+    ...parsed.module.staticImports.map((entry) => entry.moduleRequest.value),
+    ...parsed.module.staticExports.flatMap((statement) =>
+      statement.entries.flatMap((entry) => (entry.moduleRequest ? [entry.moduleRequest.value] : [])),
+    ),
+    // Dynamic imports expose only a span, so read the literal back from source.
+    ...parsed.module.dynamicImports.map((entry) =>
+      text.slice(entry.moduleRequest.start, entry.moduleRequest.end).replace(/^["'`]|["'`]$/g, ""),
+    ),
+  ];
+
+  const ownExports = parsed.module.staticExports.flatMap((statement) =>
+    statement.entries.flatMap((entry) =>
+      entry.moduleRequest === null && entry.exportName.name !== null ? [entry.exportName.name] : [],
+    ),
+  );
+
+  return {
+    id,
+    layer: layerOf(id),
+    localImports: specifiers.filter((s) => s.startsWith(".")).map((s) => resolveLocal(id, s)),
+    packageImports: specifiers.filter((s) => !s.startsWith(".")),
+    ownExports,
+  };
+}
+
+const modules = await Promise.all((await tsFilesUnder(ROOT)).map(readModule));
+const byId = new Map(modules.map((module) => [module.id, module]));
+const inLayer = (layer: Layer) => modules.filter((module) => module.layer === layer);
+
+/** Every edge as `{from, to}` pairs of module ids, for per-rule filtering. */
+const edges = modules.flatMap((from) =>
+  from.localImports.map((to) => ({ from, to: byId.get(to), toId: to })),
+);
+
+describe("agent-react layering", () => {
+  it("sees every layer plus a top-level facade", () => {
+    expect(new Set(modules.map((module) => module.layer))).toEqual(
+      new Set([...LAYERS, "root"]),
+    );
+    // A rule that silently matches zero modules proves nothing.
+    for (const layer of LAYERS) expect(inLayer(layer).length, layer).toBeGreaterThan(0);
+  });
+
+  it("resolves every relative import to a real module", () => {
+    const unresolved = edges.filter((edge) => edge.to === undefined);
+    expect(unresolved.map((edge) => `${edge.from.id} -> ${edge.toId}`)).toEqual([]);
+  });
+
+  it("keeps dependencies pointing down the layer stack", () => {
+    const violations = edges.flatMap(({ from, to }) => {
+      if (!to || from.layer === "root" || to.layer === from.layer) return [];
+      const allowed = to.layer !== "root"
+        && ALLOWED_DEPENDENCIES[from.layer as Layer].includes(to.layer);
+      return allowed ? [] : [`${from.id} -> ${to.id}`];
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it("crosses layers only through the target layer's barrel", () => {
+    const violations = edges.flatMap(({ from, to }) => {
+      if (!to || to.layer === from.layer || to.layer === "root") return [];
+      // `contracts` is addressable file by file. Its barrel is `export *`, so
+      // importing through it would pull every contract module into the sandbox
+      // bundle — including `build.ts`, whose `BuildGenerationSuperseded` is real
+      // emitted code the frame has no use for. Every other layer hides
+      // implementation behind its barrel.
+      if (to.layer === "contracts") return [];
+      return to.id === `${to.layer}/index.ts` ? [] : [`${from.id} -> ${to.id}`];
+    });
+    expect([...new Set(violations)]).toEqual([]);
+  });
+
+  it("restricts each layer to its declared external packages", () => {
+    const violations = modules.flatMap((module) => {
+      if (module.layer === "root") return [];
+      const allowed = ALLOWED_PACKAGES[module.layer];
+      const builtinsOk = NODE_BUILTINS_ALLOWED.has(module.layer);
+      return module.packageImports
+        .filter((specifier) => {
+          if (specifier.startsWith("node:")) return !builtinsOk;
+          return !allowed.includes(specifier);
+        })
+        .map((specifier) => `${module.id} imports ${specifier}`);
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it("has no import cycles", () => {
+    const state = new Map<string, "visiting" | "done">();
+    const cycles: string[] = [];
+    const visit = (id: string, stack: readonly string[]): void => {
+      if (state.get(id) === "done") return;
+      if (state.get(id) === "visiting") {
+        cycles.push([...stack.slice(stack.indexOf(id)), id].join(" -> "));
+        return;
+      }
+      state.set(id, "visiting");
+      for (const next of byId.get(id)?.localImports ?? []) visit(next, [...stack, id]);
+      state.set(id, "done");
+    };
+    for (const module of modules) visit(module.id, []);
+    expect(cycles).toEqual([]);
+  });
+});
+
+describe("contracts layer", () => {
+  it("depends on nothing outside itself", () => {
+    const escaping = inLayer("contracts").flatMap((module) =>
+      module.localImports
+        .filter((id) => layerOf(id) !== "contracts")
+        .map((id) => `${module.id} -> ${id}`),
+    );
+    expect(escaping).toEqual([]);
+  });
+
+  it("imports no package and no Node built-in, so the sandbox can load it", () => {
+    // The runtime layer re-exports these contracts into the frame. A single
+    // `node:crypto` here would break that load, which is why hashing is injected
+    // as `DigestFn` instead of imported.
+    const offenders = inLayer("contracts").flatMap((module) =>
+      module.packageImports.map((specifier) => `${module.id} imports ${specifier}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("runtime layer", () => {
+  it("stays browser-loadable: only react, no Node built-ins", () => {
+    const offenders = inLayer("runtime").flatMap((module) =>
+      module.packageImports
+        .filter((specifier) => !ALLOWED_PACKAGES.runtime.includes(specifier))
+        .map((specifier) => `${module.id} imports ${specifier}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("never reaches the kernel, which would drag a native binding into the frame", () => {
+    const offenders = inLayer("runtime").flatMap((module) =>
+      module.localImports
+        .filter((id) => layerOf(id) === "kernel" || layerOf(id) === "linker" || layerOf(id) === "host")
+        .map((id) => `${module.id} -> ${id}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("toolchain ownership", () => {
+  it.each([
+    ["oxc-parser", "kernel"],
+    ["oxc-transform", "kernel"],
+    ["esbuild-wasm", "linker"],
+  ] as const)("confines %s to the %s layer", (specifier, owner) => {
+    const importers = modules
+      .filter((module) => module.packageImports.includes(specifier))
+      .map((module) => module.id);
+    expect(importers.length, `${specifier} must be used somewhere`).toBeGreaterThan(0);
+    expect(importers.filter((id) => layerOf(id) !== owner)).toEqual([]);
+  });
+});
+
+describe("shared addressing algorithm", () => {
+  it.each(["stableHash", "sourceNodeId", "instanceAddress"])(
+    "defines %s exactly once, in the contract both sides import",
+    (name) => {
+      const definers = modules
+        .filter((module) => module.ownExports.includes(name))
+        .map((module) => module.id);
+      expect(definers).toEqual(["contracts/addressing.ts"]);
+    },
+  );
+
+  it("is imported by both the compile-time and render-time sides", () => {
+    const importsAddressing = (id: string): boolean => {
+      const module = byId.get(id);
+      if (!module) return false;
+      return module.localImports.some((target) =>
+        target === "contracts/addressing.ts" || target === "contracts/index.ts",
+      );
+    };
+    expect(importsAddressing("kernel/semantic-index.ts")).toBe(true);
+    expect(importsAddressing("runtime/address-registry.ts")).toBe(true);
+    expect(importsAddressing("runtime/jsx-dev-runtime.ts")).toBe(true);
+  });
+});

--- a/packages/harness-studio/test/agent-react/observation-bridge.test.ts
+++ b/packages/harness-studio/test/agent-react/observation-bridge.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { OBSERVATION_KINDS, type Digest } from "../../src/agent-react/contracts/index.js";
+import {
+  createObservationBridge,
+  HARNESS_ARTIFACT_OBSERVATION_EVENT,
+} from "../../src/agent-react/host/observation-bridge.js";
+
+const ARTIFACT: Digest = "sha256:artifact";
+const BUILD: Digest = "sha256:build";
+
+describe("ObservationBridge (AR-AC-10)", () => {
+  it("numbers observations with strictly increasing sequences", () => {
+    const bridge = createObservationBridge();
+
+    const first = bridge.record({ kind: "compileDiagnostic" });
+    const second = bridge.record({ kind: "renderCompleted" });
+
+    expect([first.sequence, second.sequence]).toEqual([1, 2]);
+    expect(bridge.recorded().map((event) => event.sequence)).toEqual([1, 2]);
+  });
+
+  it("encodes an observation as a namespaced AG-UI CUSTOM event", () => {
+    const bridge = createObservationBridge();
+    const event = bridge.record({
+      kind: "renderFailed",
+      artifactDigest: ARTIFACT,
+      buildDigest: BUILD,
+      detail: { reason: "component threw" },
+    });
+
+    expect(bridge.encodeHarnessEvent(event)).toEqual({
+      type: "CUSTOM",
+      name: HARNESS_ARTIFACT_OBSERVATION_EVENT,
+      value: {
+        kind: "renderFailed",
+        sequence: 1,
+        artifactDigest: ARTIFACT,
+        buildDigest: BUILD,
+        detail: { reason: "component threw" },
+      },
+    });
+  });
+
+  it("omits digests and detail that were never recorded", () => {
+    const bridge = createObservationBridge();
+    const encoded = bridge.encodeHarnessEvent(bridge.record({ kind: "nodeSelected" }));
+
+    expect(encoded.value).toEqual({ kind: "nodeSelected", sequence: 1 });
+  });
+
+  it("encodes every observation kind the runtime can report", () => {
+    const bridge = createObservationBridge();
+    for (const kind of OBSERVATION_KINDS) bridge.record({ kind, artifactDigest: ARTIFACT });
+
+    const encoded = bridge.drainToAgent();
+
+    expect(encoded).toHaveLength(OBSERVATION_KINDS.length);
+    expect(encoded.every((event) => event.name === HARNESS_ARTIFACT_OBSERVATION_EVENT)).toBe(true);
+    expect(encoded.map((event) => (event.value as { kind: string }).kind)).toEqual([...OBSERVATION_KINDS]);
+  });
+
+  it("owns and deeply freezes each recorded observation", () => {
+    const bridge = createObservationBridge();
+    const detail = { nested: { value: 1 } };
+    const event = bridge.record({ kind: "annotationCreated", detail });
+    detail.nested.value = 2;
+
+    expect(Object.isFrozen(event)).toBe(true);
+    expect(Object.isFrozen(event.detail)).toBe(true);
+    expect(Object.isFrozen(event.detail?.["nested"])).toBe(true);
+    expect(event.detail).toEqual({ nested: { value: 1 } });
+  });
+
+  it("notifies a listener as observations arrive", () => {
+    const seen: number[] = [];
+    const bridge = createObservationBridge({ onRecord: (event) => seen.push(event.sequence) });
+
+    bridge.record({ kind: "actionAttempted" });
+    bridge.record({ kind: "actionDenied" });
+
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it("evicts the oldest observations but keeps sequences increasing", () => {
+    const bridge = createObservationBridge({ maxRetained: 2 });
+
+    bridge.record({ kind: "compileDiagnostic" });
+    bridge.record({ kind: "profileViolation" });
+    bridge.record({ kind: "runtimeException" });
+
+    expect(bridge.recorded().map((event) => event.sequence)).toEqual([2, 3]);
+    expect(bridge.recorded().map((event) => event.kind)).toEqual(["profileViolation", "runtimeException"]);
+  });
+
+  it("delivers live subscriptions even when no observations are retained", () => {
+    const bridge = createObservationBridge({ maxRetained: 0 });
+    const received: number[] = [];
+    const unsubscribe = bridge.subscribe((event) => received.push(event.sequence));
+
+    bridge.record({ kind: "actionAttempted" });
+    unsubscribe();
+    bridge.record({ kind: "actionDenied" });
+
+    expect(received).toEqual([1]);
+    expect(bridge.recorded()).toEqual([]);
+  });
+
+  it("rejects invalid retention bounds instead of looping during record", () => {
+    expect(() => createObservationBridge({ maxRetained: -1 })).toThrow(/non-negative safe integer/);
+    expect(() => createObservationBridge({ maxRetained: 1.5 })).toThrow(/non-negative safe integer/);
+  });
+
+  it("clears retained observations without resetting the sequence", () => {
+    const bridge = createObservationBridge();
+    bridge.record({ kind: "stateValidationFailed" });
+
+    bridge.clear();
+
+    expect(bridge.recorded()).toEqual([]);
+    expect(bridge.record({ kind: "nodeSelected" }).sequence).toBe(2);
+  });
+});

--- a/packages/harness-studio/test/agent-react/oxc-compiler.test.ts
+++ b/packages/harness-studio/test/agent-react/oxc-compiler.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_REACT_PROFILE_VERSION, type CompileModuleOutput, type Diagnostic } from "../../src/agent-react/contracts/index.js";
+import { createOxcCompiler } from "../../src/agent-react/kernel/compiler.js";
+
+const compiler = createOxcCompiler();
+const ALLOWED = ["react", "@studio/agent-react", "@studio/agent-react/jsx-dev-runtime"] as const;
+
+async function compile(text: string, entry = false): Promise<CompileModuleOutput> {
+  return compiler.compileModule({ module: { path: "/view.tsx", text }, entry, allowedPackages: ALLOWED });
+}
+
+function errors(output: CompileModuleOutput): readonly Diagnostic[] {
+  return output.diagnostics.filter((diagnostic) => diagnostic.level === "error");
+}
+
+function codesOf(output: CompileModuleOutput): readonly string[] {
+  return errors(output).map((diagnostic) => diagnostic.code);
+}
+
+const CONFORMING = `import { defineArtifactView, useArtifactState } from "@studio/agent-react";
+
+function Panel() {
+  const [orders] = useArtifactState<readonly string[]>("/orders");
+  return <section className="panel"><span>{orders.length}</span></section>;
+}
+
+export default defineArtifactView({
+  id: "orders.dashboard",
+  state: { "/orders": { schema: "orders", version: 2 } },
+  capabilities: ["orders.refresh", "orders.read", "orders.read"],
+  component: Panel,
+});
+`;
+
+describe("AgentReact Profile (AR-AC-2)", () => {
+  it("reports its Profile version alongside the compiler version", () => {
+    expect(compiler.profileVersion).toBe(AGENT_REACT_PROFILE_VERSION);
+    expect(compiler.compilerVersion).toMatch(/^oxc-/);
+    expect(compiler.policyFingerprint).toContain("maxModuleBytes");
+  });
+
+  it("emits code and no error diagnostics for a conforming module", async () => {
+    const output = await compile(CONFORMING, true);
+
+    expect(errors(output)).toEqual([]);
+    expect(typeof output.code).toBe("string");
+    expect(output.sourceMap).toBeTypeOf("string");
+  });
+
+  it.each([
+    ["profile/commonjs", 'const fs = require("node:fs");'],
+    ["profile/commonjs", "module.exports = Panel;"],
+    ["profile/commonjs", "exports.Panel = Panel;"],
+    ["profile/node-builtin", 'import { readFile } from "node:fs/promises";'],
+    ["profile/node-builtin", 'import path from "path";'],
+    ["profile/dynamic-import", 'const later = () => import("./panel.js");'],
+    ["profile/package-not-allowed", 'import lodash from "lodash";'],
+    ["profile/react-dom-root", "const mount = (node) => createRoot(node).render(null);"],
+    ["profile/react-dom-root", "const mount = (node) => ReactDOM.render(null, node);"],
+    ["profile/dynamic-eval", 'const run = () => eval("1");'],
+    ["profile/dynamic-eval", 'const run = () => new Function("return 1");'],
+    ["profile/worker", 'const spawn = () => new Worker("worker.js");'],
+    ["profile/worker", "const sw = () => navigator.serviceWorker;"],
+    ["profile/network", 'const load = () => fetch("/api/orders");'],
+    ["profile/network", 'const live = () => new WebSocket("wss://example.test");'],
+    ["profile/network", 'const beacon = () => navigator.sendBeacon("/x");'],
+    ["profile/class-component", "class Panel extends React.Component {}"],
+    ["profile/top-level-effect", 'console.log("boot");'],
+    ["profile/top-level-effect", "for (let index = 0; index < 3; index += 1) {}"],
+    ["profile/top-level-effect", "if (globalThis.debug) {}"],
+  ])("refuses %s and emits no code", async (code, snippet) => {
+    const output = await compile(`${CONFORMING}\n${snippet}\n`, true);
+
+    expect(codesOf(output)).toContain(code);
+    expect(output.code).toBeUndefined();
+  });
+
+  it("locates a refusal at the offending line and column", async () => {
+    const output = await compile('import lodash from "lodash";\n', false);
+    const [diagnostic] = errors(output);
+
+    expect(diagnostic?.code).toBe("profile/package-not-allowed");
+    expect(diagnostic?.module).toBe("/view.tsx");
+    expect(diagnostic?.line).toBe(1);
+    expect(diagnostic?.column).toBeGreaterThan(1);
+  });
+
+  it("accepts a module directive and internal relative imports", async () => {
+    const output = await compile(`"use client";\nimport { StatRow } from "./stat-row.js";\nexport const Row = StatRow;\n`);
+
+    expect(errors(output)).toEqual([]);
+  });
+
+  it("reports a syntax error instead of a Profile refusal", async () => {
+    const output = await compile("export default function ( {\n");
+
+    expect(codesOf(output)).toEqual(["syntax/parse-failed"]);
+    expect(output.code).toBeUndefined();
+  });
+
+  it("enforces the per-module byte budget", async () => {
+    const small = createOxcCompiler({ maxModuleBytes: 16 });
+    const output = await small.compileModule({
+      module: { path: "/view.tsx", text: CONFORMING },
+      entry: true,
+      allowedPackages: ALLOWED,
+    });
+
+    expect(codesOf(output)).toEqual(["limit/module-bytes"]);
+  });
+});
+
+describe("Artifact View ABI (AR-AC-3)", () => {
+  it("extracts the declaration exactly as written, sorted and deduplicated", async () => {
+    const output = await compile(CONFORMING, true);
+
+    expect(output.viewDeclaration).toEqual({
+      id: "orders.dashboard",
+      state: [{ path: "/orders", schema: "orders", version: 2 }],
+      capabilities: ["orders.read", "orders.refresh"],
+      componentName: "Panel",
+      module: "/view.tsx",
+    });
+  });
+
+  it("does not extract a declaration from a non-entry module", async () => {
+    const output = await compile(CONFORMING, false);
+
+    expect(output.viewDeclaration).toBeUndefined();
+  });
+
+  it("reports a missing view when the entry has no defineArtifactView default export", async () => {
+    const output = await compile("export const Panel = () => <div />;\n", true);
+
+    expect(codesOf(output)).toEqual(["abi/missing-view"]);
+  });
+
+  it("reports a missing view when defineArtifactView is not the runtime import", async () => {
+    const source = `const defineArtifactView = (input) => input;
+const Panel = () => <div />;
+export default defineArtifactView({ id: "x", component: Panel });
+`;
+    const output = await compile(source, true);
+
+    expect(codesOf(output)).toContain("abi/missing-view");
+  });
+
+  it.each([
+    ["a computed id", 'id: ["orders", "dashboard"].join(".")'],
+    ["a spread definition", "...base"],
+    ["a mapped capability list", 'capabilities: ["a"].map((value) => value)'],
+    ["a non-literal state version", 'state: { "/orders": { schema: "orders", version: VERSION } }'],
+    ["a spread state descriptor", 'state: { "/orders": { ...base, schema: "orders", version: 1 } }'],
+    ["an extra state descriptor field", 'state: { "/orders": { schema: "orders", version: 1, optional: true } }'],
+    ["a relative state key", 'state: { "orders": { schema: "orders", version: 1 } }'],
+    ["an inline component expression", "component: () => <div />"],
+  ])("refuses %s as not static", async (_label, field) => {
+    const source = `import { defineArtifactView } from "@studio/agent-react";
+const VERSION = 2;
+const base = { id: "x" };
+const Panel = () => <div />;
+export default defineArtifactView({
+  id: "orders.dashboard",
+  component: Panel,
+  ${field},
+});
+`;
+    const output = await compile(source, true);
+
+    expect(codesOf(output)).toContain("abi/not-static");
+    expect(output.viewDeclaration).toBeUndefined();
+  });
+
+  it("refuses a duplicated state path", async () => {
+    const source = `import { defineArtifactView } from "@studio/agent-react";
+const Panel = () => <div />;
+export default defineArtifactView({
+  id: "orders.dashboard",
+  state: { "/orders": { schema: "orders", version: 1 }, "/orders": { schema: "orders", version: 2 } },
+  component: Panel,
+});
+`;
+    const output = await compile(source, true);
+
+    expect(codesOf(output)).toContain("abi/duplicate-state-path");
+  });
+
+  it("accepts a component imported from another Revision module", async () => {
+    const source = `import { defineArtifactView } from "@studio/agent-react";
+import { Panel } from "./panel.js";
+export default defineArtifactView({ id: "orders.dashboard", component: Panel });
+`;
+    const output = await compile(source, true);
+
+    expect(output.viewDeclaration?.componentName).toBe("Panel");
+    expect(errors(output)).toEqual([]);
+  });
+
+  it("rejects a component binding imported from a trusted package", async () => {
+    const source = `import { useState as Panel } from "react";
+import { defineArtifactView } from "@studio/agent-react";
+export default defineArtifactView({ id: "orders.dashboard", component: Panel });
+`;
+
+    const output = await compile(source, true);
+
+    expect(codesOf(output)).toContain("abi/not-static");
+    expect(output.viewDeclaration).toBeUndefined();
+  });
+});
+
+describe("React semantic index", () => {
+  it("indexes components, JSX structure, and hook references", async () => {
+    const output = await compile(CONFORMING, true);
+    const index = output.semanticIndex;
+
+    expect(index?.components).toEqual([{ name: "Panel", exported: false, line: 3 }]);
+    expect(index?.imports).toEqual(["@studio/agent-react"]);
+    expect(index?.exports).toEqual(["default"]);
+    expect(index?.stateReferences).toEqual(["/orders"]);
+    expect(index?.jsxNodes.map((node) => node.elementType)).toEqual(["section", "span"]);
+    expect(index?.jsxNodes[0]).toMatchObject({ intrinsic: true, structurePath: [], staticAttributes: ["className"] });
+    expect(index?.jsxNodes[1]?.structurePath).toEqual(["section"]);
+  });
+
+  it("indexes named and wildcard re-export sources as module dependencies", async () => {
+    const output = await compile([
+      'export { Panel } from "./panel.js";',
+      'export * from "./shared.js";',
+    ].join("\n"));
+
+    expect(errors(output)).toEqual([]);
+    expect(output.semanticIndex?.imports).toEqual(["./panel.js", "./shared.js"]);
+  });
+
+  it("gives two elements of the same type on different lines different source node ids", async () => {
+    const source = `const Panel = () => (
+  <div>
+    <span>a</span>
+    <span>b</span>
+  </div>
+);
+export const Row = Panel;
+`;
+    const index = (await compile(source)).semanticIndex;
+    const spans = index?.jsxNodes.filter((node) => node.elementType === "span") ?? [];
+
+    expect(spans).toHaveLength(2);
+    expect(spans[0]?.sourceNodeId).not.toBe(spans[1]?.sourceNodeId);
+  });
+});

--- a/packages/harness-studio/test/agent-react/pipeline-fixture.ts
+++ b/packages/harness-studio/test/agent-react/pipeline-fixture.ts
@@ -1,0 +1,110 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { ArtifactRevision, BuildSnapshot, ModuleSource } from "../../src/agent-react/contracts/index.js";
+import { AgentStreamAssembler } from "../../src/agent-react/host/stream-assembler.js";
+import type { ArtifactBundleModule } from "../../src/agent-react/host/frames/local-frame-factory.js";
+import type { TrustedRuntimePackage } from "../../src/agent-react/linker/allowed-packages.js";
+import { digestParts } from "../../src/agent-react/host/digest.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+/** Bundles land inside the package so relative Bootstrap specifiers still resolve. */
+export const BUNDLE_DIRECTORY = join(here, "..", ".artifacts");
+
+/**
+ * The Trusted Bootstrap for tests.
+ *
+ * The externals are relative specifiers from `test/.artifacts/`, which is the
+ * whole reason bundles are written there: the linked bundle imports the same
+ * `react` and the same runtime modules the Host uses, exactly as a browser build
+ * would import a versioned Bootstrap URL.
+ */
+export const TEST_RUNTIME_PACKAGES: readonly TrustedRuntimePackage[] = Object.freeze([
+  { specifier: "react", external: "react" },
+  { specifier: "@studio/agent-react", external: "../../src/agent-react/runtime/index.js" },
+  { specifier: "@studio/agent-react/jsx-dev-runtime", external: "../../src/agent-react/runtime/jsx-dev-runtime.js" },
+]);
+
+export function revisionOf(id: string, entry: string, modules: readonly ModuleSource[]): ArtifactRevision {
+  const assembler = new AgentStreamAssembler({ id, entry });
+  for (const module of modules) {
+    assembler.applyModulePatch({ path: module.path, text: module.text, mode: "replace" });
+    assembler.sealModule(module.path);
+  }
+  return assembler.commitArtifactRevision();
+}
+
+export async function writeBundle(snapshot: BuildSnapshot): Promise<string> {
+  await mkdir(BUNDLE_DIRECTORY, { recursive: true });
+  // Distinct file per bundle text so a second build of the same Revision is not
+  // served from the module cache of the first.
+  const name = `${digestParts([snapshot.buildDigest, snapshot.bundle]).slice(7, 23)}.mjs`;
+  const path = join(BUNDLE_DIRECTORY, name);
+  await writeFile(path, snapshot.bundle, "utf8");
+  return path;
+}
+
+export async function loadBundle(snapshot: BuildSnapshot): Promise<ArtifactBundleModule> {
+  const path = await writeBundle(snapshot);
+  return (await import(pathToFileURL(path).href)) as ArtifactBundleModule;
+}
+
+export const ORDERS_VIEW_MODULE: ModuleSource = {
+  path: "/view.tsx",
+  text: `import { defineArtifactView, useArtifactAction, useArtifactState } from "@studio/agent-react";
+import { StatRow } from "./stat-row.js";
+
+interface Order {
+  readonly id: string;
+}
+
+function OrderDashboard() {
+  const [orders, setOrders] = useArtifactState<readonly Order[]>("/orders");
+  const refresh = useArtifactAction("orders.refresh");
+  const onRefresh = () => {
+    setOrders(orders);
+    void refresh({ reason: "user" });
+  };
+  return (
+    <section className="dashboard">
+      <h1>Orders</h1>
+      <StatRow label="count" value={orders.length} />
+      <button type="button" onClick={onRefresh}>Refresh</button>
+    </section>
+  );
+}
+
+export default defineArtifactView({
+  id: "orders.dashboard",
+  state: { "/orders": { schema: "orders", version: 2 } },
+  capabilities: ["orders.read", "orders.refresh"],
+  component: OrderDashboard,
+});
+`,
+};
+
+export const STAT_ROW_MODULE: ModuleSource = {
+  path: "/stat-row.tsx",
+  text: `interface StatRowProps {
+  readonly label: string;
+  readonly value: number;
+}
+
+export function StatRow({ label, value }: StatRowProps) {
+  return (
+    <div className="stat">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+`,
+};
+
+export const ORDERS_STATE_SCHEMA = {
+  name: "orders",
+  version: 2,
+  initial: [] as readonly unknown[],
+  validate: (value: unknown): true | string =>
+    Array.isArray(value) ? true : "Orders state must be an array.",
+};

--- a/packages/harness-studio/test/agent-react/runtime-addressing.test.ts
+++ b/packages/harness-studio/test/agent-react/runtime-addressing.test.ts
@@ -1,0 +1,377 @@
+import { rm } from "node:fs/promises";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createBuildCoordinator } from "../../src/agent-react/host/build-coordinator.js";
+import type { ArtifactRevision, BuildSnapshot } from "../../src/agent-react/contracts/index.js";
+import { AgentStreamAssembler } from "../../src/agent-react/host/stream-assembler.js";
+import { createSandboxFrameController } from "../../src/agent-react/host/frames/frame-controller.js";
+import {
+  createLocalFrameFactory,
+  type ArtifactBundleModule,
+  type LocalFrameHandle,
+} from "../../src/agent-react/host/frames/local-frame-factory.js";
+import { createActionGateway } from "../../src/agent-react/host/action-gateway.js";
+import { createCapabilityBroker, createCapabilityPolicy } from "../../src/agent-react/host/capability.js";
+import { createObservationBridge } from "../../src/agent-react/host/observation-bridge.js";
+import { createArtifactStateStore } from "../../src/agent-react/host/state-store.js";
+import { createOxcCompiler } from "../../src/agent-react/kernel/compiler.js";
+import { ARTIFACT_NODE_ATTRIBUTE, instanceAddress } from "../../src/agent-react/contracts/addressing.js";
+import { activeArtifactRuntime } from "../../src/agent-react/runtime/index.js";
+import {
+  BUNDLE_DIRECTORY,
+  loadBundle,
+  ORDERS_STATE_SCHEMA,
+  ORDERS_VIEW_MODULE,
+  revisionOf,
+  STAT_ROW_MODULE,
+  TEST_RUNTIME_PACKAGES,
+} from "./pipeline-fixture.js";
+
+afterAll(async () => {
+  await rm(BUNDLE_DIRECTORY, { recursive: true, force: true });
+});
+
+async function buildOrders(revision: ArtifactRevision): Promise<BuildSnapshot> {
+  const snapshot = await createBuildCoordinator({
+    compiler: createOxcCompiler(),
+    runtimePackages: TEST_RUNTIME_PACKAGES,
+  }).build(revision);
+  expect(snapshot.status).toBe("ready");
+  return snapshot;
+}
+
+/** Verification Host wiring: the synchronous render proves linked address agreement. */
+async function mountOrders(revision: ArtifactRevision, seedOrders?: readonly unknown[]) {
+  const snapshot = await buildOrders(revision);
+  const observations = createObservationBridge();
+  const policy = createCapabilityPolicy({ allowedCapabilities: ["orders.read", "orders.refresh"] });
+  const broker = createCapabilityBroker({ policy });
+  const state = createArtifactStateStore({
+    declarations: snapshot.viewDeclaration!.state,
+    schemas: [ORDERS_STATE_SCHEMA],
+    observations,
+  });
+  if (seedOrders !== undefined) expect(state.set("/orders", seedOrders)).toEqual({ ok: true });
+  const gateway = createActionGateway({ broker, policy, observations, artifactDigest: snapshot.artifactDigest });
+  const controller = createSandboxFrameController({
+    frames: createLocalFrameFactory({ loadBundle, state, gateway, observations, renderToMarkup: renderToStaticMarkup }),
+    broker,
+    observations,
+    state,
+    allowInProcessVerification: true,
+  });
+
+  const staged = await controller.stage(snapshot);
+  if (staged.status !== "staged") throw new Error(`staging failed: ${staged.reason}`);
+  return { snapshot, controller, frame: staged.frame as LocalFrameHandle, observations, gateway, state, broker };
+}
+
+function addressesIn(markup: string): readonly string[] {
+  return [...markup.matchAll(new RegExp(`${ARTIFACT_NODE_ATTRIBUTE}="([0-9a-f]+)"`, "g"))].map((match) => match[1]!);
+}
+
+const ordersRevision = () => revisionOf("orders.dashboard", "/view.tsx", [ORDERS_VIEW_MODULE, STAT_ROW_MODULE]);
+
+function streamedOrdersRevision(viewText: string): ArtifactRevision {
+  const assembler = new AgentStreamAssembler({ id: "orders.dashboard", entry: "/view.tsx" });
+  for (const module of [{ ...ORDERS_VIEW_MODULE, text: viewText }, STAT_ROW_MODULE]) {
+    for (let offset = 0; offset < module.text.length; offset += 97) {
+      assembler.applyModulePatch({ path: module.path, text: module.text.slice(offset, offset + 97) });
+    }
+    assembler.sealModule(module.path);
+  }
+  return assembler.commitArtifactRevision();
+}
+
+describe("AgentReact end-to-end addressing (AR-AC-5)", () => {
+  it("executes the linked bundle and renders the declared component", async () => {
+    const { snapshot, frame } = await mountOrders(ordersRevision());
+    const markup = frame.markup()!;
+
+    expect(snapshot.viewDeclaration?.id).toBe("orders.dashboard");
+    expect(markup).toContain("<h1");
+    expect(markup).toContain("Orders");
+    expect(markup).toContain("Refresh");
+  });
+
+  it("resolves every stamped DOM address back to its source span", async () => {
+    const { frame } = await mountOrders(ordersRevision());
+    const spans = addressesIn(frame.markup()!).map((address) => frame.registry.resolveSourceSpan(address));
+
+    expect(spans.every((span) => span !== undefined)).toBe(true);
+    expect(spans.map((span) => span!.elementType)).toEqual(
+      expect.arrayContaining(["section", "h1", "button", "div", "span", "strong"]),
+    );
+    for (const span of spans) {
+      expect(["/view.tsx", "/stat-row.tsx"]).toContain(span!.modulePath);
+      expect(span!.line).toBeGreaterThan(0);
+      expect(span!.column).toBeGreaterThan(0);
+    }
+  });
+
+  it("addresses the outer section at the span the compiler indexed", async () => {
+    const { snapshot, frame } = await mountOrders(ordersRevision());
+    const viewIndex = snapshot.semanticIndex.find((index) => index.module === "/view.tsx")!;
+    const section = viewIndex.jsxNodes.find((node) => node.elementType === "section")!;
+
+    const expected = instanceAddress({
+      artifactDigest: snapshot.artifactDigest,
+      sourceNodeId: section.sourceNodeId,
+      key: null,
+    });
+
+    expect(addressesIn(frame.markup()!)).toContain(expected);
+    expect(frame.registry.resolveSourceSpan(expected)).toEqual({
+      modulePath: "/view.tsx",
+      line: section.line,
+      column: section.column,
+      elementType: "section",
+    });
+  });
+
+  it("finds the addressed element in a DOM subtree and misses an unknown address", async () => {
+    const { frame } = await mountOrders(ordersRevision());
+    const [first] = addressesIn(frame.markup()!);
+    const queried: string[] = [];
+    const root = {
+      querySelector(selectors: string) {
+        queried.push(selectors);
+        return { selectors };
+      },
+    };
+
+    expect(frame.registry.resolveDomNode(root, first!)).toEqual({
+      selectors: `[${ARTIFACT_NODE_ATTRIBUTE}="${first}"]`,
+    });
+    expect(frame.registry.resolveDomNode(root, "deadbeefdeadbeef")).toBeNull();
+    expect(queried).toHaveLength(1);
+  });
+
+  it("keeps source node ids stable when the same Revision is rebuilt", async () => {
+    const revision = ordersRevision();
+    const first = await mountOrders(revision);
+    const second = await mountOrders(revision);
+
+    expect(addressesIn(second.frame.markup()!)).toEqual(addressesIn(first.frame.markup()!));
+  });
+
+  it("moves the addresses of a component whose source shifts", async () => {
+    const original = await mountOrders(ordersRevision());
+    const shifted = await mountOrders(revisionOf("orders.dashboard", "/view.tsx", [
+      { ...ORDERS_VIEW_MODULE, text: `// a new leading comment\n${ORDERS_VIEW_MODULE.text}` },
+      STAT_ROW_MODULE,
+    ]));
+
+    const before = new Set(addressesIn(original.frame.markup()!));
+    const after = addressesIn(shifted.frame.markup()!);
+    const viewAddresses = after.filter((address) => {
+      const span = shifted.frame.registry.resolveSourceSpan(address);
+      return span?.modulePath === "/view.tsx";
+    });
+
+    expect(viewAddresses.length).toBeGreaterThan(0);
+    expect(viewAddresses.every((address) => !before.has(address))).toBe(true);
+  });
+
+  it("does not pass the reserved node prop to a component that has not opted in", async () => {
+    const { frame } = await mountOrders(ordersRevision());
+
+    expect(frame.markup()).not.toContain("artifactNode");
+  });
+
+  it("reads staged Artifact state through the runtime hook", async () => {
+    const empty = await mountOrders(ordersRevision());
+    const seeded = await mountOrders(ordersRevision(), [{ id: "a" }, { id: "b" }]);
+
+    // The StatRow renders `orders.length` from the frozen snapshot the staging
+    // frame was handed, so the count follows Host state and not a local default.
+    expect(empty.frame.markup()).toMatch(/<strong[^>]*>0<\/strong>/);
+    expect(seeded.frame.markup()).toMatch(/<strong[^>]*>2<\/strong>/);
+    expect(seeded.state.get("/orders")).toEqual([{ id: "a" }, { id: "b" }]);
+  });
+
+  it("records a staging renderCompleted observation for the committed build", async () => {
+    const { snapshot, observations } = await mountOrders(ordersRevision());
+    const completed = observations.recorded().filter((event) => event.kind === "renderCompleted");
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      buildDigest: snapshot.buildDigest,
+      artifactDigest: snapshot.artifactDigest,
+      detail: { phase: "staging" },
+    });
+  });
+
+  it("does not let an outgoing bundle clear a newer bundle's runtime bridge", async () => {
+    const first = await mountOrders(ordersRevision());
+    const shifted = await mountOrders(revisionOf("orders.dashboard", "/view.tsx", [
+      { ...ORDERS_VIEW_MODULE, text: `// shifted build\n${ORDERS_VIEW_MODULE.text}` },
+      STAT_ROW_MODULE,
+    ]));
+    expect(activeArtifactRuntime()?.buildDigest).toBe(shifted.snapshot.buildDigest);
+
+    first.frame.dispose();
+
+    expect(activeArtifactRuntime()?.buildDigest).toBe(shifted.snapshot.buildDigest);
+    shifted.frame.dispose();
+    expect(activeArtifactRuntime()).toBeUndefined();
+  });
+
+  it("aborts a timed-out loader before a late bundle can activate", async () => {
+    const snapshot = await buildOrders(ordersRevision());
+    const observations = createObservationBridge();
+    const policy = createCapabilityPolicy({ allowedCapabilities: ["orders.read", "orders.refresh"] });
+    const broker = createCapabilityBroker({ policy });
+    const state = createArtifactStateStore({
+      declarations: snapshot.viewDeclaration!.state,
+      schemas: [ORDERS_STATE_SCHEMA],
+      observations,
+    });
+    const gateway = createActionGateway({ broker, policy, observations });
+    let resolveBundle!: (bundle: ArtifactBundleModule) => void;
+    let loaderSignal: AbortSignal | undefined;
+    let activations = 0;
+    const factory = createLocalFrameFactory({
+      loadBundle: (_build, signal) => {
+        loaderSignal = signal;
+        return new Promise((resolve) => {
+          resolveBundle = resolve;
+        });
+      },
+      state,
+      gateway,
+      observations,
+      renderToMarkup: renderToStaticMarkup,
+    });
+    const grant = broker.computeGrant(snapshot.viewDeclaration!);
+    const token = broker.issueFrameToken(snapshot.buildDigest, "dry-run", grant);
+    const frame = factory.create(snapshot, {
+      actionMode: "dry-run",
+      frameToken: token,
+      state: state.snapshot(),
+    });
+    await frame.mount();
+
+    expect(await frame.waitForRenderCompleted(1)).toEqual({ status: "timedOut" });
+    frame.dispose();
+    expect(loaderSignal?.aborted).toBe(true);
+    resolveBundle({
+      view: { id: "late", component: () => null },
+      activateArtifactRuntime() {
+        activations += 1;
+        return { component: () => null };
+      },
+      deactivateArtifactRuntime() {},
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(activations).toBe(0);
+    expect(frame.markup()).toBeUndefined();
+  });
+});
+
+describe("AgentReact original POC end-to-end flow (AR-AC-1, AR-AC-4, AR-AC-5, AR-AC-7..10)", () => {
+  it("streams, builds, commits, acts, preserves Current on failure, and rolls back", async () => {
+    const observations = createObservationBridge();
+    const coordinator = createBuildCoordinator({
+      compiler: createOxcCompiler(),
+      runtimePackages: TEST_RUNTIME_PACKAGES,
+      onObservation: (observation) => observations.record(observation),
+    });
+    const firstSnapshot = await coordinator.build(streamedOrdersRevision(ORDERS_VIEW_MODULE.text));
+    expect(firstSnapshot).toMatchObject({ status: "ready", artifactId: "orders.dashboard" });
+    expect(firstSnapshot.bundle.length).toBeGreaterThan(0);
+
+    const policy = createCapabilityPolicy({
+      allowedCapabilities: ["orders.read", "orders.refresh"],
+      requiresApproval: ["orders.refresh"],
+    });
+    const broker = createCapabilityBroker({ policy, approvals: ["orders.refresh"] });
+    const state = createArtifactStateStore({
+      declarations: firstSnapshot.viewDeclaration!.state,
+      schemas: [ORDERS_STATE_SCHEMA],
+      observations,
+    });
+    const refresh = vi.fn(async (payload: unknown) => ({ accepted: payload }));
+    const gateway = createActionGateway({
+      broker,
+      policy,
+      observations,
+      artifactDigest: firstSnapshot.artifactDigest,
+      handlers: { "orders.refresh": refresh },
+    });
+    const controller = createSandboxFrameController({
+      frames: createLocalFrameFactory({ loadBundle, state, gateway, observations, renderToMarkup: renderToStaticMarkup }),
+      broker,
+      observations,
+      state,
+      allowInProcessVerification: true,
+    });
+
+    const firstStage = await controller.stage(firstSnapshot);
+    expect(firstStage.status).toBe("staged");
+    if (firstStage.status !== "staged") throw new Error(firstStage.reason);
+    const firstFrame = firstStage.frame as LocalFrameHandle;
+    expect(firstFrame.markup()).toMatch(/Orders[\s\S]*<strong[^>]*>0<\/strong>/);
+    expect(activeArtifactRuntime()?.actionMode).toBe("dry-run");
+    await expect(activeArtifactRuntime()!.dispatchAction("orders.refresh", { phase: "staging" }))
+      .resolves.toEqual({ status: "dry-run" });
+    expect(refresh).not.toHaveBeenCalled();
+
+    controller.activate();
+    const liveRuntime = activeArtifactRuntime();
+    expect(liveRuntime?.actionMode).toBe("live");
+    liveRuntime!.setState("/orders", [{ id: "a" }, { id: "b" }]);
+    expect(state.get("/orders")).toEqual([{ id: "a" }, { id: "b" }]);
+    await expect(liveRuntime!.dispatchAction("orders.refresh", { phase: "live" })).resolves.toEqual({
+      status: "completed",
+      result: { accepted: { phase: "live" } },
+    });
+    expect(refresh).toHaveBeenCalledOnce();
+
+    const brokenText = ORDERS_VIEW_MODULE.text.replace(
+      "function OrderDashboard() {",
+      'function OrderDashboard() {\n  throw new Error("e2e render failure");',
+    );
+    const brokenSnapshot = await coordinator.build(streamedOrdersRevision(brokenText));
+    expect(brokenSnapshot.status).toBe("ready");
+    const rejected = await controller.stage(brokenSnapshot);
+    expect(rejected).toMatchObject({ status: "rejected", reason: "e2e render failure" });
+    expect(controller.current).toBe(firstFrame);
+    expect(firstFrame.disposed).toBe(false);
+
+    const secondText = ORDERS_VIEW_MODULE.text.replace("<h1>Orders</h1>", "<h1>Orders v2</h1>");
+    const secondSnapshot = await coordinator.build(streamedOrdersRevision(secondText));
+    const secondStage = await controller.stage(secondSnapshot);
+    expect(secondStage.status).toBe("staged");
+    if (secondStage.status !== "staged") throw new Error(secondStage.reason);
+    expect((secondStage.frame as LocalFrameHandle).markup()).toContain("Orders v2");
+    controller.activate();
+    expect(controller.current?.snapshot.buildDigest).toBe(secondSnapshot.buildDigest);
+    expect(firstFrame.disposed).toBe(true);
+
+    const rolledBack = await controller.rollback();
+    expect(rolledBack.status).toBe("staged");
+    expect(controller.current?.snapshot.buildDigest).toBe(firstSnapshot.buildDigest);
+    expect((controller.current as LocalFrameHandle).markup()).toContain("Orders</h1>");
+
+    const events = observations.recorded();
+    expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1));
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "actionAttempted", detail: expect.objectContaining({ actionMode: "dry-run" }) }),
+      expect.objectContaining({ kind: "actionAttempted", detail: expect.objectContaining({ actionMode: "live" }) }),
+      expect.objectContaining({ kind: "runtimeException", buildDigest: brokenSnapshot.buildDigest }),
+      expect.objectContaining({ kind: "renderFailed", buildDigest: brokenSnapshot.buildDigest }),
+      expect.objectContaining({ kind: "renderCompleted", detail: expect.objectContaining({ phase: "rolled-back" }) }),
+    ]));
+    expect(observations.drainToAgent()).toEqual(events.map((event) => expect.objectContaining({
+      type: "CUSTOM",
+      name: "harness.artifact-observation",
+      value: expect.objectContaining({ kind: event.kind, sequence: event.sequence }),
+    })));
+
+    broker.revokeFrameToken(controller.current!.frameToken.token);
+    controller.current!.dispose();
+    expect(activeArtifactRuntime()).toBeUndefined();
+  });
+});

--- a/packages/harness-studio/test/agent-react/state-store.test.ts
+++ b/packages/harness-studio/test/agent-react/state-store.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { createObservationBridge } from "../../src/agent-react/host/observation-bridge.js";
+import { createArtifactStateStore, type StateSchema } from "../../src/agent-react/host/state-store.js";
+
+const ordersV1: StateSchema = {
+  name: "orders",
+  version: 1,
+  initial: { items: [] as unknown[] },
+  validate: (value) => (isRecord(value) && Array.isArray(value.items) ? true : "Orders v1 needs an items array."),
+};
+
+const ordersV2: StateSchema = {
+  name: "orders",
+  version: 2,
+  initial: { rows: [] as unknown[], total: 0 },
+  validate: (value) =>
+    isRecord(value) && Array.isArray(value.rows) && typeof value.total === "number"
+      ? true
+      : "Orders v2 needs rows and a numeric total.",
+  migrate: (value) => {
+    const items = isRecord(value) && Array.isArray(value.items) ? value.items : [];
+    return { rows: items, total: items.length };
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function store(version = 1) {
+  const observations = createObservationBridge();
+  const state = createArtifactStateStore({
+    declarations: [{ path: "/orders", schema: "orders", version }],
+    schemas: [ordersV1, ordersV2],
+    observations,
+  });
+  return { state, observations };
+}
+
+describe("ArtifactStateStore (AR-AC-8)", () => {
+  it("initializes every declared path from its bound schema", () => {
+    const { state } = store();
+
+    expect(state.get("/orders")).toEqual({ items: [] });
+    expect(state.declaredSchema("/orders")?.version).toBe(1);
+  });
+
+  it("refuses to bind a schema the Host does not provide", () => {
+    expect(() => createArtifactStateStore({
+      declarations: [{ path: "/orders", schema: "orders", version: 9 }],
+      schemas: [ordersV1],
+    })).toThrow(/does not provide/);
+  });
+
+  it("returns a frozen snapshot that later writes do not mutate", () => {
+    const { state } = store();
+    const before = state.snapshot();
+
+    expect(Object.isFrozen(before)).toBe(true);
+    expect(state.set("/orders", { items: [1, 2] })).toEqual({ ok: true });
+    expect(before["/orders"]).toEqual({ items: [] });
+    expect(state.snapshot()["/orders"]).toEqual({ items: [1, 2] });
+  });
+
+  it("freezes nested values so a staging frame cannot mutate what it reads", () => {
+    const { state } = store();
+    state.set("/orders", { items: [{ id: "a" }] });
+
+    const value = state.get("/orders") as { items: { id: string }[] };
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.items)).toBe(true);
+    expect(Object.isFrozen(value.items[0])).toBe(true);
+  });
+
+  it("takes an owned copy even when the caller shallow-freezes the outer value", () => {
+    const { state } = store();
+    const source = Object.freeze({ items: [{ id: "a" }] });
+
+    expect(state.set("/orders", source)).toEqual({ ok: true });
+    source.items[0]!.id = "mutated";
+
+    expect(state.get("/orders")).toEqual({ items: [{ id: "a" }] });
+    expect(state.get("/orders")).not.toBe(source);
+  });
+
+  it("rejects state shapes that cannot stay immutable across a frame boundary", () => {
+    const { state, observations } = store();
+    const cyclic: { items: unknown[] } = { items: [] };
+    cyclic.items.push(cyclic);
+
+    const cycle = state.set("/orders", cyclic);
+    const exotic = state.set("/orders", { items: [], generatedAt: new Date() });
+
+    expect(cycle).toMatchObject({ ok: false });
+    expect(exotic).toMatchObject({ ok: false });
+    expect(state.get("/orders")).toEqual({ items: [] });
+    expect(observations.recorded().map((event) => event.kind)).toEqual([
+      "stateValidationFailed",
+      "stateValidationFailed",
+    ]);
+  });
+
+  it("rejects an invalid write, keeps the previous value, and observes the failure", () => {
+    const { state, observations } = store();
+    state.set("/orders", { items: [1] });
+
+    const result = state.set("/orders", { items: "not-an-array" });
+
+    expect(result).toEqual({ ok: false, reason: "Orders v1 needs an items array." });
+    expect(state.get("/orders")).toEqual({ items: [1] });
+    expect(observations.recorded()).toEqual([{
+      kind: "stateValidationFailed",
+      sequence: 1,
+      detail: { path: "/orders", schema: "orders", version: 1, reason: "Orders v1 needs an items array." },
+    }]);
+  });
+
+  it("rejects a write to an undeclared path", () => {
+    const { state } = store();
+
+    expect(state.set("/unknown", 1)).toEqual({
+      ok: false,
+      reason: "State path '/unknown' is not declared by this Artifact View.",
+    });
+  });
+
+  it("notifies only the subscribers of the written path", () => {
+    const { state } = store();
+    const listener = vi.fn();
+    const unsubscribe = state.subscribe("/orders", listener);
+
+    state.set("/orders", { items: [1] });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    state.set("/orders", { items: [1, 2] });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("migrates a path forward and notifies subscribers", () => {
+    const { state } = store();
+    state.set("/orders", { items: [{ id: "a" }, { id: "b" }] });
+    const listener = vi.fn();
+    state.subscribe("/orders", listener);
+
+    expect(state.migrate("/orders", ordersV2)).toEqual({ ok: true });
+    expect(state.get("/orders")).toEqual({ rows: [{ id: "a" }, { id: "b" }], total: 2 });
+    expect(state.declaredSchema("/orders")?.version).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a migration that changes schema name or moves backwards", () => {
+    const { state } = store(2);
+
+    expect(state.migrate("/orders", ordersV1)).toEqual({
+      ok: false,
+      reason: "State path '/orders' is already at version 2.",
+    });
+    expect(state.migrate("/orders", { ...ordersV1, name: "invoices", version: 3 })).toEqual({
+      ok: false,
+      reason: "State path '/orders' cannot change schema from 'orders' to 'invoices'.",
+    });
+  });
+
+  it("refuses a migration whose result fails the new schema", () => {
+    const { state, observations } = store();
+    const broken: StateSchema = { ...ordersV2, migrate: () => ({ rows: "no" }) };
+
+    expect(state.migrate("/orders", broken)).toEqual({
+      ok: false,
+      reason: "Orders v2 needs rows and a numeric total.",
+    });
+    expect(state.get("/orders")).toEqual({ items: [] });
+    expect(observations.recorded().map((event) => event.kind)).toEqual(["stateValidationFailed"]);
+  });
+});

--- a/packages/harness-studio/test/agent-react/stream-assembler.test.ts
+++ b/packages/harness-studio/test/agent-react/stream-assembler.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { AgentStreamAssembler } from "../../src/agent-react/host/stream-assembler.js";
+
+const ENTRY = "/view.tsx";
+const descriptor = { id: "orders.dashboard", entry: ENTRY };
+
+function sealedAssembler(modules: readonly [string, string][]): AgentStreamAssembler {
+  const assembler = new AgentStreamAssembler(descriptor);
+  for (const [path, text] of modules) {
+    assembler.applyModulePatch({ path, text, mode: "replace" });
+    assembler.sealModule(path);
+  }
+  return assembler;
+}
+
+describe("AgentStreamAssembler (AR-AC-1)", () => {
+  it("assembles streamed patches into the sealed module text", () => {
+    const assembler = new AgentStreamAssembler(descriptor);
+    assembler.applyModulePatch({ path: ENTRY, text: "export default " });
+    assembler.applyModulePatch({ path: ENTRY, text: "view;" });
+    assembler.sealModule(ENTRY);
+
+    const revision = assembler.commitArtifactRevision();
+    expect(revision.modules).toEqual([{ path: ENTRY, text: "export default view;" }]);
+  });
+
+  it("refuses to commit while a module is still streaming", () => {
+    const assembler = sealedAssembler([[ENTRY, "a"]]);
+    assembler.applyModulePatch({ path: "/panel.tsx", text: "partial" });
+
+    expect(assembler.unsealedModules()).toEqual(["/panel.tsx"]);
+    expect(() => assembler.commitArtifactRevision()).toThrow(/unsealed/);
+  });
+
+  it("drops unsealed work on abort and keeps sealed modules", () => {
+    const assembler = sealedAssembler([[ENTRY, "a"]]);
+    assembler.applyModulePatch({ path: "/panel.tsx", text: "partial" });
+    assembler.abortGeneration();
+
+    expect(assembler.unsealedModules()).toEqual([]);
+    expect(assembler.commitArtifactRevision().modules.map((module) => module.path)).toEqual([ENTRY]);
+  });
+
+  it("re-seals a module that is restated after sealing", () => {
+    const assembler = sealedAssembler([[ENTRY, "first"]]);
+    assembler.applyModulePatch({ path: ENTRY, text: "second", mode: "replace" });
+
+    expect(() => assembler.commitArtifactRevision()).toThrow(/unsealed/);
+    assembler.sealModule(ENTRY);
+    expect(assembler.commitArtifactRevision().modules[0]?.text).toBe("second");
+  });
+
+  it("digests the same module bytes to the same Revision regardless of stream order", () => {
+    const forward = sealedAssembler([[ENTRY, "a"], ["/panel.tsx", "b"]]).commitArtifactRevision();
+    const reverse = sealedAssembler([["/panel.tsx", "b"], [ENTRY, "a"]]).commitArtifactRevision();
+
+    expect(reverse.digest).toBe(forward.digest);
+    expect(reverse.modules).toEqual(forward.modules);
+  });
+
+  it("digests different module bytes to a different Revision", () => {
+    const original = sealedAssembler([[ENTRY, "a"]]).commitArtifactRevision();
+    const changed = sealedAssembler([[ENTRY, "a "]]).commitArtifactRevision();
+
+    expect(changed.digest).not.toBe(original.digest);
+  });
+
+  it("requires the descriptor's entry module", () => {
+    const assembler = sealedAssembler([["/panel.tsx", "b"]]);
+
+    expect(() => assembler.commitArtifactRevision()).toThrow(/entry module/);
+  });
+
+  it("rejects module paths that are not normalized POSIX paths", () => {
+    const assembler = new AgentStreamAssembler(descriptor);
+
+    expect(() => assembler.applyModulePatch({ path: "view.tsx", text: "" })).toThrow(/POSIX path/);
+    expect(() => assembler.applyModulePatch({ path: "/a/../b.tsx", text: "" })).toThrow(/POSIX path/);
+    expect(() => assembler.applyModulePatch({ path: "/a/..", text: "" })).toThrow(/POSIX path/);
+    expect(() => assembler.applyModulePatch({ path: "/a/./b.tsx", text: "" })).toThrow(/POSIX path/);
+    expect(() => assembler.applyModulePatch({ path: "/folder/", text: "" })).toThrow(/POSIX path/);
+    expect(() => assembler.applyModulePatch({ path: "\\view.tsx", text: "" })).toThrow(/POSIX path/);
+    expect(() => new AgentStreamAssembler({ id: "orders", entry: "/a/../view.tsx" })).toThrow(/POSIX path/);
+  });
+
+  it("owns and deeply freezes the committed Revision", () => {
+    const callerDescriptor = { id: "orders.dashboard", entry: ENTRY };
+    const assembler = new AgentStreamAssembler(callerDescriptor);
+    callerDescriptor.id = "mutated";
+    callerDescriptor.entry = "/other.tsx";
+    assembler.applyModulePatch({ path: ENTRY, text: "a", mode: "replace" });
+    assembler.sealModule(ENTRY);
+    const revision = assembler.commitArtifactRevision();
+
+    expect(Object.isFrozen(revision)).toBe(true);
+    expect(Object.isFrozen(revision.modules)).toBe(true);
+    expect(Object.isFrozen(revision.modules[0])).toBe(true);
+    expect(Object.isFrozen(revision.descriptor)).toBe(true);
+    expect(revision.descriptor).toEqual({ id: "orders.dashboard", entry: ENTRY });
+    expect(() => {
+      (revision.modules[0] as { text: string }).text = "mutated";
+    }).toThrow(TypeError);
+    expect(revision.modules[0]?.text).toBe("a");
+  });
+});

--- a/packages/harness-studio/test/agent-react/worker-oxc-compiler.test.ts
+++ b/packages/harness-studio/test/agent-react/worker-oxc-compiler.test.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { describe, expect, it } from "vitest";
+import type { CompileModuleInput } from "../../src/agent-react/contracts/index.js";
+import { createWorkerOxcCompiler } from "../../src/agent-react/host/worker-oxc-compiler.js";
+
+const INPUT: CompileModuleInput = {
+  module: {
+    path: "/orders.tsx",
+    text: `import { defineArtifactView } from "@studio/agent-react";
+function Orders() { return <h1>Orders</h1>; }
+export default defineArtifactView({ id: "orders", component: Orders });
+`,
+  },
+  entry: true,
+  allowedPackages: ["react", "@studio/agent-react", "@studio/agent-react/jsx-dev-runtime"],
+};
+
+describe("Worker Oxc compiler", () => {
+  it("locks every optional native binding declared by the pinned Oxc packages", async () => {
+    const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+    const lock = JSON.parse(await readFile(resolve(repositoryRoot, "package-lock.json"), "utf8")) as {
+      packages: Record<string, { optionalDependencies?: Record<string, string>; [key: string]: unknown }>;
+    };
+
+    for (const packagePath of ["node_modules/oxc-parser", "node_modules/oxc-transform"]) {
+      const optionalDependencies = lock.packages[packagePath]?.optionalDependencies ?? {};
+      const missing = Object.keys(optionalDependencies)
+        .filter((name) => lock.packages[`node_modules/${name}`] === undefined);
+      expect(missing, `${packagePath} optional bindings missing from package-lock.json`).toEqual([]);
+    }
+    expect(lock.packages["node_modules/@oxc-parser/binding-darwin-x64"]).toMatchObject({
+      version: "0.147.0",
+      optional: true,
+      os: ["darwin"],
+      cpu: ["x64"],
+    });
+  });
+
+  it("compiles through the emitted isolated Worker", async () => {
+    const compiler = createWorkerOxcCompiler();
+    try {
+      const output = await compiler.compileModule(INPUT);
+
+      expect(output.diagnostics).toEqual([]);
+      expect(output.code).toContain("function Orders");
+      expect(output.viewDeclaration).toMatchObject({ id: "orders", componentName: "Orders" });
+    } finally {
+      await compiler.close();
+    }
+  });
+
+  it("terminates a timed-out Worker and starts a clean one for the next compile", async () => {
+    let workerCount = 0;
+    const compiler = createWorkerOxcCompiler({
+      timeoutMs: 1_000,
+      createWorker(url) {
+        workerCount += 1;
+        return workerCount === 1
+          ? new Worker("setInterval(() => {}, 1_000);", { eval: true })
+          : new Worker(url);
+      },
+    });
+    try {
+      const timedOut = await compiler.compileModule(INPUT);
+      const recovered = await compiler.compileModule(INPUT);
+
+      expect(timedOut.code).toBeUndefined();
+      expect(timedOut.diagnostics).toEqual([expect.objectContaining({ code: "limit/compile-timeout" })]);
+      expect(recovered.diagnostics).toEqual([]);
+      expect(recovered.viewDeclaration?.id).toBe("orders");
+      expect(workerCount).toBe(2);
+    } finally {
+      await compiler.close();
+    }
+  }, 10_000);
+
+  it("refuses use after close", async () => {
+    const compiler = createWorkerOxcCompiler();
+    await compiler.close();
+
+    await expect(compiler.compileModule(INPUT)).rejects.toThrow("compiler is closed");
+  });
+});

--- a/packages/harness-studio/test/artifact-compile-runtime.test.ts
+++ b/packages/harness-studio/test/artifact-compile-runtime.test.ts
@@ -37,6 +37,7 @@ describe("ArtifactCompileRuntime", () => {
     const first = await compileEntry(directory, "card.canvas.tsx");
     const second = await compileEntry(directory, "card.canvas.tsx");
     expect(first.snapshot.status).toBe("ready");
+    expect(first.snapshot.runtime).toEqual({ id: "studio.sandboxed-react", version: "5" });
     expect(first.snapshot.buildId).toBe(second.snapshot.buildId);
     expect(first.snapshot.sequence).toBe(second.snapshot.sequence);
     expect(first.css).toContain("rebeccapurple");
@@ -72,6 +73,90 @@ describe("ArtifactCompileRuntime", () => {
     expect(second.snapshot.buildId).toBe(first.snapshot.buildId);
     expect(second.snapshot.sequence).toBe(first.snapshot.sequence);
     expect(artifactCompileCount()).toBe(1);
+  });
+
+  it("compiles explicit AgentReact projects through the production Worker and profile", async () => {
+    resetArtifactCompileRuntime();
+    const directory = await mkdtemp(join(tmpdir(), "artifact-agent-react-"));
+    await writeFile(join(directory, "stat-row.tsx"), [
+      "export function StatRow({value}:{value:number}) {",
+      '  return <strong data-value="count">{value}</strong>;',
+      "}",
+    ].join("\n"), "utf8");
+    await writeFile(join(directory, "orders.agent.canvas.tsx"), [
+      'import { defineArtifactView, useArtifactAction, useArtifactState } from "@studio/agent-react";',
+      'import { StatRow } from "./stat-row.js";',
+      "function Orders() {",
+      '  const [items, setItems] = useArtifactState<readonly string[]>("/items");',
+      '  const showSource = useArtifactAction("studio.show-source");',
+      "  return <main><h1>AgentReact orders</h1><StatRow value={items.length} />",
+      '    <button onClick={() => setItems([...items, "next"])}>Add</button>',
+      '    <button onClick={() => void showSource()}>Show source</button></main>;',
+      "}",
+      "export default defineArtifactView({",
+      '  id: "orders",',
+      '  state: { "/items": { schema: "list", version: 1 } },',
+      '  capabilities: ["studio.show-source"],',
+      "  component: Orders,",
+      "});",
+    ].join("\n"), "utf8");
+
+    const compiled = await compileEntry(directory, "orders.agent.canvas.tsx");
+
+    expect(compiled.snapshot.status, JSON.stringify(compiled.snapshot.diagnostics)).toBe("ready");
+    expect(compiled.snapshot).toMatchObject({
+      status: "ready",
+      agentReact: {
+        protocolVersion: "agent-react/1",
+        view: {
+          id: "orders",
+          state: [{ path: "/items", schema: "list", version: 1 }],
+          capabilities: ["studio.show-source"],
+        },
+      },
+    });
+    expect(compiled.code?.length).toBeGreaterThan(10_000);
+    expect(JSON.stringify(compiled.snapshot)).not.toContain(directory);
+  });
+
+  it("compiles an AgentReact project through a barrel re-export", async () => {
+    resetArtifactCompileRuntime();
+    const directory = await mkdtemp(join(tmpdir(), "artifact-agent-react-barrel-"));
+    await writeFile(join(directory, "orders.tsx"), [
+      "export function Orders() {",
+      "  return <main><h1>Orders through barrel</h1></main>;",
+      "}",
+    ].join("\n"), "utf8");
+    await writeFile(join(directory, "index.ts"), 'export { Orders } from "./orders.js";\n', "utf8");
+    await writeFile(join(directory, "orders.agent.canvas.tsx"), [
+      'import { defineArtifactView } from "@studio/agent-react";',
+      'import { Orders } from "./index.js";',
+      'export default defineArtifactView({ id: "orders", component: Orders });',
+    ].join("\n"), "utf8");
+
+    const compiled = await compileEntry(directory, "orders.agent.canvas.tsx");
+
+    expect(compiled.snapshot.status, JSON.stringify(compiled.snapshot.diagnostics)).toBe("ready");
+    expect(compiled.snapshot.agentReact?.view.id).toBe("orders");
+    expect(compiled.code).toContain("Orders through barrel");
+  });
+
+  it("does not cache a transient AgentReact build deadline", async () => {
+    resetArtifactCompileRuntime();
+    const directory = await mkdtemp(join(tmpdir(), "artifact-agent-react-timeout-"));
+    await writeFile(join(directory, "orders.agent.canvas.tsx"), [
+      'import { defineArtifactView } from "@studio/agent-react";',
+      "function Orders() { return <h1>Orders</h1>; }",
+      'export default defineArtifactView({ id: "orders", component: Orders });',
+    ].join("\n"), "utf8");
+
+    const first = await compileEntry(directory, "orders.agent.canvas.tsx", { timeoutMs: 1 });
+    const second = await compileEntry(directory, "orders.agent.canvas.tsx", { timeoutMs: 1 });
+
+    expect(first.snapshot.status).toBe("failed");
+    expect(first.snapshot.diagnostics[0]?.message).toContain("deadline");
+    expect(second.snapshot.status).toBe("failed");
+    expect(artifactCompileCount()).toBe(2);
   });
 
   it("fails closed for package imports and filesystem escapes", async () => {

--- a/packages/harness-studio/test/artifact-view-registry.test.ts
+++ b/packages/harness-studio/test/artifact-view-registry.test.ts
@@ -13,6 +13,7 @@ import {
 describe("Artifact View surface registry", () => {
   it("keeps one stable ordered composition boundary for every view family", () => {
     expect(ARTIFACT_SURFACE_MOUNTS.map((mount) => mount.id)).toEqual([
+      "studio.agent-react-preview",
       "studio.sandboxed-preview",
       "external-hosted",
       "studio.markdown",
@@ -26,6 +27,7 @@ describe("Artifact View surface registry", () => {
   });
 
   it.each([
+    ["AgentReact", descriptor({ id: "studio.agent-react-preview", type: "sandboxed-web" }, { backing: "code", format: "agent-react-tsx" }), "studio.agent-react-preview"],
     ["dynamic React", descriptor({ id: "studio.react-preview", type: "sandboxed-web" }, { backing: "code", format: "tsx" }), "studio.sandboxed-preview"],
     ["Qoder Canvas", descriptor({ id: "qoder-canvas.deck", type: "qoder-canvas", viewUri: "/api/artifacts/deck/view" }), "external-hosted"],
     ["Structurizr", descriptor({ id: "homology.structurizr-svg", type: "homology-diagram-svg", viewUri: "/api/artifacts/structurizr/view" }, { format: "dsl" }), "external-hosted"],

--- a/packages/harness-studio/test/artifact-viewers.test.ts
+++ b/packages/harness-studio/test/artifact-viewers.test.ts
@@ -25,6 +25,7 @@ describe("Artifact plugin registry and the Qoder Canvas provider", () => {
       ["deck.pptx", "pptx", ["navigate", "outline", "select", "zoom"]],
       ["workbook.xlsx", "xlsx", ["navigate", "select"]],
       ["component.tsx", "code", []],
+      ["orders.agent.canvas.tsx", "code", ["execute", "live-update", "state", "actions"]],
       ["component.canvas.tsx", "code", ["execute", "live-update"]],
       ["diagram.svg", "svg", ["live-update"]],
       ["diagram.mmd", "mermaid", ["live-update"]],

--- a/packages/harness-studio/test/browser/acp-debugger.spec.mjs
+++ b/packages/harness-studio/test/browser/acp-debugger.spec.mjs
@@ -51,7 +51,7 @@ test("runs ACP through the Debugger permission gate at wide, compact, and narrow
   page.on("pageerror", (error) => errors.push(error.message));
   await page.setViewportSize(layouts[0]);
   await page.goto(`${studio.url}/#/debugger`);
-  await page.getByRole("button", { name: "Choose workspace" }).click();
+  await page.getByRole("button", { name: "Choose Project" }).click();
   await expect(page.getByRole("button", { name: "New live run" })).toBeVisible();
   await runAcpPrompt(page, "Verify the browser ACP bridge");
   await expect(page.getByText("session/request_permission", { exact: true })).toBeVisible();

--- a/packages/harness-studio/test/browser/acp-debugger.spec.mjs
+++ b/packages/harness-studio/test/browser/acp-debugger.spec.mjs
@@ -22,7 +22,7 @@ async function runAcpPrompt(page, prompt) {
   await page.getByRole("combobox", { name: "Runtime" }).selectOption("acp");
   await page.getByRole("textbox", { name: "Task prompt for the harness run…" }).fill(prompt);
   await page.getByRole("button", { name: "Run harness" }).click();
-  await expect(page.getByText("ACP permission requested")).toBeVisible();
+  await expect(page.locator(".live-inspector > header")).toContainText("Permission required");
   await page.getByRole("button", { name: "Allow once allow_once" }).click();
   await expect(page.getByText("fixture:allow-once", { exact: true })).toBeVisible();
 }

--- a/packages/harness-studio/test/browser/artifact-host.spec.mjs
+++ b/packages/harness-studio/test/browser/artifact-host.spec.mjs
@@ -1151,11 +1151,24 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
   }
 
   await page.setViewportSize({ width: 1440, height: 900 });
+  const sessionRows = page.locator(".session-catalog-rows > li > button");
+  await expect(sessionRows).toHaveCount(2);
+  await expect(page.locator('.session-catalog-rows > li > button[tabindex="0"]')).toHaveCount(1);
+  await sessionRows.first().focus();
+  await page.keyboard.press("ArrowDown");
+  await expect(sessionRows.nth(1)).toBeFocused();
+  await page.keyboard.press("ArrowUp");
+  await expect(sessionRows.first()).toBeFocused();
+  await expect(page.getByRole("checkbox", { name: /Select Repair parser .* for comparison/u })).toBeVisible();
+  await expect(page.getByRole("checkbox", { name: /Select Repair renderer .* for comparison/u })).toBeVisible();
   const compareChecks = page.locator(".session-catalog-rows input[type=checkbox]");
   await compareChecks.nth(0).check();
   await compareChecks.nth(1).check();
   await page.getByRole("button", { name: "Compare 2/2" }).click();
   await expect(page.getByRole("heading", { name: "Compare Sessions" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Metric" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Left" })).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Right" })).toBeVisible();
   await expect(page.locator(".session-compare-boundary")).toContainText("No winner inferred");
   await expect(page.locator(".session-compare-workspace")).toContainText("Repair parser");
   await expect(page.locator(".session-compare-workspace")).toContainText("Repair renderer");
@@ -1168,6 +1181,22 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
     if (layout.width <= 1080) await expect(page.locator(".studio-primary-nav")).not.toBeInViewport();
     const overflows = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1);
     expect(overflows, `${layout.name} session comparison overflows horizontally`).toBe(false);
+    if (layout.name === "narrow") {
+      const metricLayout = await page.evaluate(() => {
+        const table = document.querySelector(".session-compare-table");
+        const cells = [...document.querySelectorAll(".session-compare-table [role=cell]")];
+        return {
+          tableClient: table?.clientWidth ?? 0,
+          tableScroll: table?.scrollWidth ?? Infinity,
+          cells: cells.map((cell) => {
+            const rect = cell.getBoundingClientRect();
+            return { left: rect.left, right: rect.right };
+          }),
+        };
+      });
+      expect(metricLayout.tableScroll).toBeLessThanOrEqual(metricLayout.tableClient + 1);
+      expect(metricLayout.cells.every((cell) => cell.left >= 0 && cell.right <= layout.width + 1)).toBe(true);
+    }
     await page.screenshot({ path: `test-results/session-compare-${layout.name}.png`, fullPage: true });
   }
 

--- a/packages/harness-studio/test/browser/artifact-host.spec.mjs
+++ b/packages/harness-studio/test/browser/artifact-host.spec.mjs
@@ -29,6 +29,7 @@ test.beforeAll(async () => {
   await writeFile(join(artifactDirectory, "deck.pptx"), createPptxFixture("01"));
   await writeFile(join(artifactDirectory, "workbook.xlsx"), createXlsxFixture());
   await writeFile(join(artifactDirectory, "component.canvas.tsx"), 'document.body.dataset.moduleEvaluated = "yes"; export default () => <p data-preview="current">first render</p>;\n', "utf8");
+  await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("first verified build"), "utf8");
   await writeFile(join(artifactDirectory, "fallback.canvas.tsx"), 'export default () => <p data-preview="canvas-fallback">Studio React fallback</p>;\n', "utf8");
   await writeFile(join(artifactDirectory, "broken.canvas.tsx"), 'export default () => <main>broken;\n', "utf8");
   await writeFile(join(artifactDirectory, "throws.canvas.tsx"), 'export default function Boom() { throw new Error("render exploded"); }\n', "utf8");
@@ -205,6 +206,35 @@ function watchFailures(page) {
   return failures;
 }
 
+function agentReactSource(label, throwMessage, lateThrowMessage) {
+  return [
+    'import { defineArtifactView, useArtifactAction, useArtifactState } from "@studio/agent-react";',
+    "function Orders() {",
+    ...(throwMessage === undefined ? [] : [`  throw new Error(${JSON.stringify(throwMessage)});`]),
+    '  const [orders, setOrders] = useArtifactState<readonly string[]>("/orders");',
+    '  const showSource = useArtifactAction("studio.show-source");',
+    "  const addOrder = () => setOrders([...orders, `order-${orders.length + 1}`]);",
+    "  const openSource = () => { void showSource(); };",
+    ...(lateThrowMessage === undefined ? [] : [`  const breakCurrent = () => { setTimeout(() => { throw new Error(${JSON.stringify(lateThrowMessage)}); }, 0); };`]),
+    '  return <main data-agent-react-build={"' + label + '"}>',
+    "    <h1>Orders AgentReact</h1>",
+    '    <p data-agent-react-label>{"' + label + '"}</p>',
+    "    <output aria-label=\"Order count\">{orders.length}</output>",
+    "    <button type=\"button\" onClick={addOrder}>Add order</button>",
+    "    <button type=\"button\" onClick={openSource}>Show source</button>",
+    ...(lateThrowMessage === undefined ? [] : ['    <button type="button" onClick={breakCurrent}>Break current</button>']),
+    "  </main>;",
+    "}",
+    "export default defineArtifactView({",
+    '  id: "orders",',
+    '  state: { "/orders": { schema: "list", version: 1 } },',
+    '  capabilities: ["studio.show-source"],',
+    "  component: Orders,",
+    "});",
+    "",
+  ].join("\n");
+}
+
 async function openArtifacts(page) {
   await page.goto(`${studio.url}/#/artifacts`);
   const artifactsPaneTab = page.getByRole("tab", { name: "Artifacts", exact: true });
@@ -277,6 +307,170 @@ test("keeps an unactivated Canvas TSX file on the Studio React fallback", async 
     format: "cursor-canvas-tsx",
     renderer: { id: "studio.react-preview", type: "sandboxed-web", status: "ready" },
   });
+  expect(failures).toEqual([]);
+});
+
+test("runs explicit AgentReact end to end and commits only a verified staging build", async ({ page }, testInfo) => {
+  test.setTimeout(60_000);
+  const failures = watchFailures(page);
+  await page.addInitScript(() => {
+    globalThis.__agentReactObservations = [];
+    addEventListener("harness.artifact-observation", (event) => globalThis.__agentReactObservations.push(event.detail));
+  });
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openArtifacts(page);
+  await page.getByRole("button", { name: /orders\.agent\.canvas\.tsx/ }).click();
+
+  const liveFrame = page.locator('iframe[title="Live AgentReact preview: orders.agent.canvas.tsx"]');
+  const live = page.frameLocator('iframe[title="Live AgentReact preview: orders.agent.canvas.tsx"]');
+  await expect(live.locator("h1")).toHaveText("Orders AgentReact", { timeout: 15_000 });
+  await expect(live.locator("[data-agent-react-label]")).toHaveText("first verified build");
+  await expect(live.locator("[data-artifact-node]").first()).toBeVisible();
+  await expect(page.getByText("AgentReact build committed from isolated staging.")).toBeVisible();
+  await expect(liveFrame).toHaveAttribute("sandbox", "allow-scripts");
+  await expect(liveFrame).toHaveAttribute("referrerpolicy", "no-referrer");
+  const previewUri = await liveFrame.getAttribute("src");
+  const previewResponse = await page.request.get(`${studio.url}${previewUri}`);
+  expect(previewResponse.headers()["cache-control"]).toBe("private, max-age=31536000, immutable");
+  expect(previewResponse.headers()["content-security-policy"]).toContain("default-src 'none'");
+  expect(previewResponse.headers()["content-security-policy"]).toContain("connect-src 'none'");
+
+  const catalog = await (await page.request.get(`${studio.url}/api/artifacts`)).json();
+  expect(catalog.artifacts.find((artifact) => artifact.label === "orders.agent.canvas.tsx")).toMatchObject({
+    format: "agent-react-tsx",
+    renderer: { id: "studio.agent-react-preview", type: "sandboxed-web", status: "ready" },
+    capabilities: expect.arrayContaining(["actions", "execute", "live-update", "state"]),
+  });
+
+  const direct = await page.context().newPage();
+  await direct.goto(`${studio.url}${previewUri}`);
+  await expect(direct.getByRole("heading", { name: "Orders AgentReact" })).toHaveCount(0);
+  await direct.close();
+
+  await live.getByRole("button", { name: "Add order" }).click();
+  await expect(live.getByLabel("Order count")).toHaveText("1");
+  const firstBuildUri = await liveFrame.getAttribute("src");
+
+  try {
+    await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("must not commit", "staging exploded"), "utf8");
+    await expect(page.locator(".artifact-runtime-status")).toContainText("staging exploded", { timeout: 15_000 });
+    await expect(page.locator(".artifact-runtime-status")).toContainText("Current remains on the last verified build.");
+    await expect(live.locator("[data-agent-react-label]")).toHaveText("first verified build");
+    await expect(live.getByLabel("Order count")).toHaveText("1");
+    await expect(liveFrame).toHaveAttribute("src", firstBuildUri);
+
+    await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("second verified build"), "utf8");
+    await expect(live.locator("[data-agent-react-label]")).toHaveText("second verified build", { timeout: 15_000 });
+    await expect(live.getByLabel("Order count")).toHaveText("1");
+    await expect(liveFrame).not.toHaveAttribute("src", firstBuildUri);
+    await expect(page.getByText("AgentReact build committed from isolated staging.")).toBeVisible();
+
+    await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("interactive failure build", undefined, "current exploded"), "utf8");
+    await expect(live.locator("[data-agent-react-label]")).toHaveText("interactive failure build", { timeout: 15_000 });
+    await live.getByRole("button", { name: "Break current" }).click();
+    await expect(page.locator(".artifact-runtime-status")).toContainText("current exploded");
+    await expect(page.getByRole("tab", { name: "Source", exact: true })).toHaveAttribute("aria-selected", "true");
+    await expect(liveFrame).toHaveCount(0);
+
+    await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("recovered current build"), "utf8");
+    await expect(page.getByText("AgentReact build committed from isolated staging.")).toBeVisible({ timeout: 15_000 });
+    await page.locator(".artifact-runtime-tabs").getByRole("tab", { name: "Preview", exact: true }).click();
+    await expect(live.locator("[data-agent-react-label]")).toHaveText("recovered current build");
+    await expect(live.getByLabel("Order count")).toHaveText("1");
+
+    const observations = await page.evaluate(() => globalThis.__agentReactObservations);
+    expect(observations.length).toBeGreaterThanOrEqual(5);
+    expect(observations.map((entry) => entry?.value?.kind)).toEqual(expect.arrayContaining([
+      "renderCompleted",
+      "renderFailed",
+    ]));
+    expect(observations.every((entry, index) => entry.type === "CUSTOM"
+      && entry.name === "harness.artifact-observation"
+      && entry.value.sequence === index + 1
+      && typeof entry.value.artifactDigest === "string"
+      && typeof entry.value.buildDigest === "string")).toBe(true);
+
+    await live.getByRole("button", { name: "Show source" }).click();
+    await expect(page.getByRole("tab", { name: "Source", exact: true })).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator('[data-artifact-code-view="source"]')).toContainText("recovered current build");
+    await page.screenshot({ path: testInfo.outputPath("agent-react-source-action.png"), fullPage: true });
+  } finally {
+    await writeFile(join(artifactDirectory, "orders.agent.canvas.tsx"), agentReactSource("first verified build"), "utf8");
+  }
+  expect(failures).toEqual(["current exploded"]);
+});
+
+test("keeps the current AgentReact session across unrelated artifact invalidations", async ({ page }) => {
+  const failures = watchFailures(page);
+  await openArtifacts(page);
+  await page.getByRole("button", { name: /orders\.agent\.canvas\.tsx/ }).click();
+
+  const live = page.frameLocator('iframe[title="Live AgentReact preview: orders.agent.canvas.tsx"]');
+  const status = page.locator(".artifact-runtime-status");
+  await expect(live.getByRole("heading", { name: "Orders AgentReact" })).toBeVisible({ timeout: 15_000 });
+  await expect(status).toContainText("AgentReact build committed from isolated staging.");
+  await live.getByRole("button", { name: "Add order" }).click();
+  await expect(live.getByLabel("Order count")).toHaveText("1");
+
+  const catalog = await (await page.request.get(`${studio.url}/api/artifacts`)).json();
+  const snapshotUri = catalog.artifacts.find((artifact) => artifact.label === "orders.agent.canvas.tsx")?.build?.snapshotUri;
+  expect(snapshotUri).toBeTruthy();
+  try {
+    for (const text of ["unrelated invalidation one\n", "unrelated invalidation two\n"]) {
+      const refreshed = page.waitForResponse((response) => response.request().method() === "GET"
+        && new URL(response.url()).pathname === snapshotUri);
+      await writeFile(join(artifactDirectory, "notes.txt"), text, "utf8");
+      await refreshed;
+      await expect(status).toContainText("AgentReact build committed from isolated staging.");
+      await expect(live.getByLabel("Order count")).toHaveText("1");
+    }
+
+    await live.getByRole("button", { name: "Add order" }).click();
+    await expect(live.getByLabel("Order count")).toHaveText("2");
+    await live.getByRole("button", { name: "Show source" }).click();
+    await expect(page.getByRole("tab", { name: "Source", exact: true })).toHaveAttribute("aria-selected", "true");
+    await page.locator(".artifact-runtime-tabs").getByRole("tab", { name: "Preview", exact: true }).click();
+    await expect(live.getByLabel("Order count")).toHaveText("2");
+  } finally {
+    await writeFile(join(artifactDirectory, "notes.txt"), "followed the declared content reference\n", "utf8");
+  }
+  expect(failures).toEqual([]);
+});
+
+test("keeps AgentReact Preview primary at wide, compact, and narrow widths", async ({ page }, testInfo) => {
+  const failures = watchFailures(page);
+  for (const layout of [
+    { name: "wide", width: 1440, height: 900 },
+    { name: "compact", width: 1024, height: 768 },
+    { name: "narrow", width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize({ width: layout.width, height: layout.height });
+    await openArtifacts(page);
+    await page.getByRole("button", { name: /orders\.agent\.canvas\.tsx/ }).click();
+    const live = page.frameLocator('iframe[title="Live AgentReact preview: orders.agent.canvas.tsx"]');
+    await expect(live.getByRole("heading", { name: "Orders AgentReact" })).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator(".artifact-runtime-tabs").getByRole("tab", { name: "Preview", exact: true })).toHaveAttribute("aria-selected", "true");
+    expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1), `${layout.name} AgentReact preview overflows horizontally`).toBe(false);
+    await page.locator(".artifact-runtime-tabs").getByRole("tab", { name: "Source" }).focus();
+    expect(Number.parseFloat(await page.locator(".artifact-runtime-tabs").getByRole("tab", { name: "Source" }).evaluate((element) => getComputedStyle(element).outlineWidth))).toBeGreaterThan(0);
+    await page.screenshot({ path: testInfo.outputPath(`agent-react-${layout.name}.png`), fullPage: true });
+  }
+  expect(failures).toEqual([]);
+});
+
+test("commits AgentReact when preview paint callbacks are suspended", async ({ page }) => {
+  const failures = watchFailures(page);
+  await page.addInitScript(() => {
+    if (location.pathname.includes("/api/artifacts/") && location.pathname.endsWith("/preview")) {
+      globalThis.requestAnimationFrame = () => 1;
+    }
+  });
+  await openArtifacts(page);
+  await page.getByRole("button", { name: /orders\.agent\.canvas\.tsx/ }).click();
+
+  const live = page.frameLocator('iframe[title="Live AgentReact preview: orders.agent.canvas.tsx"]');
+  await expect(live.getByRole("heading", { name: "Orders AgentReact" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("AgentReact build committed from isolated staging.")).toBeVisible();
   expect(failures).toEqual([]);
 });
 

--- a/packages/harness-studio/test/browser/artifact-host.spec.mjs
+++ b/packages/harness-studio/test/browser/artifact-host.spec.mjs
@@ -1044,11 +1044,11 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
   const requestedUrls = [];
   page.on("request", (request) => requestedUrls.push(request.url()));
   await page.goto(emptyStudio.url);
-  const gate = page.getByRole("dialog", { name: "Open a workspace to start" });
+  const gate = page.getByRole("dialog", { name: "Open a Project to start" });
   await expect(gate).toBeVisible();
   await expect(page.locator(".studio-control-plane")).toHaveAttribute("inert", "");
   await expect(page.locator(".studio-control-plane")).toHaveAttribute("aria-hidden", "true");
-  await expect(page.getByRole("button", { name: "Choose workspace" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Choose Project" })).toBeVisible();
 
   for (const layout of [
     { name: "wide", width: 1440, height: 900 },
@@ -1063,15 +1063,17 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
   }
 
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.getByRole("button", { name: "Choose workspace" }).click();
-  await expect(page.getByRole("button", { name: "Opening workspace" })).toBeDisabled();
-  await expect(page.locator(".workspace-open-progress")).toContainText("Finding matching Sessions across local providers");
+  await page.getByRole("button", { name: "Choose Project" }).click();
+  await expect(page.getByRole("button", { name: "Opening Project" })).toBeDisabled();
+  await expect(page.locator(".workspace-open-progress")).toContainText("Finding matching Project Sessions across local providers");
   await expect(page.locator(".workspace-open-progress > i")).toHaveCSS("animation-name", "workspace-progress-spin");
   await page.screenshot({ path: "test-results/session-workspace-loading-wide.png", fullPage: true });
 
   await expect(gate).toHaveCount(0);
   await expect(page.locator(".studio-control-plane")).not.toHaveAttribute("inert", "");
-  await expect(page).toHaveURL(/#\/sessions$/);
+  await expect(page).toHaveURL(/#\/projects\/project_[a-f0-9]{32}\/overview$/u);
+  await page.getByRole("navigation", { name: "Studio project and View navigation" }).getByRole("button", { name: /^Sessions/ }).click();
+  await expect(page).toHaveURL(/#\/projects\/project_[a-f0-9]{32}\/sessions$/u);
   const inspector = page.locator("[data-studio-native-inspector]");
   await expect(inspector).toBeVisible();
   await expect(inspector).toHaveAttribute("data-react-inspector-workbench", "true");
@@ -1170,10 +1172,10 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
   }
 
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.getByRole("navigation", { name: "Harness control plane" }).getByRole("button", { name: /^Debugger/ }).click();
-  await expect(page.getByText("Workspace default · Qoder", { exact: true })).toBeVisible();
+  await page.getByRole("navigation", { name: "Studio project and View navigation" }).getByRole("button", { name: /^Debugger/ }).click();
+  await expect(page.getByText(/Project default · Qoder · fixture-project/u)).toBeVisible();
   await page.getByRole("button", { name: "New live run" }).click();
-  await expect(page.getByRole("dialog", { name: "Start a live harness session" })).toContainText("selected workspace");
+  await expect(page.getByRole("dialog", { name: "Start a live harness session" })).toContainText("Project fixture-project");
   await page.getByPlaceholder("Task prompt for the harness run…").fill("verify the default workspace harness");
   await page.getByRole("button", { name: "Run harness" }).click();
   await expect(page.locator(".session-notebook")).toContainText("default harness: verify the default workspace harness");

--- a/packages/harness-studio/test/browser/artifact-workspace.spec.mjs
+++ b/packages/harness-studio/test/browser/artifact-workspace.spec.mjs
@@ -107,9 +107,10 @@ test("keeps Date, Files, Artifact selection, and Canvas reachable at all target 
   ]) {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await page.goto(`${studio.url}/#/artifacts`);
-    const workspaceRegion = page.getByRole("region", { name: "Workspace artifacts" });
+    const workspaceRegion = page.getByRole("region", { name: "Project artifacts" });
     if (viewport.width <= 760) await workspaceRegion.getByRole("tab", { name: "Browse" }).click();
-    await expect(workspaceRegion.getByRole("heading", { name: "artifact-fixture" })).toBeVisible();
+    await expect(page.locator(".studio-context-title")).toContainText("artifact-fixture");
+    await expect(workspaceRegion.locator(".artifact-scope-pane > header")).toContainText("Project scopeBrowse");
     await expect(workspaceRegion.getByRole("gridcell", { name: /August 24, 2026, 3 artifacts/ })).toHaveAttribute("aria-selected", "true");
     await expect(page.locator(".artifact-editor-header small")).toContainText("current ");
 
@@ -149,7 +150,7 @@ test("keeps Date, Files, Artifact selection, and Canvas reachable at all target 
 test("switches between Date and file-tree scopes without changing catalog authority", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${studio.url}/#/artifacts`);
-  const workspaceRegion = page.getByRole("region", { name: "Workspace artifacts" });
+  const workspaceRegion = page.getByRole("region", { name: "Project artifacts" });
   await workspaceRegion.getByRole("gridcell", { name: /August 23, 2026, 1 artifact/ }).click();
   await expect(page.locator(".artifact-list-pane").getByRole("button", { name: /contract\.md/ })).toBeVisible();
   await expect(page.locator(".artifact-list-pane").getByRole("button", { name: /report\.md/ })).toHaveCount(0);

--- a/packages/harness-studio/test/browser/customization.spec.mjs
+++ b/packages/harness-studio/test/browser/customization.spec.mjs
@@ -96,7 +96,10 @@ test("analyzes Host customizations only after the explicit action across layouts
   await expect(page.getByRole("table")).toContainText("Codex, Qoder");
   await expect(page.getByRole("table")).toContainText("MCP Server");
   await expect(page.getByRole("row").filter({ hasText: "schedule" })).toContainText("Qoder");
-  await expect(page.getByText("Claude customization collection failed. Other Host results remain available.")).toBeVisible();
+  const hostFailure = page.getByRole("alert");
+  await expect(hostFailure).toContainText("Claude customization collection failed");
+  await expect(hostFailure).toContainText("collector runtime failed unexpectedly");
+  await expect(hostFailure).toContainText("use Analyze again to retry");
   expect(calls).toBe(3);
   expect(await page.locator("body").innerText()).not.toContain(workspace);
   expect(await page.locator("body").innerText()).not.toContain("private-token");

--- a/packages/harness-studio/test/browser/overview.spec.mjs
+++ b/packages/harness-studio/test/browser/overview.spec.mjs
@@ -91,7 +91,7 @@ test("labels a configured source action for the workbench it opens", async ({ pa
   await page.goto(`${sourceStudio.url}/#/overview`);
 
   await expect(page.getByRole("heading", { name: "Comparison setup is ready." })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Open workspace", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Open Project", exact: true })).toHaveCount(0);
   const action = page.getByRole("button", { name: "Open Compare" });
   await expect(action).toBeVisible();
   await action.focus();
@@ -109,7 +109,7 @@ test("renders the connected workspace home across layout modes", async ({ page }
   for (const layout of layouts) {
     await page.setViewportSize({ width: layout.width, height: layout.height });
     await page.goto(`${workspaceStudio.url}/#/overview`);
-    await expect(page.getByRole("heading", { name: "better-harness-dashboard" })).toBeVisible();
+    await expect(page.locator(".studio-context-title")).toContainText("better-harness-dashboard");
     await expect(page.getByLabel("Workspace summary")).toContainText("Sessions2");
     await expect(page.getByRole("heading", { name: "Recent Sessions" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Open Session: Repair the Studio overview" })).toBeVisible();
@@ -121,7 +121,7 @@ test("renders the connected workspace home across layout modes", async ({ page }
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${workspaceStudio.url}/#/overview`);
   await page.getByRole("button", { name: "Open Session: Inspect the workspace evidence" }).click();
-  await expect(page).toHaveURL(/#\/sessions$/u);
+  await expect(page).toHaveURL(/#\/projects\/project_[a-f0-9]{32}\/sessions$/u);
   await expect(page.getByRole("heading", { name: "Inspect the workspace evidence" })).toBeVisible();
   expect(browserErrors).toEqual([]);
 });

--- a/packages/harness-studio/test/browser/overview.spec.mjs
+++ b/packages/harness-studio/test/browser/overview.spec.mjs
@@ -90,7 +90,9 @@ test("labels a configured source action for the workbench it opens", async ({ pa
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${sourceStudio.url}/#/overview`);
 
-  await expect(page.getByRole("heading", { name: "Comparison setup is ready." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Comparison setup needs attention." })).toBeVisible();
+  await expect(page.getByRole("term").filter({ hasText: "Harness Bench" })).toContainText("Checkpoint source unavailable");
+  await expect(page.getByRole("definition").filter({ hasText: "Blocked" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Open Project", exact: true })).toHaveCount(0);
   const action = page.getByRole("button", { name: "Open Compare" });
   await expect(action).toBeVisible();

--- a/packages/harness-studio/test/browser/project-shell.spec.mjs
+++ b/packages/harness-studio/test/browser/project-shell.spec.mjs
@@ -1,0 +1,186 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { HarnessRunEmitter } from "@qoder-ai/harness/exec";
+import { startHarnessStudioServer } from "../../dist/server/server.js";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const layouts = [
+  { name: "wide", width: 1440, height: 900 },
+  { name: "compact", width: 1024, height: 768 },
+  { name: "narrow", width: 390, height: 844 },
+];
+
+let studio;
+let projectA;
+let projectB;
+let labelA;
+let labelB;
+let descriptorA;
+let descriptorB;
+let observedRunCwd;
+
+test.beforeAll(async () => {
+  projectA = await mkdtemp(join(tmpdir(), "studio-shell-a-"));
+  projectB = await mkdtemp(join(tmpdir(), "studio-shell-b-"));
+  labelA = basename(projectA);
+  labelB = basename(projectB);
+  const selections = [projectA, projectB];
+  studio = await startHarnessStudioServer({
+    appDir: join(packageRoot, "dist", "app"),
+    port: 0,
+    workspaceDirectoryPicker: async () => selections.shift(),
+    workspaceSessionProvider: {
+      discover: async (selected) => {
+        const count = basename(selected) === labelA ? 1 : 2;
+        return {
+          label: basename(selected),
+          providers: [{ provider: "codex", status: "ok", discovered: count, included: count }],
+          sessions: Array.from({ length: count }, (_, index) => ({
+            summary: {
+              id: `codex:session-${basename(selected)}-${index}`,
+              savedAt: `2026-08-27T0${index}:00:00.000Z`,
+              prompt: `${basename(selected)} Session ${index + 1}`,
+              status: "observed",
+              toolCallCount: 0,
+              provider: "codex",
+            },
+            debugger: {
+              id: `codex:session-${basename(selected)}-${index}`,
+              name: `${basename(selected)} Session ${index + 1}`,
+              agent: "codex",
+              protocol: "Inspector normalized local evidence",
+              connection: "observed",
+              mode: "Retained run",
+              startedAt: "00:00:00",
+              finishedAt: "00:00:01",
+              events: [],
+            },
+          })),
+        };
+      },
+    },
+    executorFactory: (context) => ({
+      host: "qoder",
+      async execute(revision, _bundle, task) {
+        observedRunCwd = task.cwd;
+        const emitter = new HarnessRunEmitter(context.onRunEvent);
+        emitter.start({ revisionId: revision.revisionId, host: "qoder" });
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 700));
+        emitter.text(`bound project: ${basename(task.cwd ?? "")}`);
+        emitter.finish(0);
+        return { host: "qoder", revisionId: revision.revisionId, exitCode: 0, output: "finished", errorOutput: "", warnings: [] };
+      },
+    }),
+  });
+  const openedA = await (await fetch(`${studio.url}/api/projects/open`, { method: "POST" })).json();
+  const openedB = await (await fetch(`${studio.url}/api/projects/open`, { method: "POST" })).json();
+  descriptorA = openedA.project;
+  descriptorB = openedB.project;
+});
+
+test.afterAll(async () => {
+  await studio?.close();
+  if (projectA) await rm(projectA, { recursive: true, force: true });
+  if (projectB) await rm(projectB, { recursive: true, force: true });
+});
+
+function projectButton(page, label) {
+  return page.getByRole("button", { name: new RegExp(`^${label}`) });
+}
+
+test("switches one shared View workbench between remembered Projects", async ({ page }, testInfo) => {
+  const errors = [];
+  page.on("console", (message) => { if (message.type() === "error") errors.push(`console: ${message.text()}`); });
+  page.on("pageerror", (error) => errors.push(`page: ${error.message}`));
+  await page.setViewportSize(layouts[0]);
+  await page.goto(`${studio.url}/#/overview`);
+
+  await expect(projectButton(page, labelB)).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(new RegExp(`#\/projects\/${descriptorB.id}\/overview$`, "u"));
+  await expect(page.getByLabel(`${labelB} Views`)).toBeVisible();
+  await expect(page.getByLabel(`${labelA} Views`)).toHaveCount(0);
+  await expect(page.getByLabel("Workspace summary")).toContainText("Sessions2");
+
+  await projectButton(page, labelA).click();
+  await expect(projectButton(page, labelA)).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(new RegExp(`#\/projects\/${descriptorA.id}\/overview$`, "u"));
+  await expect(page.getByLabel(`${labelA} Views`)).toBeVisible();
+  await expect(page.getByLabel("Workspace summary")).toContainText("Sessions1");
+
+  await page.goBack();
+  await expect(projectButton(page, labelB)).toHaveAttribute("aria-current", "true");
+  await expect(page.getByLabel("Workspace summary")).toContainText("Sessions2");
+  await page.goForward();
+  await expect(projectButton(page, labelA)).toHaveAttribute("aria-current", "true");
+  await expect(page.getByLabel("Workspace summary")).toContainText("Sessions1");
+
+  await projectButton(page, labelA).focus();
+  await page.keyboard.press("ArrowDown");
+  await expect(page.getByRole("button", { name: /^Overview/ })).toBeFocused();
+  await page.keyboard.press("End");
+  await expect(projectButton(page, labelB)).toBeFocused();
+
+  for (const layout of layouts) {
+    await page.setViewportSize({ width: layout.width, height: layout.height });
+    if (layout.name !== "wide") {
+      await expect(page.locator(".studio-primary-nav")).not.toBeInViewport();
+      await page.locator(".studio-nav-toggle").click();
+      await expect(page.locator(".studio-primary-nav")).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 0)");
+      await expect(projectButton(page, labelA)).toBeVisible();
+    }
+    expect(await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)).toBe(0);
+    const visibleViewNavigations = await page.evaluate(() => [...document.querySelectorAll(".studio-project-views")].filter((node) => node.getClientRects().length > 0 && getComputedStyle(node).visibility !== "hidden").length);
+    expect(visibleViewNavigations).toBe(1);
+    await page.screenshot({ path: testInfo.outputPath(`project-shell-${layout.name}.png`) });
+    if (layout.name === "narrow") {
+      await projectButton(page, labelB).click();
+      await expect(page.locator(".studio-primary-nav")).not.toBeInViewport();
+      await expect(page.locator(".studio-nav-toggle")).toBeFocused();
+      await expect(page.locator(".studio-context-title > small")).toHaveText(labelB);
+    } else if (layout.name !== "wide") {
+      await page.locator(".studio-project-close").click();
+      await expect(page.locator(".studio-primary-nav")).not.toBeInViewport();
+    }
+  }
+  expect(errors).toEqual([]);
+});
+
+test("keeps a live run bound to its starting Project across a sidebar switch", async ({ page }) => {
+  await page.setViewportSize(layouts[0]);
+  await page.goto(`${studio.url}/#/projects/${descriptorA.id}/debugger`);
+  await expect(projectButton(page, labelA)).toHaveAttribute("aria-current", "true");
+  await page.getByRole("button", { name: "New live run" }).click();
+  await expect(page.getByRole("dialog", { name: "Start a live harness session" })).toContainText(`Project ${labelA}`);
+  await page.getByPlaceholder("Task prompt for the harness run…").fill("prove the Project binding");
+  await page.getByRole("button", { name: "Run harness" }).click();
+  await expect(page.locator(".debugger-brand")).toContainText(labelA);
+
+  await projectButton(page, labelB).click();
+  await expect(projectButton(page, labelB)).toHaveAttribute("aria-current", "true");
+  await expect(page.locator(".debugger-brand")).toContainText(labelA);
+  await expect(page.locator(".session-notebook")).toContainText(`bound project: ${labelA}`);
+  expect(await realpath(observedRunCwd)).toBe(await realpath(projectA));
+});
+
+test("keeps configured Sources reachable before a Project is opened", async ({ page }) => {
+  const sourceStudio = await startHarnessStudioServer({
+    appDir: join(packageRoot, "dist", "app"),
+    port: 0,
+    workspaceDirectoryPicker: async () => projectA,
+    workspaceSessionProvider: { discover: async () => ({ label: labelA, sessions: [] }) },
+    sourceCatalog: [{ id: "evidence_fixture", kind: "evidence", label: "Frozen evidence", path: projectA }],
+  });
+  try {
+    await page.setViewportSize(layouts[0]);
+    await page.goto(sourceStudio.url);
+    await expect(page.getByRole("dialog", { name: "Open a Project to start" })).toHaveCount(0);
+    await expect(page.getByLabel("Configured source Views")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Evidence results are ready." })).toBeVisible();
+  } finally {
+    await sourceStudio.close();
+  }
+});

--- a/packages/harness-studio/test/browser/project-shell.spec.mjs
+++ b/packages/harness-studio/test/browser/project-shell.spec.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -122,6 +122,7 @@ test("switches one shared View workbench between remembered Projects", async ({ 
   await expect(page.getByRole("button", { name: /^Overview/ })).toBeFocused();
   await page.keyboard.press("End");
   await expect(projectButton(page, labelB)).toBeFocused();
+  expect(await page.locator(".studio-primary-nav nav button").evaluateAll((buttons) => buttons.filter((button) => button.tabIndex === 0).length)).toBe(1);
 
   for (const layout of layouts) {
     await page.setViewportSize({ width: layout.width, height: layout.height });
@@ -148,14 +149,39 @@ test("switches one shared View workbench between remembered Projects", async ({ 
   expect(errors).toEqual([]);
 });
 
+test("recovers a failed workbench bootstrap without reloading the page", async ({ page }) => {
+  let configRequests = 0;
+  await page.route("**/api/config", async (route) => {
+    configRequests += 1;
+    if (configRequests === 1) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "temporary fixture failure" }) });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto(`${studio.url}/#/overview`);
+  await expect(page.getByRole("alert")).toContainText("Cannot load Studio configuration");
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
+  expect(configRequests).toBeGreaterThanOrEqual(2);
+});
+
 test("keeps a live run bound to its starting Project across a sidebar switch", async ({ page }) => {
+  const runCount = async (directory) => (await readdir(join(directory, ".harness-studio-runs")).catch(() => [])).filter((name) => name.endsWith(".json")).length;
+  const beforeA = await runCount(projectA);
+  const beforeB = await runCount(projectB);
   await page.setViewportSize(layouts[0]);
   await page.goto(`${studio.url}/#/projects/${descriptorA.id}/debugger`);
   await expect(projectButton(page, labelA)).toHaveAttribute("aria-current", "true");
+  await expect(page.getByRole("status").filter({ hasText: "Ready for a live run" })).toBeVisible();
+  await expect(page.locator(".live-inspector > header")).toContainText("Ready");
+  await expect(page.getByText(/Soft Pause|no Evidence Cursor/u)).toHaveCount(0);
   await page.getByRole("button", { name: "New live run" }).click();
   await expect(page.getByRole("dialog", { name: "Start a live harness session" })).toContainText(`Project ${labelA}`);
   await page.getByPlaceholder("Task prompt for the harness run…").fill("prove the Project binding");
   await page.getByRole("button", { name: "Run harness" }).click();
+  await expect(page.getByRole("status").filter({ hasText: "Live run in progress" })).toBeVisible();
   await expect(page.locator(".debugger-brand")).toContainText(labelA);
 
   await projectButton(page, labelB).click();
@@ -163,23 +189,44 @@ test("keeps a live run bound to its starting Project across a sidebar switch", a
   await expect(page.locator(".debugger-brand")).toContainText(labelA);
   await expect(page.locator(".session-notebook")).toContainText(`bound project: ${labelA}`);
   expect(await realpath(observedRunCwd)).toBe(await realpath(projectA));
+  await expect.poll(() => runCount(projectA)).toBe(beforeA + 1);
+  expect(await runCount(projectB)).toBe(beforeB);
 });
 
-test("keeps configured Sources reachable before a Project is opened", async ({ page }) => {
+test("keeps configured Sources reachable without an active Project", async ({ page }) => {
+  const sourceSelections = [projectA, projectB];
   const sourceStudio = await startHarnessStudioServer({
     appDir: join(packageRoot, "dist", "app"),
     port: 0,
-    workspaceDirectoryPicker: async () => projectA,
-    workspaceSessionProvider: { discover: async () => ({ label: labelA, sessions: [] }) },
+    workspaceDirectoryPicker: async () => sourceSelections.shift(),
+    workspaceSessionProvider: { discover: async (selected) => ({ label: basename(selected), sessions: [] }) },
     sourceCatalog: [{ id: "evidence_fixture", kind: "evidence", label: "Frozen evidence", path: projectA }],
   });
   try {
+    await fetch(`${sourceStudio.url}/api/projects/open`, { method: "POST" });
+    const openedB = await (await fetch(`${sourceStudio.url}/api/projects/open`, { method: "POST" })).json();
+    await fetch(`${sourceStudio.url}/api/projects/${openedB.project.id}`, { method: "DELETE" });
     await page.setViewportSize(layouts[0]);
     await page.goto(sourceStudio.url);
     await expect(page.getByRole("dialog", { name: "Open a Project to start" })).toHaveCount(0);
-    await expect(page.getByLabel("Configured source Views")).toBeVisible();
+    await expect(page.getByLabel("Studio Views")).toBeVisible();
+    await expect(projectButton(page, labelA)).not.toHaveAttribute("aria-current", "true");
     await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Evidence results are ready." })).toBeVisible();
+
+    await page.goto(`${sourceStudio.url}/#/sessions`);
+    const openProject = page.getByRole("button", { name: "Open Project", exact: true });
+    await expect(openProject).toBeVisible();
+    await openProject.focus();
+    await expect(openProject).toBeFocused();
+
+    await page.goto(sourceStudio.url);
+    await page.setViewportSize(layouts[2]);
+    await expect(page.locator(".studio-context-title h1")).toHaveText("Overview");
+    const sourceControl = page.getByRole("button", { name: "Data sources (1 active)" });
+    await expect(sourceControl).toBeVisible();
+    expect((await sourceControl.boundingBox())?.width).toBeLessThanOrEqual(44);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)).toBe(0);
   } finally {
     await sourceStudio.close();
   }

--- a/packages/harness-studio/test/browser/tool-call.spec.mjs
+++ b/packages/harness-studio/test/browser/tool-call.spec.mjs
@@ -288,9 +288,10 @@ test("organizes configured surfaces around the Harness control plane", async ({ 
   await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Sessions");
   await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Debugger");
   await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Compare");
-  await page.getByRole("button", { name: "Open Project" }).first().click();
-  await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Project opening unavailable" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Open Project", exact: true })).toHaveCount(0);
+  await openDestination(page, "Sessions");
+  await expect(page.getByRole("heading", { name: "Open a Project" })).toBeVisible();
+  await expect(page.getByText("This Studio launcher does not provide Project discovery.")).toBeVisible();
 });
 
 test("compares a focused ACP pair across roles, views, filters, and evidence", async ({ page }, testInfo) => {
@@ -489,7 +490,7 @@ test("renders a keyboard-expandable failed and truncated Tool Call at 390px", as
   await page.getByRole("button", { name: "Run harness" }).click();
 
   await expect(page.getByRole("navigation", { name: "Session debugger controls" })).toHaveCount(0);
-  await expect(page.getByText("Live observation · no Evidence Cursor")).toBeVisible();
+  await expect(page.getByText("Run finished", { exact: true })).toBeVisible();
 
   await expect(page.locator(".run-status strong")).toHaveText("finished");
   const card = page.locator("details.tool-card");
@@ -599,7 +600,8 @@ test("renders the shell, local workspace intake, and empty compare surfaces at a
     }
 
     await openDestination(page, "Sessions");
-    await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Open a Project" })).toBeVisible();
+    await expect(page.getByText("This Studio launcher does not provide Project discovery.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Choose Project" })).toHaveCount(0);
     await assertRenderedContract(page);
     await page.screenshot({ path: testInfo.outputPath(`foundation-${layout.name}.png`) });
@@ -611,7 +613,7 @@ test("renders the shell, local workspace intake, and empty compare surfaces at a
     await page.screenshot({ path: testInfo.outputPath(`empty-${layout.name}.png`) });
 
     await openDestination(page, "Sessions");
-    await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Open a Project" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Choose Project" })).toHaveCount(0);
     await assertRenderedContract(page);
     await page.screenshot({ path: testInfo.outputPath(`sessions-${layout.name}.png`) });

--- a/packages/harness-studio/test/browser/tool-call.spec.mjs
+++ b/packages/harness-studio/test/browser/tool-call.spec.mjs
@@ -32,6 +32,7 @@ const SOURCE = `
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 let studio;
 let experimentStudio;
+let blockedExperimentStudio;
 let inspectorStudio;
 let lockedFixtureDir;
 let inspectorFixtureDir;
@@ -268,11 +269,18 @@ test.beforeAll(async () => {
       return compareSet;
     },
   });
+  blockedExperimentStudio = await startHarnessStudioServer({
+    appDir: resolve(packageRoot, "dist/app"),
+    experimentManifestPath: resolve(packageRoot, "../harness/examples/checkpoint-experiment/experiment.json"),
+    acpAgents: [{ id: "codex-acp", label: "Codex ACP", unavailableReason: "not used by Qoder" }],
+    experimentRunner: async () => { throw new Error("blocked comparison must not start"); },
+  });
 });
 
 test.afterAll(async () => {
   await studio?.close();
   await experimentStudio?.close();
+  await blockedExperimentStudio?.close();
   await inspectorStudio?.close();
   if (lockedFixtureDir) await rm(lockedFixtureDir, { recursive: true, force: true });
   if (inspectorFixtureDir) await rm(inspectorFixtureDir, { recursive: true, force: true });
@@ -292,6 +300,46 @@ test("organizes configured surfaces around the Harness control plane", async ({ 
   await openDestination(page, "Sessions");
   await expect(page.getByRole("heading", { name: "Open a Project" })).toBeVisible();
   await expect(page.getByText("This Studio launcher does not provide Project discovery.")).toBeVisible();
+});
+
+test("blocks an unavailable Qoder comparison without assigning ACP identity", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const browserErrors = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => browserErrors.push(`page: ${error.message}`));
+
+  await page.goto(blockedExperimentStudio.url);
+  await openDestination(page, "Compare");
+
+  await expect(page.getByLabel("AI 1 Agent")).toHaveCount(0);
+  await expect(page.getByLabel("AI 2 Agent")).toHaveCount(0);
+  await expect(page.locator(".simple-lane")).toHaveCount(2);
+  await expect(page.locator(".simple-lane").nth(0)).toContainText("Qoder");
+  await expect(page.locator(".simple-lane").nth(1)).toContainText("Qoder");
+  await expect(page.locator(".simple-compare-shell")).not.toContainText("Codex ACP");
+  await expect(page.getByRole("button", { name: "Run compare" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Advanced evidence" })).toBeDisabled();
+  await expect(page.locator(".simple-run-control [role=status]")).not.toHaveText("Ready");
+
+  await page.getByRole("button", { name: "Review setup" }).click();
+  await expect(page.getByText("Blocked", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("View status: Comparison")).toContainText("Comparison blocked");
+  await expect(page.locator(".builder-footer").getByText("Comparison blocked", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Checkpoint unavailable" })).toBeDisabled();
+
+  const directRunResponse = await fetch(new URL("api/experiment/runs", blockedExperimentStudio.url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ experimentId: "exp_browser_blocked" }),
+  });
+  const directRun = { status: directRunResponse.status, payload: await directRunResponse.json() };
+  expect(directRun.status).toBe(409);
+  expect(directRun.payload.error).toBeTruthy();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
+  expect(browserErrors).toEqual([]);
+  await page.screenshot({ path: testInfo.outputPath("blocked-qoder-compare-narrow.png"), fullPage: true });
 });
 
 test("compares a focused ACP pair across roles, views, filters, and evidence", async ({ page }, testInfo) => {

--- a/packages/harness-studio/test/browser/tool-call.spec.mjs
+++ b/packages/harness-studio/test/browser/tool-call.spec.mjs
@@ -50,7 +50,7 @@ async function openDestination(page, label) {
     await quickAction.click();
     return;
   }
-  const destination = page.getByRole("navigation", { name: "Harness control plane" }).getByRole("button", { name: new RegExp(`^${label}`) });
+  const destination = page.getByRole("navigation", { name: "Studio project and View navigation" }).getByRole("button", { name: new RegExp(`^${label}`) });
   const toggle = page.getByRole("button", { name: "Open Studio navigation" });
   if (await toggle.isVisible() && await toggle.getAttribute("aria-expanded") !== "true") await toggle.click();
   await destination.click();
@@ -285,12 +285,12 @@ test("organizes configured surfaces around the Harness control plane", async ({ 
   await page.goto(inspectorStudio.url);
 
   await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
-  await expect(page.getByRole("navigation", { name: "Harness control plane" })).toContainText("Sessions");
-  await expect(page.getByRole("navigation", { name: "Harness control plane" })).toContainText("Debugger");
-  await expect(page.getByRole("navigation", { name: "Harness control plane" })).toContainText("Compare");
-  await page.getByRole("button", { name: "Open workspace" }).first().click();
-  await expect(page.getByRole("heading", { name: "Open a project workspace" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Choose workspace" })).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Sessions");
+  await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Debugger");
+  await expect(page.getByRole("navigation", { name: "Studio project and View navigation" })).toContainText("Compare");
+  await page.getByRole("button", { name: "Open Project" }).first().click();
+  await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Project opening unavailable" })).toBeDisabled();
 });
 
 test("compares a focused ACP pair across roles, views, filters, and evidence", async ({ page }, testInfo) => {
@@ -303,7 +303,7 @@ test("compares a focused ACP pair across roles, views, filters, and evidence", a
 
   await page.goto(experimentStudio.url);
   await openDestination(page, "Compare");
-  await expect(page.getByLabel("Current project")).toHaveValue("better-harness");
+  await expect(page.getByLabel("Checkpoint project")).toContainText("better-harness");
   await expect(page.getByLabel("User prompt")).toBeVisible();
   await expect(page.getByLabel("AI 1 Agent")).toHaveValue("qodercli");
   await expect(page.getByLabel("AI 2 Agent")).toHaveValue("qodercli");
@@ -599,18 +599,20 @@ test("renders the shell, local workspace intake, and empty compare surfaces at a
     }
 
     await openDestination(page, "Sessions");
-    await expect(page.getByRole("heading", { name: "Open a project workspace" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Choose Project" })).toHaveCount(0);
     await assertRenderedContract(page);
     await page.screenshot({ path: testInfo.outputPath(`foundation-${layout.name}.png`) });
 
     await page.goto(inspectorStudio.url);
     await openDestination(page, "Compare");
-    await expect(page.getByRole("heading", { name: "Open a project workspace" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Open a Project" })).toBeVisible();
     await assertRenderedContract(page);
     await page.screenshot({ path: testInfo.outputPath(`empty-${layout.name}.png`) });
 
     await openDestination(page, "Sessions");
-    await expect(page.getByRole("button", { name: "Choose workspace" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Select a Project" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Choose Project" })).toHaveCount(0);
     await assertRenderedContract(page);
     await page.screenshot({ path: testInfo.outputPath(`sessions-${layout.name}.png`) });
   }
@@ -626,7 +628,7 @@ test("keeps Bench decision workspaces primary at all layout modes", async ({ pag
     await page.setViewportSize({ width: layout.width, height: layout.height });
     await page.goto(experimentStudio.url);
     await openDestination(page, "Compare");
-    await expect(page.getByLabel("Current project")).toBeVisible();
+    await expect(page.getByLabel("Checkpoint project")).toBeVisible();
     await expect(page.getByLabel("User prompt")).toBeInViewport();
     await expect(page.getByRole("button", { name: "Run compare" })).toBeInViewport();
     await expect(page.locator(".simple-lane")).toHaveCount(2);

--- a/packages/harness-studio/test/customization-collector.test.ts
+++ b/packages/harness-studio/test/customization-collector.test.ts
@@ -148,5 +148,8 @@ describe("Studio customization collector", () => {
       observation.kind === "host-collection" || observation.kind === "mcp-server-discovery")).toBe(true);
     expect(serialized).toContain("Workspace/.agents/skills/review/SKILL.md");
     expect(serialized).toContain("Claude customization collection failed");
+    expect(serialized).toContain("collector runtime failed unexpectedly");
+    expect(serialized).toContain("Analyze again to retry");
+    expect(serialized).not.toContain("private failure");
   });
 });

--- a/packages/harness-studio/test/customization-server.test.ts
+++ b/packages/harness-studio/test/customization-server.test.ts
@@ -105,6 +105,43 @@ describe("Studio customization analysis routes", () => {
     expect(selected).toBe(launchWorkspace);
   });
 
+  it("does not publish analysis completed for a previously active Project", async () => {
+    const appDir = await tempDirectory("customization-binding-app-");
+    const projectA = await tempDirectory("customization-binding-a-");
+    const projectB = await tempDirectory("customization-binding-b-");
+    await writeFile(join(appDir, "index.html"), "<!doctype html><title>fixture</title>", "utf8");
+    const selections = [projectA, projectB];
+    let calls = 0;
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceDirectoryPicker: async () => selections.shift(),
+      workspaceSessionProvider: { discover: async (workspace) => ({ label: workspace, sessions: [] }) },
+      customizationCollector: {
+        analyze: async () => {
+          calls += 1;
+          await gate;
+          return emptyAnalysis();
+        },
+      },
+    });
+    expect((await fetch(`${started.url}/api/projects/open`, { method: "POST" })).status).toBe(200);
+
+    const pending = fetch(`${started.url}/api/customizations/analyze`, { method: "POST" });
+    await viWaitFor(() => calls === 1);
+    expect((await fetch(`${started.url}/api/projects/open`, { method: "POST" })).status).toBe(200);
+    release?.();
+
+    const stale = await pending;
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({
+      error: "The active Project changed before customization analysis completed. Run the analysis again for the current Project.",
+    });
+    expect(await (await fetch(`${started.url}/api/config`)).json()).toMatchObject({ customizationAnalyzed: false });
+    expect((await fetch(`${started.url}/api/customizations`)).status).toBe(404);
+  });
+
   it("rejects private fields returned by an injected collector", async () => {
     const appDir = await tempDirectory("customization-app-");
     const launchWorkspace = await tempDirectory("customization-private-workspace-");

--- a/packages/harness-studio/test/experiment-setup.test.ts
+++ b/packages/harness-studio/test/experiment-setup.test.ts
@@ -4,6 +4,7 @@ import {
   countLaneMaterializations,
   deriveCompareScenario,
   deriveRequestProvenance,
+  isExperimentRunnable,
   type ExperimentSetupPreview,
 } from "../src/contracts/experiment-setup.js";
 
@@ -62,5 +63,10 @@ describe("checkpoint-backed compare setup", () => {
     };
 
     expect(canLockCompare(setup)).toBe(true);
+    expect(isExperimentRunnable(setup)).toBe(true);
+    expect(isExperimentRunnable({
+      ...setup,
+      checkpointSource: { ...setup.checkpointSource, status: "unavailable", limitation: "Revision missing." },
+    })).toBe(false);
   });
 });

--- a/packages/harness-studio/test/inspector-workspace-provider.test.mjs
+++ b/packages/harness-studio/test/inspector-workspace-provider.test.mjs
@@ -3,6 +3,62 @@ import { describe, expect, it, vi } from "vitest";
 import { createInspectorWorkspaceSessionProvider } from "../scripts/inspector-workspace-provider.mjs";
 
 describe("Inspector workspace provider", () => {
+  it("keeps Session discovery available for a Project without Git history", async () => {
+    const collect = vi.fn(async () => ({ providers: [], sessions: [] }));
+    const collectCommits = vi.fn();
+    const collectCheckpoints = vi.fn();
+    const provider = createInspectorWorkspaceSessionProvider({
+      collect,
+      collectCommits,
+      collectCheckpoints,
+      repoRootFor: () => { throw new Error("not a Git repository"); },
+      platforms: ["codex"],
+    });
+
+    const result = await provider.discover("/private/plain-project");
+
+    expect(collect).toHaveBeenCalledWith(expect.objectContaining({
+      workspace: "/private/plain-project",
+      repoRoot: "/private/plain-project",
+    }));
+    expect(collectCommits).not.toHaveBeenCalled();
+    expect(collectCheckpoints).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ label: "plain-project", sessions: [] });
+    expect(result.inspectorReport.diagnostics).toContain("Git history is unavailable for this Project; Session evidence remains available.");
+  });
+
+  it("keeps Git history when Entire checkpoint discovery fails", async () => {
+    const collect = vi.fn(async () => ({ providers: [], sessions: [] }));
+    const provider = createInspectorWorkspaceSessionProvider({
+      collect,
+      collectCommits: vi.fn(() => ({
+        repoRoot: "/private/repository",
+        commits: [{
+          hash: "0123456789abcdef",
+          shortHash: "0123456",
+          subject: "retain history",
+          authorName: "Developer",
+          authoredAt: "2026-08-20T09:06:00.000Z",
+          committedAt: "2026-08-20T09:06:00.000Z",
+          files: [],
+          sessionTrailers: [],
+          sessionLinks: [],
+        }],
+      })),
+      collectCheckpoints: vi.fn(() => { throw new Error("checkpoint unavailable"); }),
+      repoRootFor: () => "/private/repository",
+      platforms: ["codex"],
+    });
+
+    const result = await provider.discover("/private/repository");
+
+    expect(result.inspectorReport.commits).toEqual([
+      expect.objectContaining({ shortHash: "0123456", subject: "retain history" }),
+    ]);
+    expect(result.inspectorReport.diagnostics).toContain("Entire checkpoint evidence is unavailable; Git history remains available.");
+    expect(result.inspectorReport.diagnostics).not.toContain("Git history is unavailable for this Project; Session evidence remains available.");
+  });
+
   it("reuses the injected multi-provider collector and projects privacy-safe Session evidence", async () => {
     const collect = vi.fn(async () => ({
       providers: [

--- a/packages/harness-studio/test/project-server.test.ts
+++ b/packages/harness-studio/test/project-server.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startHarnessStudioServer, type StartedHarnessStudioServer } from "../src/server/server.js";
-import type { StudioProjectCatalog, StudioProjectDescriptor } from "../src/contracts/studio-project.js";
+import { MAX_STUDIO_PROJECTS, type StudioProjectCatalog, type StudioProjectDescriptor } from "../src/contracts/studio-project.js";
+import { DirectoryPickerUnavailableError } from "../src/server/workspace/native-directory-picker.js";
 
 let started: StartedHarnessStudioServer | undefined;
 const directories: string[] = [];
@@ -27,6 +28,20 @@ async function json<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 describe("Studio Project catalog", () => {
+  it("preserves actionable native picker availability errors", async () => {
+    const appDir = await directory("studio-project-picker-app-");
+    await writeFile(join(appDir, "index.html"), "<!doctype html><title>Project fixture</title>", "utf8");
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceDirectoryPicker: async () => { throw new DirectoryPickerUnavailableError("No supported native directory chooser is installed (expected zenity or kdialog)."); },
+      workspaceSessionProvider: { discover: async () => ({ label: "unused", sessions: [] }) },
+    });
+
+    const response = await fetch(`${started.url}/api/projects/open`, { method: "POST" });
+    expect(response.status).toBe(501);
+    expect(await response.json()).toEqual({ error: "No supported native directory chooser is installed (expected zenity or kdialog)." });
+  });
+
   it("registers, refreshes, switches, rolls back failed discovery, and removes opaque Projects", async () => {
     const appDir = await directory("studio-project-app-");
     await writeFile(join(appDir, "index.html"), "<!doctype html><title>Project fixture</title>", "utf8");
@@ -114,6 +129,61 @@ describe("Studio Project catalog", () => {
     await json(`${started.url}/api/projects/${openedB.project.id}`, { method: "DELETE" });
     expect(await json<StudioProjectCatalog>(`${started.url}/api/projects`)).toMatchObject({ projects: [] });
     expect(await json<{ connected: boolean }>(`${started.url}/api/workspace`)).toMatchObject({ connected: false });
+  });
+
+  it("retains a completed run in its starting Project after the active Project changes", async () => {
+    const appDir = await directory("studio-project-run-app-");
+    await writeFile(join(appDir, "index.html"), "<!doctype html><title>Project run fixture</title>", "utf8");
+    const projectA = await directory("studio-project-run-a-");
+    const projectB = await directory("studio-project-run-b-");
+    const selections = [projectA, projectB];
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceDirectoryPicker: async () => selections.shift(),
+      workspaceSessionProvider: { discover: async (selected) => ({ label: basename(selected), sessions: [] }) },
+    });
+
+    const openedA = await json<{ project: StudioProjectDescriptor; revision: number }>(`${started.url}/api/projects/open`, { method: "POST" });
+    await json(`${started.url}/api/projects/open`, { method: "POST" });
+    const saved = await fetch(`${started.url}/api/runs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Project-Id": openedA.project.id,
+        "X-Harness-Project-Revision": String(openedA.revision),
+      },
+      body: JSON.stringify({
+        prompt: "retain the starting Project",
+        status: "finished",
+        runId: "run_bound_a",
+        threadId: "thread_bound_a",
+        warnings: [],
+        timeline: [],
+      }),
+    });
+
+    expect(saved.status).toBe(201);
+    expect((await readdir(join(projectA, ".harness-studio-runs"))).filter((name) => name.endsWith(".json"))).toHaveLength(1);
+    expect(await readdir(join(projectB, ".harness-studio-runs")).catch(() => [])).toEqual([]);
+  });
+
+  it("bounds the process-local Project catalog", async () => {
+    const appDir = await directory("studio-project-limit-app-");
+    await writeFile(join(appDir, "index.html"), "<!doctype html><title>Project limit fixture</title>", "utf8");
+    const selections = await Promise.all(Array.from({ length: MAX_STUDIO_PROJECTS + 1 }, (_, index) => directory(`studio-project-limit-${index}-`)));
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceDirectoryPicker: async () => selections.shift(),
+      workspaceSessionProvider: { discover: async (selected) => ({ label: basename(selected), sessions: [] }) },
+    });
+
+    for (let index = 0; index < MAX_STUDIO_PROJECTS; index += 1) {
+      expect((await fetch(`${started.url}/api/projects/open`, { method: "POST" })).status).toBe(200);
+    }
+    const overflow = await fetch(`${started.url}/api/projects/open`, { method: "POST" });
+    expect(overflow.status).toBe(429);
+    expect(await overflow.json()).toEqual({ error: `Studio remembers at most ${MAX_STUDIO_PROJECTS} Projects. Remove one before opening another.` });
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`)).projects).toHaveLength(MAX_STUDIO_PROJECTS);
   });
 });
 

--- a/packages/harness-studio/test/project-server.test.ts
+++ b/packages/harness-studio/test/project-server.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startHarnessStudioServer, type StartedHarnessStudioServer } from "../src/server/server.js";
+import type { StudioProjectCatalog, StudioProjectDescriptor } from "../src/contracts/studio-project.js";
+
+let started: StartedHarnessStudioServer | undefined;
+const directories: string[] = [];
+
+afterEach(async () => {
+  await started?.close();
+  started = undefined;
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+async function directory(prefix: string): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), prefix));
+  directories.push(value);
+  return value;
+}
+
+async function json<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  expect(response.ok).toBe(true);
+  return await response.json() as T;
+}
+
+describe("Studio Project catalog", () => {
+  it("registers, refreshes, switches, rolls back failed discovery, and removes opaque Projects", async () => {
+    const appDir = await directory("studio-project-app-");
+    await writeFile(join(appDir, "index.html"), "<!doctype html><title>Project fixture</title>", "utf8");
+    const projectA = await directory("studio-project-a-");
+    const projectB = await directory("studio-project-b-");
+    const selections = [projectA, projectB];
+    const discoveries: string[] = [];
+    let failProjectB = false;
+    let blockProjectB = false;
+    let releaseProjectB: (() => void) | undefined;
+    const projectBRelease = new Promise<void>((resolveRelease) => { releaseProjectB = resolveRelease; });
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceDirectoryPicker: async () => selections.shift(),
+      workspaceSessionProvider: {
+        discover: async (selected) => {
+          discoveries.push(selected);
+          if (failProjectB && basename(selected) === basename(projectB)) throw new Error("fixture discovery failure");
+          if (blockProjectB && basename(selected) === basename(projectB)) await projectBRelease;
+          return {
+            label: basename(selected) === basename(projectB)
+              ? `C:\\Users\\private\\${basename(projectB)}`
+              : selected,
+            sessions: [],
+          };
+        },
+      },
+    });
+
+    const initialCatalog = await fetch(`${started.url}/api/projects`);
+    expect(initialCatalog.headers.get("cache-control")).toBe("no-store");
+    expect(await initialCatalog.json()).toMatchObject({ revision: 0, projects: [], stage: "idle" });
+    const openedA = await json<{ project: StudioProjectDescriptor; revision: number }>(`${started.url}/api/projects/open`, { method: "POST" });
+    const openedB = await json<{ project: StudioProjectDescriptor; revision: number }>(`${started.url}/api/projects/open`, { method: "POST" });
+    expect(openedA.project.id).toMatch(/^project_[a-f0-9]{32}$/u);
+    expect(openedB.project.id).not.toBe(openedA.project.id);
+    expect(openedB.project.label).toBe(basename(projectB));
+    expect(openedB.revision).toBeGreaterThan(openedA.revision);
+
+    const catalog = await json<StudioProjectCatalog>(`${started.url}/api/projects`);
+    expect(catalog).toMatchObject({ activeProjectId: openedB.project.id, revision: openedB.revision });
+    expect(catalog.projects).toHaveLength(2);
+    expect(JSON.stringify(catalog)).not.toContain(projectA);
+    expect(JSON.stringify(catalog)).not.toContain(projectB);
+
+    const activatedA = await json<{ revision: number }>(`${started.url}/api/projects/${openedA.project.id}/activate`, { method: "POST" });
+    expect(activatedA.revision).toBeGreaterThan(openedB.revision);
+    expect(await json<{ label: string }>(`${started.url}/api/workspace`)).toMatchObject({ label: basename(projectA) });
+
+    const refreshedA = await json<{ revision: number }>(`${started.url}/api/projects/${openedA.project.id}/refresh`, { method: "POST" });
+    expect(refreshedA.revision).toBeGreaterThan(activatedA.revision);
+    expect(discoveries.filter((path) => basename(path) === basename(projectA))).toHaveLength(3);
+
+    failProjectB = true;
+    const failed = await fetch(`${started.url}/api/projects/${openedB.project.id}/activate`, { method: "POST" });
+    expect(failed.status).toBe(422);
+    expect(await failed.json()).toEqual({ error: "Studio could not refresh the requested Project. The previous Project remains active." });
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`)).projects.find((project) => project.id === openedB.project.id)).toMatchObject({ availability: "unavailable" });
+    expect(await json<{ id: string; revision: number; label: string }>(`${started.url}/api/workspace`)).toMatchObject({
+      id: openedA.project.id,
+      revision: refreshedA.revision,
+      label: basename(projectA),
+    });
+
+    const hostile = await fetch(`${started.url}/api/projects/${openedA.project.id}/refresh`, { method: "POST", headers: { Origin: "https://hostile.example" } });
+    expect(hostile.status).toBe(403);
+    failProjectB = false;
+    blockProjectB = true;
+    const pendingActivation = fetch(`${started.url}/api/projects/${openedB.project.id}/activate`, { method: "POST" });
+    await waitForStage(started.url, "discovering");
+    const concurrentRemoval = await fetch(`${started.url}/api/projects/${openedB.project.id}`, { method: "DELETE" });
+    expect(concurrentRemoval.status).toBe(409);
+    releaseProjectB?.();
+    expect((await pendingActivation).status).toBe(200);
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`)).projects.find((project) => project.id === openedB.project.id)).toMatchObject({ availability: "ready" });
+
+    await rm(projectA, { recursive: true, force: true });
+    const missingDirectory = await fetch(`${started.url}/api/projects/${openedA.project.id}/activate`, { method: "POST" });
+    expect(missingDirectory.status).toBe(422);
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`))).toMatchObject({ activeProjectId: openedB.project.id });
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`)).projects.find((project) => project.id === openedA.project.id)).toMatchObject({ availability: "unavailable" });
+
+    await json(`${started.url}/api/projects/${openedA.project.id}`, { method: "DELETE" });
+    expect((await json<StudioProjectCatalog>(`${started.url}/api/projects`)).projects.map((project) => project.id)).toEqual([openedB.project.id]);
+    await json(`${started.url}/api/projects/${openedB.project.id}`, { method: "DELETE" });
+    expect(await json<StudioProjectCatalog>(`${started.url}/api/projects`)).toMatchObject({ projects: [] });
+    expect(await json<{ connected: boolean }>(`${started.url}/api/workspace`)).toMatchObject({ connected: false });
+  });
+});
+
+async function waitForStage(serverUrl: string, stage: "discovering"): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const catalog = await json<StudioProjectCatalog>(`${serverUrl}/api/projects`);
+    if (catalog.stage === stage) return;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+  }
+  throw new Error(`Project catalog did not reach ${stage}.`);
+}

--- a/packages/harness-studio/test/server.test.ts
+++ b/packages/harness-studio/test/server.test.ts
@@ -26,6 +26,15 @@ const ACP_AGENT_FIXTURE = resolve(
   "../../harness/test/fixtures/acp-agent.mjs",
 );
 
+const READY_CHECKPOINT_SOURCE = {
+  status: "ready" as const,
+  adapter: { id: "test-checkpoint-v1", label: "Test checkpoint" },
+  resource: { label: "Repository", value: "better-harness" },
+  revision: { label: "Revision", value: "fixture-ready" },
+  materialization: { label: "Isolated checkout", value: "10 copies", timing: "on-run" as const, count: 10 },
+  capabilities: { isolatedMaterialization: true, observedHistory: true, preserveResult: true },
+};
+
 const SOURCE = `
   language 0.3
   skill require-tests {
@@ -234,6 +243,7 @@ describe("harness-studio server", () => {
       artifactsEnabled: false,
       evidenceEnabled: true,
       experimentEnabled: false,
+      experimentRunnable: false,
       gitEnabled: false,
       harnessMode: "none",
       historyEnabled: false,
@@ -1115,6 +1125,8 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath: EXPERIMENT_MANIFEST,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
+      acpAgents: [{ id: "codex-acp", label: "Codex ACP", unavailableReason: "not used by Qoder" }],
       experimentRunner: async (options) => {
         submittedPrompt = options.promptOverride;
         options.onEvent?.({
@@ -1162,7 +1174,7 @@ describe("harness-studio server", () => {
     expect(preview.setup).toMatchObject({
       scenario: "historical-replay",
       checkpointSource: {
-        status: "unavailable",
+        status: "ready",
         materialization: { timing: "on-run", count: 10 },
       },
       request: { provenance: "unverified-history" },
@@ -1175,6 +1187,11 @@ describe("harness-studio server", () => {
     });
     expect(preview.observedCallPages.history).toMatchObject({ complete: true, malformedLines: 0 });
     expect(preview).not.toHaveProperty("observedEvents");
+    expect(preview).not.toHaveProperty("acpAgents");
+    expect(await (await fetch(`${started.url}/api/config`)).json()).toMatchObject({
+      experimentEnabled: true,
+      experimentRunnable: true,
+    });
 
     const observedPage = await (await fetch(`${started.url}/api/experiment/observed-calls?laneId=history&limit=100`)).json();
     expect(observedPage.complete).toBe(true);
@@ -1198,6 +1215,14 @@ describe("harness-studio server", () => {
     expect(body).not.toContain('"type":"tool.requested"');
     expect(submittedPrompt).toBe("Use this live request exactly.\n");
 
+    const qoderAgentSelection = await fetch(`${started.url}/api/experiment/runs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentIds: { "fresh-default": "codex-acp" } }),
+    });
+    expect(qoderAgentSelection.status).toBe(400);
+    expect(await qoderAgentSelection.json()).toMatchObject({ error: expect.stringContaining("only for ACP-hosted") });
+
     const emptyPrompt = await fetch(`${started.url}/api/experiment/runs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1205,6 +1230,37 @@ describe("harness-studio server", () => {
     });
     expect(emptyPrompt.status).toBe(400);
     expect(await emptyPrompt.json()).toMatchObject({ error: expect.stringContaining("non-empty") });
+  });
+
+  it("blocks execution when the checkpoint source is unavailable", async () => {
+    const appDir = await makeAppDir();
+    let runnerCalled = false;
+    started = await startHarnessStudioServer({
+      appDir,
+      experimentManifestPath: EXPERIMENT_MANIFEST,
+      experimentRunner: async () => {
+        runnerCalled = true;
+        return {} as never;
+      },
+    });
+
+    const preview = await (await fetch(`${started.url}/api/experiment`)).json();
+    expect(preview.setup.checkpointSource.status).toBe("unavailable");
+    expect(preview).not.toHaveProperty("acpAgents");
+    expect(await (await fetch(`${started.url}/api/config`)).json()).toMatchObject({
+      experimentEnabled: true,
+      experimentRunnable: false,
+    });
+
+    const response = await fetch(`${started.url}/api/experiment/runs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ experimentId: "exp_blocked_checkpoint" }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: expect.any(String) });
+    expect(runnerCalled).toBe(false);
   });
 
   it("rejects cross-origin experiment execution", async () => {
@@ -1230,6 +1286,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       experimentRunner: async () => ({} as never),
     });
 
@@ -1252,6 +1309,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       acpAgent: alpha,
       acpAgents: [
         { id: "alpha", label: "Alpha ACP", agent: alpha },
@@ -1300,6 +1358,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       acpAgent: alpha,
       acpAgents: [
         { id: "alpha", label: "Alpha ACP", agent: alpha },
@@ -1332,6 +1391,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       acpAgent: { command: process.execPath, args: [ACP_AGENT_FIXTURE] },
       experimentRunner: async (options) => {
         factoryConfigured = options.executorFactory !== undefined;
@@ -1355,6 +1415,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath: EXPERIMENT_MANIFEST,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       experimentRunner: (options) => new Promise((_, reject) => {
         options.signal?.addEventListener("abort", () => reject(options.signal?.reason), { once: true });
       }),
@@ -1379,6 +1440,7 @@ describe("harness-studio server", () => {
     started = await startHarnessStudioServer({
       appDir,
       experimentManifestPath: EXPERIMENT_MANIFEST,
+      checkpointSourcePreview: READY_CHECKPOINT_SOURCE,
       experimentRunner: (options) => new Promise((_, reject) => {
         options.signal?.addEventListener("abort", () => {
           resolveAborted();

--- a/packages/harness-studio/test/server.test.ts
+++ b/packages/harness-studio/test/server.test.ts
@@ -242,6 +242,7 @@ describe("harness-studio server", () => {
       workspaceDiscoveryEnabled: false,
       workspaceConnected: false,
       projectRevision: 0,
+      projectExecutionEnabled: false,
       sessionCount: 0,
       inputCount: 0,
       intentAnalysisEnabled: false,
@@ -783,7 +784,10 @@ describe("harness-studio server", () => {
 
   it("opens a browser-selected workspace, indexes Sessions, and compares two retained runs", async () => {
     const appDir = await makeAppDir();
-    started = await startHarnessStudioServer({ appDir });
+    started = await startHarnessStudioServer({
+      appDir,
+      workspaceSessionProvider: { discover: async () => ({ label: "unused-local-project", sessions: [] }) },
+    });
     const privateImportLabel = "C:\\Users\\private\\review-sessions";
     const created = await fetch(`${started.url}/api/workspaces?label=${encodeURIComponent(privateImportLabel)}`, { method: "POST" });
     expect(created.status).toBe(201);
@@ -807,8 +811,20 @@ describe("harness-studio server", () => {
     expect(projects).not.toContain(privateImportLabel);
     expect(projects).not.toContain("Users");
 
-    const config = await (await fetch(`${started.url}/api/config`)).json() as { workspaceConnected: boolean; sessionCount: number };
-    expect(config).toMatchObject({ workspaceConnected: true, sessionCount: 2 });
+    const config = await (await fetch(`${started.url}/api/config`)).json() as { workspaceConnected: boolean; projectExecutionEnabled: boolean; sessionCount: number };
+    expect(config).toMatchObject({ workspaceConnected: true, projectExecutionEnabled: false, sessionCount: 2 });
+    const activeProject = await (await fetch(`${started.url}/api/projects`)).json() as { activeProjectId: string; revision: number };
+    const runAttempt = await fetch(`${started.url}/agui`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Project-Id": activeProject.activeProjectId,
+        "X-Harness-Project-Revision": String(activeProject.revision),
+      },
+      body: JSON.stringify({ threadId: "imported-thread", runId: "imported-run", messages: [{ role: "user", content: "must not execute" }] }),
+    });
+    expect(runAttempt.status).toBe(422);
+    expect(await runAttempt.json()).toEqual({ error: "The selected Project is read-only evidence and cannot host a live run." });
     const catalog = await (await fetch(`${started.url}/api/sessions`)).json() as { sessions: Array<{ id: string; prompt: string }> };
     expect(catalog.sessions.map((session) => session.id)).toEqual(["run_right", "run_left"]);
     const debuggerSession = await (await fetch(`${started.url}/api/sessions/run_left/debugger`)).json();
@@ -835,6 +851,39 @@ describe("harness-studio server", () => {
     const traversal = await fetch(`${started.url}/api/workspaces/${sessionId}/files?path=${encodeURIComponent("../run_escape.json")}`, { method: "PUT", body: "{}" });
     expect(traversal.status).toBe(400);
     expect((await fetch(`${started.url}/api/workspaces/${sessionId}/commit`, { method: "POST" })).status).toBe(422);
+    expect((await fetch(`${started.url}/api/workspaces/${sessionId}`, { method: "DELETE" })).status).toBe(200);
+  });
+
+  it("serializes upload, commit, and abort operations for one workspace import", async () => {
+    const appDir = await makeAppDir();
+    started = await startHarnessStudioServer({ appDir });
+    const created = await fetch(`${started.url}/api/workspaces`, { method: "POST" });
+    const { sessionId } = await created.json() as { sessionId: string };
+    let finishUpload!: () => void;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{\"partial\":"));
+        finishUpload = () => {
+          controller.enqueue(new TextEncoder().encode("true}"));
+          controller.close();
+        };
+      },
+    });
+    const upload = fetch(
+      `${started.url}/api/workspaces/${sessionId}/files?path=run_serialized.json`,
+      { method: "PUT", body, duplex: "half" } as RequestInit & { duplex: "half" },
+    );
+
+    let conflictingStatus = 0;
+    const deadline = Date.now() + 2_000;
+    while (conflictingStatus !== 409 && Date.now() < deadline) {
+      conflictingStatus = (await fetch(`${started.url}/api/workspaces/${sessionId}/commit`, { method: "POST" })).status;
+      if (conflictingStatus !== 409) await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+    }
+    expect(conflictingStatus).toBe(409);
+    expect((await fetch(`${started.url}/api/workspaces/${sessionId}`, { method: "DELETE" })).status).toBe(409);
+    finishUpload();
+    expect((await upload).status).toBe(201);
     expect((await fetch(`${started.url}/api/workspaces/${sessionId}`, { method: "DELETE" })).status).toBe(200);
   });
 
@@ -1588,6 +1637,55 @@ describe("harness-studio CLI", () => {
   it("accepts an empty startup so Studio can acquire artifacts in the UI", () => {
     expect(parseHarnessStudioArgs([])).toMatchObject({ host: "127.0.0.1", port: 3311 });
     expect(parseHarnessStudioArgs([]).error).toBeUndefined();
+  });
+
+  it("prints its package version without opening a server", async () => {
+    const out: string[] = [];
+    const errors: string[] = [];
+
+    const code = await runHarnessStudioCli(["--version"], {
+      stdout: (text) => out.push(text),
+      stderr: (text) => errors.push(text),
+    });
+
+    expect(code).toBe(0);
+    expect(out.join("").trim()).toBe("0.1.1");
+    expect(errors).toEqual([]);
+  });
+
+  it("preserves the first invalid option and does not consume a following flag as a value", () => {
+    expect(parseHarnessStudioArgs(["--evidenc", "./evidence"]).error).toBe("Unknown option '--evidenc'.");
+    const missingHarness = parseHarnessStudioArgs(["--harness", "--port", "9999"]);
+    expect(missingHarness.error).toBe("--harness requires a value.");
+    expect(missingHarness.port).toBe(9999);
+  });
+
+  it("reports a missing harness file with the option and recovery context", async () => {
+    const errors: string[] = [];
+    const code = await runHarnessStudioCli(["--harness", "./not-a-real-agent.harness"], {
+      stdout: () => undefined,
+      stderr: (text) => errors.push(text),
+    });
+
+    expect(code).toBe(2);
+    expect(errors.join("")).toContain("--harness file was not found: ./not-a-real-agent.harness");
+    expect(errors.join("")).not.toContain("ENOENT");
+  });
+
+  it("explains how to recover when the requested port is occupied", async () => {
+    const appDir = await makeAppDir();
+    started = await startHarnessStudioServer({ appDir, port: 0 });
+    const occupiedPort = new URL(started.url).port;
+    const errors: string[] = [];
+
+    const code = await runHarnessStudioCli(["--port", occupiedPort], {
+      stdout: () => undefined,
+      stderr: (text) => errors.push(text),
+    });
+
+    expect(code).toBe(2);
+    expect(errors.join("")).toContain(`Port ${occupiedPort} is already in use`);
+    expect(errors.join("")).toContain("--port <n>");
   });
 
   it("parses repeated operator-provisioned Artifact Provider modules", () => {

--- a/packages/harness-studio/test/server.test.ts
+++ b/packages/harness-studio/test/server.test.ts
@@ -149,6 +149,14 @@ async function waitForWorkspaceOpenStage(
   throw new Error(`Workspace open stage did not become '${expected}'.`);
 }
 
+async function waitForCondition(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(message);
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
+  }
+}
+
 function retainedRunFixture(id: string, savedAt: string, prompt: string, tools: string[]) {
   return {
     id,
@@ -233,6 +241,7 @@ describe("harness-studio server", () => {
       workspaceWorkbenchEnabled: false,
       workspaceDiscoveryEnabled: false,
       workspaceConnected: false,
+      projectRevision: 0,
       sessionCount: 0,
       inputCount: 0,
       intentAnalysisEnabled: false,
@@ -472,6 +481,10 @@ describe("harness-studio server", () => {
     const workspace = await makeTempDir("studio-intent-workspace-");
     let observedPacket: IntentCorrelationPacketV1 | undefined;
     let invalid = false;
+    let block = false;
+    let analyzerCalls = 0;
+    let releaseAnalyzer: (() => void) | undefined;
+    const analyzerGate = new Promise<void>((resolveGate) => { releaseAnalyzer = resolveGate; });
     started = await startHarnessStudioServer({
       appDir,
       workspaceDirectoryPicker: async () => workspace,
@@ -498,7 +511,9 @@ describe("harness-studio server", () => {
       },
       intentAnalyzer: {
         analyze: async (packet) => {
+          analyzerCalls += 1;
           observedPacket = packet;
+          if (block) await analyzerGate;
           const proposed = proposedIntentFixture(packet);
           return invalid ? { ...proposed, claims: [{ ...proposed.claims[0], reviewStatus: "confirmed" }] } : proposed;
         },
@@ -521,6 +536,18 @@ describe("harness-studio server", () => {
 
     const crossOrigin = await fetch(`${started.url}/api/intent-analysis`, { method: "POST", headers: { Origin: "https://example.test" } });
     expect(crossOrigin.status).toBe(403);
+
+    invalid = false;
+    block = true;
+    const pending = fetch(`${started.url}/api/intent-analysis`, { method: "POST" });
+    await waitForCondition(() => analyzerCalls === 3, "Intent analyzer did not start.");
+    expect((await fetch(`${started.url}/api/projects/open`, { method: "POST" })).status).toBe(200);
+    releaseAnalyzer?.();
+    const stale = await pending;
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({
+      error: "The active Project changed before Intent analysis completed. Run the analysis again for the current Project.",
+    });
   });
 
   it("provides a default local harness and runs it inside the selected workspace", async () => {
@@ -560,11 +587,54 @@ describe("harness-studio server", () => {
       harnessMode: "workspace-default",
       workspaceDiscoveryEnabled: true,
     });
+    const beforeProject = await fetch(`${started.url}/agui`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "before-project-thread",
+        runId: "before-project-run",
+        messages: [{ role: "user", content: "must not start" }],
+      }),
+    });
+    expect(beforeProject.status).toBe(409);
+    expect(await beforeProject.json()).toEqual({ error: "Open a Project before starting a Project-scoped run." });
     expect(await (await fetch(`${started.url}/api/workspace/open`, { method: "POST" })).json()).toMatchObject({ opened: true });
+
+    const projectCatalog = await (await fetch(`${started.url}/api/projects`)).json() as { activeProjectId: string; revision: number };
+    const missingBinding = await fetch(`${started.url}/agui`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "missing-thread",
+        runId: "missing-run",
+        messages: [{ role: "user", content: "must not start" }],
+      }),
+    });
+    expect(missingBinding.status).toBe(409);
+    expect(await missingBinding.json()).toEqual({ error: "A Project id and revision are required to start a Project-scoped run." });
+    const staleBinding = await fetch(`${started.url}/agui`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Project-Id": projectCatalog.activeProjectId,
+        "X-Harness-Project-Revision": String(projectCatalog.revision - 1),
+      },
+      body: JSON.stringify({
+        threadId: "stale-thread",
+        runId: "stale-run",
+        messages: [{ role: "user", content: "must not start" }],
+      }),
+    });
+    expect(staleBinding.status).toBe(409);
+    expect(observedTask).toBeUndefined();
 
     const response = await fetch(`${started.url}/agui`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Project-Id": projectCatalog.activeProjectId,
+        "X-Harness-Project-Revision": String(projectCatalog.revision),
+      },
       body: JSON.stringify({
         threadId: "default-thread",
         runId: "default-run",
@@ -593,11 +663,16 @@ describe("harness-studio server", () => {
       acpAgentLabel: "Fixture ACP",
     });
     await fetch(`${started.url}/api/workspace/open`, { method: "POST" });
+    const projectCatalog = await (await fetch(`${started.url}/api/projects`)).json() as { activeProjectId: string; revision: number };
 
     const runId = "acp-run";
     const response = await fetch(`${started.url}/agui/acp`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Project-Id": projectCatalog.activeProjectId,
+        "X-Harness-Project-Revision": String(projectCatalog.revision),
+      },
       body: JSON.stringify({
         threadId: "acp-thread",
         runId,
@@ -709,7 +784,8 @@ describe("harness-studio server", () => {
   it("opens a browser-selected workspace, indexes Sessions, and compares two retained runs", async () => {
     const appDir = await makeAppDir();
     started = await startHarnessStudioServer({ appDir });
-    const created = await fetch(`${started.url}/api/workspaces?label=review-sessions`, { method: "POST" });
+    const privateImportLabel = "C:\\Users\\private\\review-sessions";
+    const created = await fetch(`${started.url}/api/workspaces?label=${encodeURIComponent(privateImportLabel)}`, { method: "POST" });
     expect(created.status).toBe(201);
     const { sessionId } = await created.json() as { sessionId: string };
 
@@ -727,6 +803,9 @@ describe("harness-studio server", () => {
     const committed = await fetch(`${started.url}/api/workspaces/${sessionId}/commit`, { method: "POST" });
     expect(committed.status).toBe(200);
     expect(await committed.json()).toEqual({ label: "review-sessions", sessionCount: 2, omittedCount: 1 });
+    const projects = await (await fetch(`${started.url}/api/projects`)).text();
+    expect(projects).not.toContain(privateImportLabel);
+    expect(projects).not.toContain("Users");
 
     const config = await (await fetch(`${started.url}/api/config`)).json() as { workspaceConnected: boolean; sessionCount: number };
     expect(config).toMatchObject({ workspaceConnected: true, sessionCount: 2 });

--- a/packages/harness-studio/test/studio-project.test.ts
+++ b/packages/harness-studio/test/studio-project.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isStudioProjectCatalog, STUDIO_PROJECT_CATALOG_KIND } from "../src/contracts/studio-project.js";
+import { parseStudioLocation, studioLocationHash } from "../src/app/shell/project-routing.js";
+
+const PROJECT_ID = `project_${"a".repeat(32)}`;
+const AREAS = new Set(["overview", "sessions", "compare"]);
+
+describe("Studio Project contracts", () => {
+  it("round-trips opaque Project and View routes while preserving legacy routes", () => {
+    expect(parseStudioLocation(`#/projects/${PROJECT_ID}/sessions`, AREAS)).toEqual({ projectId: PROJECT_ID, area: "sessions" });
+    expect(studioLocationHash({ projectId: PROJECT_ID, area: "compare" })).toBe(`#/projects/${PROJECT_ID}/compare`);
+    expect(parseStudioLocation("#/sessions", AREAS)).toEqual({ area: "sessions" });
+    expect(parseStudioLocation("#/projects/not-a-project/sessions", AREAS)).toEqual({ area: "overview" });
+    expect(parseStudioLocation(`#/projects/${PROJECT_ID}/sessions/extra`, AREAS)).toEqual({ area: "overview" });
+  });
+
+  it("accepts a bounded catalog and rejects inconsistent active Projects", () => {
+    const descriptor = {
+      id: PROJECT_ID,
+      label: "better-harness",
+      kind: "local" as const,
+      availability: "ready" as const,
+      lastOpenedAt: "2026-08-27T00:00:00.000Z",
+      sessionCount: 2,
+      inputCount: 1,
+      artifactCount: 3,
+      gitEnabled: true,
+      workspaceWorkbenchEnabled: true,
+    };
+    expect(isStudioProjectCatalog({
+      kind: STUDIO_PROJECT_CATALOG_KIND,
+      revision: 1,
+      activeProjectId: PROJECT_ID,
+      projects: [descriptor],
+      stage: "idle",
+    })).toBe(true);
+    expect(isStudioProjectCatalog({
+      kind: STUDIO_PROJECT_CATALOG_KIND,
+      revision: 1,
+      activeProjectId: PROJECT_ID,
+      projects: [descriptor],
+      stage: "removing",
+    })).toBe(true);
+    expect(isStudioProjectCatalog({
+      kind: STUDIO_PROJECT_CATALOG_KIND,
+      revision: 1,
+      activeProjectId: `project_${"b".repeat(32)}`,
+      projects: [descriptor],
+      stage: "idle",
+    })).toBe(false);
+    expect(isStudioProjectCatalog({
+      kind: STUDIO_PROJECT_CATALOG_KIND,
+      revision: 1,
+      projects: [{ ...descriptor, id: "../../workspace" }],
+      stage: "idle",
+    })).toBe(false);
+  });
+});

--- a/packages/harness-studio/test/studio-project.test.ts
+++ b/packages/harness-studio/test/studio-project.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isStudioProjectCatalog, STUDIO_PROJECT_CATALOG_KIND } from "../src/contracts/studio-project.js";
+import { isStudioProjectCatalog, MAX_STUDIO_PROJECTS, STUDIO_PROJECT_CATALOG_KIND } from "../src/contracts/studio-project.js";
 import { parseStudioLocation, studioLocationHash } from "../src/app/shell/project-routing.js";
 
 const PROJECT_ID = `project_${"a".repeat(32)}`;
@@ -52,6 +52,15 @@ describe("Studio Project contracts", () => {
       kind: STUDIO_PROJECT_CATALOG_KIND,
       revision: 1,
       projects: [{ ...descriptor, id: "../../workspace" }],
+      stage: "idle",
+    })).toBe(false);
+    expect(isStudioProjectCatalog({
+      kind: STUDIO_PROJECT_CATALOG_KIND,
+      revision: 1,
+      projects: Array.from({ length: MAX_STUDIO_PROJECTS + 1 }, (_, index) => ({
+        ...descriptor,
+        id: `project_${index.toString(16).padStart(32, "0")}`,
+      })),
       stage: "idle",
     })).toBe(false);
   });

--- a/packages/harness-studio/test/studio-shell-model.test.ts
+++ b/packages/harness-studio/test/studio-shell-model.test.ts
@@ -15,6 +15,7 @@ const EMPTY: StudioConfig = {
   artifactsEnabled: false,
   evidenceEnabled: false,
   experimentEnabled: false,
+  experimentRunnable: false,
   gitEnabled: false,
   harnessMode: "none",
   historyEnabled: false,
@@ -80,6 +81,7 @@ describe("Studio control-plane navigation", () => {
       artifactsEnabled: true,
       evidenceEnabled: true,
       experimentEnabled: true,
+      experimentRunnable: true,
       gitEnabled: true,
       harnessMode: "configured",
       historyEnabled: true,
@@ -130,6 +132,25 @@ describe("Studio control-plane navigation", () => {
     });
   });
 
+  it("does not advertise an exact zero Artifact count as usable evidence", () => {
+    const config: StudioConfig = { ...EMPTY, artifactsEnabled: true, artifactCount: 0, workspaceConnected: true };
+
+    expect(studioDestinations(config).find((destination) => destination.id === "artifacts")).toMatchObject({
+      availability: "partial",
+      status: "No observed outputs",
+    });
+    expect(studioOverview(config).secondaryActions).not.toContainEqual({ area: "artifacts", label: "Open Artifacts" });
+    expect(studioOverview(config).facts.find((fact) => fact.id === "artifacts")).toMatchObject({ value: "0", detail: "No observed outputs" });
+  });
+
+  it("labels Compare from its active surface", () => {
+    const config: StudioConfig = { ...EMPTY, experimentEnabled: true, experimentRunnable: true, evidenceEnabled: true, sessionCount: 3, workspaceConnected: true };
+
+    expect(studioDestinations(config, "bench").find((destination) => destination.id === "compare")?.status).toBe("Harness Bench");
+    expect(studioDestinations(config, "sessions").find((destination) => destination.id === "compare")?.status).toBe("Session compare");
+    expect(studioDestinations(config, "results").find((destination) => destination.id === "compare")?.status).toBe("Frozen results");
+  });
+
   it("does not present a live AG-UI endpoint as retained Inspector evidence or a Compare input", () => {
     const config: StudioConfig = { ...EMPTY, aguiEnabled: true, harnessMode: "configured" };
 
@@ -169,6 +190,7 @@ describe("Studio control-plane navigation", () => {
     const overview = studioOverview({
       ...EMPTY,
       experimentEnabled: true,
+      experimentRunnable: true,
       inspectorEnabled: true,
       customizationAnalysisEnabled: true,
     });
@@ -182,6 +204,19 @@ describe("Studio control-plane navigation", () => {
     expect(overview.secondaryActions).toEqual([
       { area: "customizations", label: "Analyze Customizations" },
     ]);
+  });
+
+  it("does not call an unavailable experiment ready outside the Experiment workbench", () => {
+    const config: StudioConfig = { ...EMPTY, experimentEnabled: true, experimentRunnable: false };
+
+    expect(studioDestinations(config, "bench").find((destination) => destination.id === "compare")).toMatchObject({
+      availability: "partial",
+      status: "Comparison blocked",
+    });
+    expect(studioOverview(config)).toMatchObject({
+      title: "Comparison setup needs attention.",
+      facts: [expect.objectContaining({ id: "experiment", value: "Blocked" })],
+    });
   });
 
   it("leaves workspace opening to the modal gate when discovery is available", () => {
@@ -198,6 +233,7 @@ describe("Studio control-plane navigation", () => {
     expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true }, false)).toBe(true);
     expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, evidenceEnabled: true }, true)).toBe(false);
     expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, artifactsEnabled: true }, false)).toBe(false);
+    expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, artifactsEnabled: true, artifactCount: 0 }, false)).toBe(true);
     expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, aguiEnabled: true, harnessMode: "configured" }, false)).toBe(false);
   });
 

--- a/packages/harness-studio/test/studio-shell-model.test.ts
+++ b/packages/harness-studio/test/studio-shell-model.test.ts
@@ -3,6 +3,7 @@ import {
   capabilitySummary,
   compareSurfaces,
   inspectorSurfaces,
+  studioProjectGateRequired,
   studioOverview,
   studioDestinations,
   type StudioConfig,
@@ -46,19 +47,19 @@ describe("Studio control-plane navigation", () => {
     expect(destinations.find((destination) => destination.id === "overview")).toMatchObject({ availability: "ready" });
     expect(destinations.find((destination) => destination.id === "sessions")).toMatchObject({
       availability: "partial",
-      status: "Open workspace",
+      status: "Open Project",
     });
     expect(destinations.find((destination) => destination.id === "inputs")).toMatchObject({
       availability: "foundation",
-      status: "Workspace required",
+      status: "Project required",
     });
     expect(destinations.find((destination) => destination.id === "artifacts")).toMatchObject({
       availability: "foundation",
-      status: "Workspace required",
+      status: "Project required",
     });
     expect(destinations.find((destination) => destination.id === "commits")).toMatchObject({
       availability: "foundation",
-      status: "Workspace required",
+      status: "Project required",
     });
     expect(destinations.find((destination) => destination.id === "debugger")).toMatchObject({
       availability: "foundation",
@@ -66,7 +67,7 @@ describe("Studio control-plane navigation", () => {
     });
     expect(destinations.find((destination) => destination.id === "compare")).toMatchObject({
       availability: "foundation",
-      status: "Workspace required",
+      status: "Project required",
     });
     expect(capabilitySummary(EMPTY)).toEqual({ ready: 1, partial: 1, foundation: 6 });
   });
@@ -134,7 +135,7 @@ describe("Studio control-plane navigation", () => {
     expect(compareSurfaces(config)).toEqual([]);
     expect(studioDestinations(config).find((destination) => destination.id === "sessions")).toMatchObject({
       availability: "partial",
-      status: "Open workspace",
+      status: "Open Project",
     });
     expect(studioDestinations(config).find((destination) => destination.id === "compare")).toMatchObject({
       availability: "foundation",
@@ -145,8 +146,8 @@ describe("Studio control-plane navigation", () => {
     const config: StudioConfig = { ...EMPTY, aguiEnabled: true, harnessMode: "workspace-default", workspaceDiscoveryEnabled: true };
 
     expect(studioDestinations(config).find((destination) => destination.id === "debugger")).toMatchObject({
-      availability: "ready",
-      status: "Local default",
+      availability: "foundation",
+      status: "Project required",
     });
     expect(inspectorSurfaces(config)).toEqual([]);
     expect(compareSurfaces(config)).toEqual([]);
@@ -189,6 +190,26 @@ describe("Studio control-plane navigation", () => {
       secondaryActions: [],
     });
     expect(overview.primaryAction).toBeUndefined();
+  });
+
+  it("requires an initial Project only when no independent configured context is available", () => {
+    expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true }, false)).toBe(true);
+    expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, evidenceEnabled: true }, true)).toBe(false);
+    expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, artifactsEnabled: true }, false)).toBe(false);
+    expect(studioProjectGateRequired({ ...EMPTY, workspaceDiscoveryEnabled: true, aguiEnabled: true, harnessMode: "configured" }, false)).toBe(false);
+  });
+
+  it("does not advertise the Project-default Debugger before a Project is active", () => {
+    const overview = studioOverview({
+      ...EMPTY,
+      aguiEnabled: true,
+      harnessMode: "workspace-default",
+      inspectorEnabled: true,
+    });
+
+    expect(overview.mode).toBe("configured");
+    expect(overview.facts.map((fact) => fact.id)).toEqual(["inspector"]);
+    expect(overview.secondaryActions).not.toContainEqual({ area: "debugger", label: "Open Debugger" });
   });
 
   it("summarizes connected workspace evidence without capability maturity totals", () => {

--- a/packages/harness-studio/test/studio-shell-model.test.ts
+++ b/packages/harness-studio/test/studio-shell-model.test.ts
@@ -22,6 +22,7 @@ const EMPTY: StudioConfig = {
   workspaceWorkbenchEnabled: false,
   workspaceDiscoveryEnabled: false,
   workspaceConnected: false,
+  projectExecutionEnabled: false,
   sessionCount: 0,
   inputCount: 0,
   intentAnalysisEnabled: false,
@@ -47,7 +48,7 @@ describe("Studio control-plane navigation", () => {
     expect(destinations.find((destination) => destination.id === "overview")).toMatchObject({ availability: "ready" });
     expect(destinations.find((destination) => destination.id === "sessions")).toMatchObject({
       availability: "partial",
-      status: "Open Project",
+      status: "Project required",
     });
     expect(destinations.find((destination) => destination.id === "inputs")).toMatchObject({
       availability: "foundation",
@@ -86,6 +87,7 @@ describe("Studio control-plane navigation", () => {
       workspaceWorkbenchEnabled: true,
       workspaceDiscoveryEnabled: true,
       workspaceConnected: true,
+      projectExecutionEnabled: true,
       sessionCount: 3,
       inputCount: 8,
       intentAnalysisEnabled: true,
@@ -135,7 +137,7 @@ describe("Studio control-plane navigation", () => {
     expect(compareSurfaces(config)).toEqual([]);
     expect(studioDestinations(config).find((destination) => destination.id === "sessions")).toMatchObject({
       availability: "partial",
-      status: "Open Project",
+      status: "Project required",
     });
     expect(studioDestinations(config).find((destination) => destination.id === "compare")).toMatchObject({
       availability: "foundation",
@@ -212,6 +214,22 @@ describe("Studio control-plane navigation", () => {
     expect(overview.secondaryActions).not.toContainEqual({ area: "debugger", label: "Open Debugger" });
   });
 
+  it("keeps imported retained-run Projects out of the default execution path", () => {
+    const config: StudioConfig = {
+      ...EMPTY,
+      aguiEnabled: true,
+      harnessMode: "workspace-default",
+      workspaceConnected: true,
+      projectExecutionEnabled: false,
+    };
+
+    expect(studioDestinations(config).find((destination) => destination.id === "debugger")).toMatchObject({
+      availability: "foundation",
+      status: "Read-only Project",
+    });
+    expect(studioOverview(config).secondaryActions).not.toContainEqual({ area: "debugger", label: "Open Debugger" });
+  });
+
   it("summarizes connected workspace evidence without capability maturity totals", () => {
     const overview = studioOverview({
       ...EMPTY,
@@ -220,6 +238,7 @@ describe("Studio control-plane navigation", () => {
       artifactCount: 6,
       gitEnabled: true,
       harnessMode: "workspace-default",
+      projectExecutionEnabled: true,
       workspaceWorkbenchEnabled: true,
       workspaceDiscoveryEnabled: true,
       workspaceConnected: true,

--- a/packages/harness/src/artifacts/model.ts
+++ b/packages/harness/src/artifacts/model.ts
@@ -497,6 +497,18 @@ export interface ArtifactBuildDiagnostic {
   column?: number;
 }
 
+export interface AgentReactBuildMetadata {
+  protocolVersion: "agent-react/1";
+  artifactDigest: ArtifactDigest;
+  buildDigest: ArtifactDigest;
+  buildPolicyDigest: ArtifactDigest;
+  view: {
+    id: string;
+    state: readonly { path: string; schema: string; version: number }[];
+    capabilities: readonly string[];
+  };
+}
+
 /** Immutable result of compiling one code-backed Artifact project. */
 export interface ArtifactBuildSnapshot {
   kind: typeof ARTIFACT_BUILD_SNAPSHOT_KIND;
@@ -511,6 +523,8 @@ export interface ArtifactBuildSnapshot {
   };
   previewUri?: string;
   diagnostics: ArtifactBuildDiagnostic[];
+  /** Present only for builds admitted by the AgentReact production profile. */
+  agentReact?: AgentReactBuildMetadata;
 }
 
 const ARTIFACT_FAMILIES = new Set<ArtifactFamily>(["documents", "images-diagrams", "data", "source-text", "other"]);
@@ -872,12 +886,34 @@ export function isArtifactBuildSnapshot(value: unknown): value is ArtifactBuildS
     || typeof value.runtime.version !== "string") return false;
   if (value.previewUri !== undefined && !isStudioArtifactPath(value.previewUri)) return false;
   if (value.status === "ready" && value.previewUri === undefined) return false;
+  if (value.agentReact !== undefined && !isAgentReactBuildMetadata(value.agentReact)) return false;
   return Array.isArray(value.diagnostics) && value.diagnostics.every((diagnostic) => isRecord(diagnostic)
     && (diagnostic.level === "warning" || diagnostic.level === "error")
     && typeof diagnostic.message === "string"
     && (diagnostic.source === undefined || typeof diagnostic.source === "string")
     && (diagnostic.line === undefined || typeof diagnostic.line === "number")
     && (diagnostic.column === undefined || typeof diagnostic.column === "number"));
+}
+
+function isAgentReactBuildMetadata(value: unknown): value is AgentReactBuildMetadata {
+  if (!isRecord(value)
+    || value.protocolVersion !== "agent-react/1"
+    || !isDigest(value.artifactDigest)
+    || !isDigest(value.buildDigest)
+    || !isDigest(value.buildPolicyDigest)
+    || !isRecord(value.view)
+    || typeof value.view.id !== "string"
+    || value.view.id === ""
+    || !Array.isArray(value.view.state)
+    || !Array.isArray(value.view.capabilities)) return false;
+  return value.view.state.every((entry) => isRecord(entry)
+    && typeof entry.path === "string"
+    && entry.path.startsWith("/")
+    && typeof entry.schema === "string"
+    && entry.schema !== ""
+    && Number.isSafeInteger(entry.version)
+    && Number(entry.version) > 0)
+    && value.view.capabilities.every((capability) => typeof capability === "string" && capability !== "");
 }
 
 function isArtifactDescriptor(value: unknown): value is ArtifactDescriptor {

--- a/packages/harness/src/artifacts/provider.ts
+++ b/packages/harness/src/artifacts/provider.ts
@@ -55,6 +55,7 @@ export interface ArtifactBuildRuntimeImplementation {
   version: string;
   module:
     | { kind: "source" }
+    | { kind: "agent-react" }
     | {
       kind: "virtual";
       source: string;

--- a/packages/harness/test/artifacts.test.ts
+++ b/packages/harness/test/artifacts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ARTIFACT_PROVIDER_API_VERSION,
   defineArtifactProvider,
+  isArtifactBuildSnapshot,
   isArtifactCatalogResponse,
   isArtifactDataSnapshot,
   type ArtifactDataSnapshot,
@@ -97,5 +98,34 @@ describe("Artifact provider SDK", () => {
     expect(isArtifactCatalogResponse(catalog)).toBe(true);
     catalog.artifacts[0]!.renderer.bindingId = "not-a-digest";
     expect(isArtifactCatalogResponse(catalog)).toBe(false);
+  });
+
+  it("validates AgentReact metadata on immutable build snapshots", () => {
+    const snapshot = {
+      kind: "ArtifactBuildSnapshotV1",
+      artifactId: "orders",
+      revisionId: DIGEST,
+      buildId: DIGEST,
+      sequence: 1,
+      status: "ready",
+      runtime: { id: "studio.sandboxed-react", version: "4" },
+      previewUri: `/api/artifacts/orders/revisions/${"a".repeat(64)}/builds/${"a".repeat(64)}/preview`,
+      diagnostics: [],
+      agentReact: {
+        protocolVersion: "agent-react/1",
+        artifactDigest: DIGEST,
+        buildDigest: DIGEST,
+        buildPolicyDigest: DIGEST,
+        view: {
+          id: "orders",
+          state: [{ path: "/orders", schema: "list", version: 1 }],
+          capabilities: ["studio.show-source"],
+        },
+      },
+    };
+
+    expect(isArtifactBuildSnapshot(snapshot)).toBe(true);
+    snapshot.agentReact.view.state[0]!.version = 0;
+    expect(isArtifactBuildSnapshot(snapshot)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- ship the spec-backed AgentReact production pipeline: immutable revisions, Oxc semantic compilation, confined linking, restartable Worker execution, opaque Current/Staging frames, and Host-owned state, Actions, observations, and addressing
- make Projects the persistent Studio scope so every View shares one opaque active Project, Project switch and run binding are revision-safe, and native filesystem paths remain server-side
- make the published CLI Project-first by bundling workspace discovery and customization runtimes, and add actionable CLI, bootstrap, empty-state, keyboard, and narrow-screen recovery
- close the release-review gaps: unavailable checkpoints are blocked consistently in UI and server, Qoder experiments never inherit ACP identity, Session Compare is semantic and responsive, and zero Artifact catalogs are not advertised as ready
- merge current `main` so native Session Artifact opening and the refined Compare hierarchy coexist with the Project-first shell and readiness boundaries

## Traceability

- Spec: `docs/specs/2026-08-27-agent-react-artifact-runtime-poc.md` — AR-AC-1 through AR-AC-30
- Spec: `docs/specs/2026-08-27-studio-project-first-workbench.md` — AC-1 through AC-9
- Spec: `docs/specs/2026-08-28-studio-published-first-run.md` — AC-1 through AC-15
- No external Story or Issue was provided; none is inferred.

## Validation

- Node 24 root `npm run check` passed: 1,545 root tests with 2 skipped, 173 Harness tests, 31 Harness UI tests, 489 Studio tests, generated-source verification, and package verification (597 npm entries / 859 runtime-zip entries)
- `npm run test:browser -w @qoder-ai/harness-studio` — 52 Chromium tests passed, including 1440x900, 1024x768, and 390x844 layouts with changed-surface console/page-error checks
- Studio build and typecheck passed; `npm pack -w @qoder-ai/harness-studio --dry-run --ignore-scripts` listed 1,142 files / 6.9 MB and both bundled runtimes
- `npx vitest run test/skills-docs/doc-link-graph.test.mjs` — 8 tests passed
- focused AgentReact/compile delivery suite passed 207 tests across 14 files; Intel macOS dependency-plan closure selected both pinned Oxc native bindings
- visual review confirmed the primary decision, focus, and bounded overflow for Project shell, blocked Qoder comparison, Session Compare, native Session Artifact opening, and refined Compare at wide, compact, and narrow widths

## Risk and delivery boundaries

- Oxc adds platform-specific native optional dependencies. Versions and integrity remain pinned behind `OxcCompilerPort`; Windows and Linux runtime claims still depend on their corresponding CI jobs.
- The Project catalog is process-local. Project ids are opaque, native paths stay server-side, and Project switching, imports, async analysis, and run retention are revision-bound.
- Experiment readiness is enforced again at the server before runner allocation. The manifest host is authoritative for Qoder versus ACP identity and Agent selection.
- The bundled discovery and customization entries are Node-only runtimes. Browser contracts expose bounded labels and safe failure categories, not commands, environment values, credentials, or native paths.
- Publication, release, version, changelog, tag creation, and release notes are not part of this PR.
