### PR TITLE
fix(plugin-lifecycle): match hyphenated npm package name for Pi host

### DIFF
--- a/scripts/host-support/profile-builders.mjs
+++ b/scripts/host-support/profile-builders.mjs
@@ -31,7 +31,7 @@ const DEFAULT_OBSERVATION_KIND = Object.freeze({
 });
 
 const BETTER_HARNESS_IDENTITY = Object.freeze({
-  names: ["better-harness", "@qoderai/better-harness"],
+  names: ["better-harness", "@qoderai/better-harness", "@qoder-ai/better-harness"],
   nativeIds: ["better-harness", "better-harness@better-harness", "better-harness/better-harness"],
   repositories: [
     "qoderai/better-harness",

--- a/test/plugins/plugin-lifecycle.test.mjs
+++ b/test/plugins/plugin-lifecycle.test.mjs
@@ -56,6 +56,7 @@ test("Better Harness identity matching rejects display-name-only candidates", ()
   assert.equal(matchesBetterHarnessPlugin({ displayName: "Better Harness", name: "other" }, profile), false);
   assert.equal(matchesBetterHarnessPlugin({ name: "@qoderai/better-harness" }, getHostProfile("pi")), true);
   assert.equal(matchesBetterHarnessPlugin({ piPackageSource: "git:github.com/QoderAI/better-harness" }, getHostProfile("pi")), true);
+  assert.equal(matchesBetterHarnessPlugin({ name: "@qoder-ai/better-harness", piPackageSource: "npm:@qoder-ai/better-harness" }, getHostProfile("pi")), true);
   assert.equal(matchesBetterHarnessPlugin({ id: "better-harness" }, profile), true);
   assert.equal(matchesBetterHarnessPlugin({ remotePluginId: "git+ssh://git@github.com/QoderAI/better-harness.git#main" }, profile), true);
 });


### PR DESCRIPTION
The Pi host reported not-installed after a user-scope npm install because the identity name list still had the pre-rename un-hyphenated @qoderai/better-harness entry, while the published package is @qoder-ai/better-harness. Keep the old entry for historical installs and add the hyphenated npm name so plugin status and doctor resolve the install state correctly.

Closes #126

## Summary

`plugin status --host pi` (and `doctor --platform pi`) now report `installed / enabled / <version> (same)` after a user-scope npm install, instead of `not-installed`.

One-line fix: the Better Harness identity name list in `scripts/host-support/profile-builders.mjs` still carried the pre-rename un-hyphenated `@qoderai/better-harness` entry, while the published npm package is `@qoder-ai/better-harness` (issue #65 rename fallout). The old entry is kept for historical installs and the hyphenated npm name is added, so the Pi package plugin's `name` / `piPackageSource` resolve again.

## Why

- Issue/Story: #126
- User or maintainer outcome: every user who installed the npm package into Pi (the README quickstart route) gets a truthful lifecycle status row consistent with `agent-customize inventory --provider pi`.

## Traceability and Scope

- Spec/ADR, if applicable: none (one-line identity-list fix, no behavior contract change)
- Acceptance criteria addressed: #126 "success looks like" — `plugin status --host pi` reports `installed / enabled / 0.6.4 (same)` after user-scope npm install
- Canonical owners changed: none
- Explicit non-goals: no change to other hosts' matching paths (repositories/nativeIds already normalize correctly, verified); no schema, inventory, or install-flow changes

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] Documentation/community
- [ ] Refactor with no intended behavior change
- [ ] Dependency, packaging, or infrastructure

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `npm test` (full suite) | 105 files, 1570 passed, 2 skipped |
| `npx vitest run test/plugins/plugin-lifecycle.test.mjs` | 29/29 passed (incl. new npm-name matching assertion) |
| `npm run pack:verify` | passed: npm 597 entries, runtime zip 859 entries |
| `node scripts/better-harness.mjs plugin status --host pi` (real machine, npm user-scope install 0.6.4) | `pi/cli@user present installed enabled 0.6.4 (same) partial` |

Manual or visual evidence: reproduction before/after in #126.

## Risk and Recovery

- Compatibility and cross-platform impact: none — pure string-list addition in a frozen identity constant; matching is already lowercase-normalized, no platform-specific paths involved
- Package, plugin, schema, or generated-file impact: none; shipped-file boundaries re-verified via `pack:verify`
- Rollback or recovery path: revert the one-line change
- Residual risk or unverified boundary: historical installs matching only `@qoderai/better-harness` stay supported (entry retained); Windows/Linux receipts deferred to CI

## AI Involvement

- Level: Assisted
- Human review and validation: root cause traced and locally verified by the issue reporter; diff reviewed on the fork before PR

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [x] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md` (skipped per AGENTS.md change-scope rule; maintainer decision).
- [x] I have the right to contribute this work under the repository's MIT License.
