### PR TITLE
fix(docs): alias inspector trailing-slash pages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ acceptance checks.
   (<a href="assets/demo/better-harness-report.html">source</a>).</sub>
 </p>
 
-For delivery tracing, the interactive [Harness Inspector](https://qoderai.github.io/better-harness/inspector/)
+For delivery tracing, the interactive [Harness Inspector](https://qoderai.github.io/better-harness/inspector)
 follows product intent through agent activity, sessions, files, and commits in
 a read-only workspace, keeping evidence strength and limitations visible:
 
 <p align="center">
-  <a href="https://qoderai.github.io/better-harness/inspector/"><img src="docs/assets/harness-inspector/session-view.png" alt="Harness Inspector session view: a synchronized timeline of prompts, tool calls, and commits with the Evidence Drawer explaining each link" width="900"></a>
+  <a href="https://qoderai.github.io/better-harness/inspector"><img src="docs/assets/harness-inspector/session-view.png" alt="Harness Inspector session view: a synchronized timeline of prompts, tool calls, and commits with the Evidence Drawer explaining each link" width="900"></a>
 </p>
 
 <p align="center">
-  <sub><a href="https://qoderai.github.io/better-harness/inspector/">Open the interactive Harness Inspector sample</a> (fictional English data; it never reads your workspace).</sub>
+  <sub><a href="https://qoderai.github.io/better-harness/inspector">Open the interactive Harness Inspector sample</a> (fictional English data; it never reads your workspace).</sub>
 </p>
 
 After you have comparable reports over time, the history view shows how the five

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,16 +60,16 @@ Qoder 与 Cursor 生成宿主原生 Canvas 报告；Claude Code、Codex、Qwen C
   （<a href="assets/demo/better-harness-report.html">源文件</a>）。</sub>
 </p>
 
-若要追踪交付链路，交互式 [Harness Inspector](https://qoderai.github.io/better-harness/inspector/)
+若要追踪交付链路，交互式 [Harness Inspector](https://qoderai.github.io/better-harness/inspector)
 会在一个只读工作区中，把产品意图与智能体活动、会话、文件和提交串联起来，
 同时保持证据强度与局限清晰可见：
 
 <p align="center">
-  <a href="https://qoderai.github.io/better-harness/inspector/"><img src="docs/assets/harness-inspector/session-view.png" alt="Harness Inspector 会话视图：提示词、工具调用与提交的同步时间线，配套证据抽屉解释每条关联" width="900"></a>
+  <a href="https://qoderai.github.io/better-harness/inspector"><img src="docs/assets/harness-inspector/session-view.png" alt="Harness Inspector 会话视图：提示词、工具调用与提交的同步时间线，配套证据抽屉解释每条关联" width="900"></a>
 </p>
 
 <p align="center">
-  <sub><a href="https://qoderai.github.io/better-harness/inspector/">打开交互式 Harness Inspector 示例</a>（使用虚构的英文数据，不会读取你的工作区）。</sub>
+  <sub><a href="https://qoderai.github.io/better-harness/inspector">打开交互式 Harness Inspector 示例</a>（使用虚构的英文数据，不会读取你的工作区）。</sub>
 </p>
 
 当你积累了多份可比较的历史报告后，历史视图会展示智能体工作闭环五个维度的变化：

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -123,7 +123,7 @@ const config = {
             label: "Docs",
           },
           {
-            to: "/inspector/",
+            to: "/inspector",
             label: "Inspector",
             position: "left",
             className: "navbar__link--inspector-new",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "start": "docusaurus start",
     "prebuild": "node scripts/sync-assets.mjs",
     "build": "docusaurus build",
+    "postbuild": "node scripts/alias-inspector-trailing-slash.mjs",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear"
   },

--- a/docs/scripts/alias-inspector-trailing-slash.mjs
+++ b/docs/scripts/alias-inspector-trailing-slash.mjs
@@ -1,0 +1,51 @@
+// GitHub Pages serves /inspector from inspector.html and /inspector/ from
+// inspector/index.html, with no redirect between them. Docusaurus
+// trailingSlash: false only emits inspector.html, so copy the same HTML into
+// the directory index as a static alias. Canonical URLs stay slash-less.
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function aliasInspectorTrailingSlash(buildRoot) {
+  const sources = collectInspectorPages(buildRoot);
+  if (sources.length === 0) {
+    throw new Error(`No inspector.html found under ${buildRoot}`);
+  }
+
+  const written = [];
+  for (const source of sources) {
+    const target = join(dirname(source), "inspector", "index.html");
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(source, target);
+    written.push(target);
+  }
+  return written;
+}
+
+function collectInspectorPages(buildRoot) {
+  const sources = [];
+  const rootPage = join(buildRoot, "inspector.html");
+  if (existsSync(rootPage)) {
+    sources.push(rootPage);
+  }
+
+  for (const entry of readdirSync(buildRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === "inspector") {
+      continue;
+    }
+    const localePage = join(buildRoot, entry.name, "inspector.html");
+    if (existsSync(localePage)) {
+      sources.push(localePage);
+    }
+  }
+  return sources;
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentFile) {
+  const buildRoot = resolve(
+    process.argv[2] ?? join(dirname(currentFile), "..", "build"),
+  );
+  const written = aliasInspectorTrailingSlash(buildRoot);
+  console.log(`Aliased ${written.length} Inspector trailing-slash page(s).`);
+}

--- a/docs/specs/2026-09-02-132-inspector-trailing-slash.md
+++ b/docs/specs/2026-09-02-132-inspector-trailing-slash.md
@@ -1,0 +1,70 @@
+# Inspector trailing-slash Pages 404
+
+## Traceability
+
+- Spec ID: inspector-trailing-slash
+- Story: #132
+- Status: Implemented
+
+## Intent
+
+GitHub Pages currently 404s `https://qoderai.github.io/better-harness/inspector/`
+while the slash-less URL is 200. The homepage, README, and some navbar links
+still point at the trailing-slash URL. No-JS readers, crawlers, and link
+checkers should get the Inspector page instead of a 404 HTML document.
+
+Keep `trailingSlash: false` as the canonical URL policy. Do not flip the whole
+site to directory URLs.
+
+## Acceptance Scenarios
+
+- AC-1: After a production docs build, GitHub Pages-style static lookup finds
+  both `inspector.html` and `inspector/index.html` for English and Simplified
+  Chinese. Serving either path returns Inspector HTML, not `404.html`.
+- AC-2: Homepage Inspector preview and "Open the interactive sample" links use
+  the slash-less `/inspector` path. Navbar Inspector uses the same slash-less
+  path.
+- AC-3: README English and Simplified Chinese Inspector sample URLs use
+  `https://qoderai.github.io/better-harness/inspector` without a trailing slash.
+- AC-4: Canonical, sitemap, and Open Graph URLs remain slash-less
+  `/better-harness/inspector`. The trailing-slash file is an alias for static
+  hosts, not a second canonical route.
+- AC-5: Existing demo directory routes such as
+  `/demo/harness-inspector/` keep their trailing slash because they are real
+  `index.html` directories, not Docusaurus page aliases.
+
+## Non-goals
+
+- Changing `trailingSlash` for the whole Docusaurus site.
+- Adding a GitHub Pages 301/302, which static Pages cannot emit for this host.
+- Rewriting every historical `/inspector/` mention in older specs.
+- Changing Inspector demo iframe content, Workbench behavior, or locales.
+
+## Plan and Tasks
+
+1. Keep `docs/docusaurus.config.js` `trailingSlash: false`.
+2. Add a postbuild copy of `inspector.html` to `inspector/index.html` for `en`
+   and `zh-Hans`, so Pages serves `/inspector/` as 200.
+3. Point homepage and navbar Inspector links at `/inspector`.
+4. Point README Inspector sample URLs at the slash-less public URL.
+5. Add focused tests that assert the alias files, postbuild wiring, and README
+   public URLs without grepping the whole repository.
+
+Decision rationale: GitHub Pages serves `file.html` for `/file` and
+`file/index.html` for `/file/`, but does not redirect between them. Docusaurus
+`trailingSlash: false` only emits `inspector.html`, which is why the homepage
+trailing-slash href 404s. Copying the same HTML into `inspector/index.html`
+makes both URLs 200 without changing canonical URLs. Pages still cannot 301.
+
+## Test and Review Evidence
+
+- AC-1: focused Vitest coverage copies a fake `inspector.html` into a temp
+  build tree and asserts English and `zh-Hans` `inspector/index.html` exist
+  with the same Inspector title, not 404 HTML.
+- AC-1: `docs/package.json` `postbuild` runs the alias step after
+  `docusaurus build`.
+- AC-2/AC-3: focused assertions on homepage `useBaseUrl("/inspector")`, navbar
+  `to: "/inspector"`, and README public URLs.
+- AC-4/AC-5: production `docs` build leaves sitemap/canonical slash-less and
+  keeps `/demo/harness-inspector/` as a directory route.
+- Manual: `curl -sSI` both public URLs after Pages deploy; neither is 404.

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -538,7 +538,7 @@ function HowItWorks() {
 }
 
 function InspectorSection() {
-  const inspectorUrl = useBaseUrl("/inspector/");
+  const inspectorUrl = useBaseUrl("/inspector");
   const architectureUrl = useBaseUrl("/docs/concepts/harness-inspector");
 
   return (

--- a/test/docs-inspector-trailing-slash.test.mjs
+++ b/test/docs-inspector-trailing-slash.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+
+import { aliasInspectorTrailingSlash } from "../docs/scripts/alias-inspector-trailing-slash.mjs";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const CANONICAL_INSPECTOR_URL = "https://qoderai.github.io/better-harness/inspector";
+
+test("GitHub Pages static lookup serves Inspector with and without a trailing slash (AC-1)", async () => {
+  const buildRoot = await mkdtemp(path.join(os.tmpdir(), "inspector-slash-"));
+  try {
+    const english = "<!doctype html><title>Harness Inspector | Better Harness</title>";
+    const chinese = `${english}<html lang="zh-Hans">`;
+    await writeFile(path.join(buildRoot, "inspector.html"), english);
+    await mkdir(path.join(buildRoot, "zh-Hans"));
+    await writeFile(path.join(buildRoot, "zh-Hans", "inspector.html"), chinese);
+    await writeFile(path.join(buildRoot, "404.html"), "Not Found");
+
+    const written = aliasInspectorTrailingSlash(buildRoot);
+
+    assert.equal(written.length, 2);
+    const englishAlias = await readFile(path.join(buildRoot, "inspector", "index.html"), "utf8");
+    const chineseAlias = await readFile(
+      path.join(buildRoot, "zh-Hans", "inspector", "index.html"),
+      "utf8",
+    );
+    assert.equal(englishAlias, english);
+    assert.equal(chineseAlias, chinese);
+    assert.notEqual(englishAlias, "Not Found");
+  } finally {
+    await rm(buildRoot, { recursive: true, force: true });
+  }
+});
+
+test("aliasing Inspector trailing-slash HTML fails when the page is missing (AC-1)", async () => {
+  const buildRoot = await mkdtemp(path.join(os.tmpdir(), "inspector-slash-missing-"));
+  try {
+    await writeFile(path.join(buildRoot, "404.html"), "Not Found");
+    assert.throws(() => aliasInspectorTrailingSlash(buildRoot), /No inspector\.html found/u);
+  } finally {
+    await rm(buildRoot, { recursive: true, force: true });
+  }
+});
+
+test("docs production build aliases Inspector HTML after Docusaurus (AC-1)", async () => {
+  const pkg = JSON.parse(await readFile(path.join(repoRoot, "docs", "package.json"), "utf8"));
+  assert.equal(pkg.scripts.postbuild, "node scripts/alias-inspector-trailing-slash.mjs");
+});
+
+test("homepage and navbar Inspector links are slash-less (AC-2, AC-5)", async () => {
+  const homepage = await readFile(path.join(repoRoot, "docs", "src", "pages", "index.js"), "utf8");
+  const config = await readFile(path.join(repoRoot, "docs", "docusaurus.config.js"), "utf8");
+  const inspectorPage = await readFile(
+    path.join(repoRoot, "docs", "src", "pages", "inspector", "index.js"),
+    "utf8",
+  );
+
+  assert.equal(extractUseBaseUrl(homepage, "inspectorUrl"), "/inspector");
+  assert.equal(extractNavbarTo(config, "Inspector"), "/inspector");
+  assert.equal(extractUseBaseUrl(inspectorPage, "demoUrl"), "/demo/harness-inspector/");
+});
+
+test("README Inspector sample URLs are slash-less (AC-3)", async () => {
+  for (const relative of ["README.md", "README.zh-CN.md"]) {
+    const markdown = await readFile(path.join(repoRoot, relative), "utf8");
+    const hrefs = [...markdown.matchAll(/https:\/\/qoderai\.github\.io\/better-harness\/inspector\/?/gu)]
+      .map((match) => match[0]);
+    assert.ok(hrefs.length > 0, relative);
+    assert.deepEqual([...new Set(hrefs)], [CANONICAL_INSPECTOR_URL]);
+  }
+});
+
+function extractUseBaseUrl(source, binding) {
+  const match = source.match(new RegExp(`const ${binding} = useBaseUrl\\("([^"]+)"\\);`));
+  assert.ok(match, `missing useBaseUrl binding ${binding}`);
+  return match[1];
+}
+
+function extractNavbarTo(source, label) {
+  const match = source.match(new RegExp(`to:\\s*"([^"]+)",\\s*label:\\s*"${label}"`));
+  assert.ok(match, `missing navbar item ${label}`);
+  return match[1];
+}


### PR DESCRIPTION
## Summary

GitHub Pages now serves Inspector HTML for both `/inspector` and `/inspector/`. Homepage, navbar, and README links use the slash-less canonical path.

## Why

- Issue/Story: https://github.com/QoderAI/better-harness/issues/132
- User or maintainer outcome: Opening the Inspector from the homepage or a trailing-slash URL should not 404 on GitHub Pages.

## Traceability and Scope

- Spec/ADR, if applicable: `docs/specs/2026-09-02-132-inspector-trailing-slash.md`
- Acceptance criteria addressed: AC-1 through AC-5
- Canonical owners changed: none
- Explicit non-goals: do not flip site-wide `trailingSlash`; do not add a Pages 301; do not rewrite historical spec mentions; do not change Inspector demo content

## Change Type

- [x] Bug fix

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `npx vitest run test/docs-inspector-trailing-slash.test.mjs` | 5 passed |
| `npx vitest run test/skills-docs/doc-link-graph.test.mjs` | 8 passed |
| `npm run build` in `docs/` | postbuild aliased 2 Inspector trailing-slash pages |

Manual or visual evidence:

Production docs build wrote matching `build/inspector/index.html` and `build/zh-Hans/inspector/index.html`. Sitemap loc remains `https://qoderai.github.io/better-harness/inspector`. Live Pages `curl` after deploy is still pending.

## Risk and Recovery

- Compatibility and cross-platform impact: alias script uses `node:fs` / `node:path`; no shell path concatenation.
- Package, plugin, schema, or generated-file impact: docs postbuild only; generated `docs/build/` remains gitignored.
- Rollback or recovery path: revert this commit; Pages will again 404 `/inspector/` until the next docs deploy.
- Residual risk or unverified boundary: live GitHub Pages 404 check after deploy; Docusaurus client hydration on the trailing-slash URL is not separately browser-tested.

## AI Involvement

- Level: Generated
- Human review and validation: focused Vitest plus a local production docs build.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [ ] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [x] I have the right to contribute this work under the repository's MIT License.

Closes #132
