### PR TITLE
fix(docs): keep navbar brand fully visible at 1280px

### DIFF
--- a/docs/specs/2026-09-02-133-docs-navbar-brand-truncation.md
+++ b/docs/specs/2026-09-02-133-docs-navbar-brand-truncation.md
@@ -1,0 +1,61 @@
+# Docs navbar brand truncation
+
+## Traceability
+
+- Spec ID: docs-navbar-brand-truncation
+- Story: #133
+- Status: Implemented
+
+## Intent
+
+At 1280px the docs site navbar shows `Better Har…` instead of `Better Harness`.
+The brand is a primary identity landmark, so laptop widths must keep the full
+title readable without hiding Docs, Inspector, Blog, or search.
+
+Keep the existing Infima desktop navbar. Do not replace it with a hamburger at
+1280px, and do not change the product name.
+
+## Acceptance Scenarios
+
+- AC-1: At 1280×800 the navbar brand text is exactly `Better Harness`, with no
+  ellipsis and no clipped glyphs. The same holds at 1366×768.
+- AC-2: At 1280px the desktop navbar still shows Docs, Inspector, Blog, Demo
+  Report, search, locale, and GitHub. It does not collapse to the mobile menu.
+- AC-3: Compact laptop widths still keep the brand fully visible. If nav items
+  need space, shrink item padding or search width before truncating the title.
+- AC-4: The 996px mobile breakpoint is unchanged. Below it, the hamburger may
+  hide desktop links, but the brand title remains `Better Harness`.
+- AC-5: Keyboard focus, overflow, and console/page errors stay clean on the
+  homepage navbar at 1280px, 1024px, and 390px.
+
+## Non-goals
+
+- Redesigning the docs navbar or applying Studio DESIGN.md tokens to Infima.
+- Removing Inspector `New`, locale, search, or GitHub items.
+- Changing the 996px Docusaurus mobile breakpoint.
+- Editing Studio, Inspector Workbench, or report chrome.
+
+## Plan and Tasks
+
+1. Keep `.navbar__brand` from shrinking (`min-width: auto` / `flex-shrink: 0`)
+   and disable title overflow ellipsis on desktop.
+2. Raise the compact-item media query from `max-width: 1250px` past 1280px so
+   1280px laptops use the tighter padding and search width.
+3. Leave `@media (max-width: 996px)` Inspector badge rules unchanged.
+4. Verify with Playwright against the served docs site.
+
+Decision rationale: Infima sets `.navbar__brand { min-width: 0 }` and
+`.navbar__title` uses `text--truncate`. The current compact query stops at
+1250px, so 1280px still uses full padding and the brand loses. Protect the
+title first, then reclaim space from items and search.
+
+## Test and Review Evidence
+
+- AC-1/AC-2/AC-3: Playwright at `http://127.0.0.1:3000/better-harness/` with
+  viewport 1280×800 and 1366×768. Brand text `Better Harness`,
+  `scrollWidth <= clientWidth`, desktop Docs/Inspector/Blog/Demo Report remain,
+  hamburger `display: none`. Compact query now covers 997px–1400px.
+- AC-4: 390×844 still uses hamburger (`display: flex`); brand text stays
+  `Better Harness` with `overflow: visible`.
+- AC-5: no console errors; screenshots under `.qoder/design-qa/docs-navbar/`.
+- Focused: `npx vitest run test/docs-navbar-brand-truncation.test.mjs` (2 passed).

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -113,7 +113,20 @@ html[data-theme="dark"] {
   }
 }
 
-@media (min-width: 997px) and (max-width: 1250px) {
+/* Infima lets .navbar__brand shrink (min-width: 0) and .navbar__title
+   truncate. Keep the product name fully visible at every width. */
+.navbar__brand {
+  flex-shrink: 0;
+  min-width: auto;
+}
+
+.navbar__title {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+@media (min-width: 997px) and (max-width: 1400px) {
   .navbar__item {
     padding-right: 0.55rem;
     padding-left: 0.55rem;

--- a/test/docs-navbar-brand-truncation.test.mjs
+++ b/test/docs-navbar-brand-truncation.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+test("docs navbar keeps the Better Harness brand from shrinking (AC-1, AC-3)", async () => {
+  const css = await readFile(path.join(repoRoot, "docs", "src", "css", "custom.css"), "utf8");
+  const brand = declarationsFor(css, ".navbar__brand");
+  const title = declarationsFor(css, ".navbar__title");
+
+  assert.equal(brand["flex-shrink"], "0");
+  assert.equal(brand["min-width"], "auto");
+  assert.equal(title.overflow, "visible");
+  assert.equal(title["text-overflow"], "clip");
+  assert.equal(title["white-space"], "nowrap");
+});
+
+test("compact laptop navbar padding covers 1280px before the mobile breakpoint (AC-2, AC-4)", async () => {
+  const css = await readFile(path.join(repoRoot, "docs", "src", "css", "custom.css"), "utf8");
+  const compact = mediaQueryContaining(css, ".navbar__search-input");
+
+  assert.match(compact, /min-width:\s*997px/u);
+  assert.match(compact, /max-width:\s*1400px/u);
+  assert.equal(rangeIncludes(compact, 1280), true);
+  assert.equal(rangeIncludes(compact, 1366), true);
+  assert.equal(rangeIncludes(compact, 996), false);
+});
+
+function declarationsFor(css, selector) {
+  const match = css.match(new RegExp(`${escapeRegExp(selector)}\\s*\\{([^}]+)\\}`, "u"));
+  assert.ok(match, `missing rule ${selector}`);
+  const declarations = {};
+  for (const line of match[1].split(";")) {
+    const [property, value] = line.split(":").map((part) => part?.trim());
+    if (property && value) {
+      declarations[property] = value;
+    }
+  }
+  return declarations;
+}
+
+function mediaQueryContaining(css, selector) {
+  const blocks = [...css.matchAll(/@media\s*([^{]+)\{([\s\S]*?)\n\}/gu)];
+  const block = blocks.find((entry) => entry[2].includes(selector));
+  assert.ok(block, `missing media query for ${selector}`);
+  return block[1].trim();
+}
+
+function rangeIncludes(query, width) {
+  const min = Number(query.match(/min-width:\s*(\d+)px/u)?.[1] ?? Number.NaN);
+  const max = Number(query.match(/max-width:\s*(\d+)px/u)?.[1] ?? Number.NaN);
+  return width >= min && width <= max;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}


### PR DESCRIPTION
## Summary

The docs navbar now shows the full `Better Harness` brand at 1280px laptop widths instead of `Better Har…`.

## Why

- Issue/Story: https://github.com/QoderAI/better-harness/issues/133
- User or maintainer outcome: The product name stays fully readable on common laptop widths without hiding Docs, Inspector, Blog, or search.

## Traceability and Scope

- Spec/ADR, if applicable: `docs/specs/2026-09-02-133-docs-navbar-brand-truncation.md`
- Acceptance criteria addressed: AC-1 through AC-5
- Canonical owners changed: none
- Explicit non-goals: no Infima-to-Studio redesign; no hamburger at 1280px; no 996px breakpoint change

## Change Type

- [x] Bug fix

## Test and Review Evidence

| Check | Result |
| --- | --- |
| `npx vitest run test/docs-navbar-brand-truncation.test.mjs` | 2 passed |
| `npx vitest run test/skills-docs/doc-link-graph.test.mjs` | 8 passed |
| Playwright at 1280×800 / 1366×768 / 1024×768 / 390×844 | Brand text `Better Harness`, `scrollWidth <= clientWidth` |

Manual or visual evidence:

Playwright against `http://127.0.0.1:3000/better-harness/`. Desktop links remain at 1280px; hamburger remains at 390px. No console errors. Screenshots saved locally under `.qoder/design-qa/docs-navbar/` (gitignored).

## Risk and Recovery

- Compatibility and cross-platform impact: CSS-only docs theme override.
- Package, plugin, schema, or generated-file impact: none.
- Rollback or recovery path: revert this commit.
- Residual risk or unverified boundary: very crowded translations longer than English `Better Harness` were not measured.

## AI Involvement

- Level: Generated
- Human review and validation: focused Vitest plus Playwright computed-style checks.

## Checklist

- [x] I followed `AGENTS.md`, `CONTRIBUTING.md`, and the relevant canonical-owner guidance.
- [x] The change is focused and does not include unrelated local or generated state.
- [x] Tests and documentation match the behavior actually delivered.
- [x] Markdown links were checked when documentation moved or changed.
- [x] Cross-platform behavior was considered for Windows, macOS, and Linux.
- [ ] Package/runtime verification was run when shipped files or dependencies changed.
- [ ] User-facing or compatibility changes are recorded in `CHANGELOG.md`.
- [x] I have the right to contribute this work under the repository's MIT License.

Closes #133
