### PR TITLE
fix(studio): align CI contracts with tightened debugger chrome

### DIFF
--- a/docs/specs/2026-09-07-studio-ci-chrome-contracts.md
+++ b/docs/specs/2026-09-07-studio-ci-chrome-contracts.md
@@ -1,0 +1,59 @@
+# Align Studio CI contracts with the tightened Debugger chrome
+
+## Traceability
+
+- Spec ID: studio-ci-chrome-contracts
+- Status: Implemented
+
+## Intent
+
+Main is red because Studio browser tests still describe the pre-unification
+chrome, and the ACP host fails `cargo fmt --check` on two lines added with the
+diagnostics work. Bring those CI contracts onto the chrome and formatting that
+already shipped, without restoring retired labels or collapsing the composer
+stylesheet back into workbench.
+
+## Acceptance Scenarios
+
+- AC-1: The Studio layout contract counts the four owned `/assets/*.css`
+  sheets linked from `index.html` (`tokens.css`, `shell.css`, `workbench.css`,
+  `live-composer.css`). Adding a fifth sheet still fails the contract.
+- AC-2: Theme contrast is measured from a primary-fill control that exists on
+  every Studio view: `button.primary`, `button.new-run`, or the selected
+  sidebar View. A missing node must not throw `getComputedStyle` on `null`.
+- AC-3: After opening Debugger on a discovered Project, the status bar names
+  that Project and the title-bar action is `New live run`. The retired
+  concatenated harness label is not required.
+- AC-4: `cargo fmt --check` for `harness-acp-host` is clean on
+  `connection.rs` and `services.rs`.
+- AC-5: At the compact 1024px Debugger layout, the session notebook is at
+  least half the grid width, so live trial evidence stays the primary pane.
+
+## Non-goals
+
+- Restoring Overview, Inputs, or the concatenated
+  `Project default · Qoder · fixture-project` chrome.
+- Merging `live-composer.css` into `workbench.css`.
+- Changing theme tokens, ACP handshake behavior, or the live-run dialog.
+
+## Plan and Tasks
+
+1. Format the two ACP host hunks the way rustfmt 1.96 wraps them.
+2. Name the four owned stylesheets in `assertRenderedContract`.
+3. Guard the contrast helper with a selector that matches current chrome.
+4. Point the Debugger workspace assertion at `.studio-status-bar` and
+   `New live run`.
+5. Shrink the default tree and inspector pane widths so a 1024px overlay
+   layout still leaves the notebook at least half the grid.
+
+## Test and Review Evidence
+
+- AC-1/AC-2/AC-3/AC-5: Playwright
+  `packages/harness-studio/test/browser/tool-call.spec.mjs` layout tests and
+  `packages/harness-studio/test/browser/artifact-host.spec.mjs` theme and
+  workspace tests. Full Studio browser suite: 65 passed.
+- AC-4: `cargo fmt --check` in `packages/better-harness-desktop/rust/acp-host`.
+- Risk: relaxing the stylesheet count to an un-named integer would hide a
+  fifth sheet. Named filenames keep the original gate.
+- Risk: a probe-only contrast check would pass with no on-screen primary fill.
+  Measuring the selected View row covers the landing surface at 375px.

--- a/packages/better-harness-desktop/rust/acp-host/src/connection.rs
+++ b/packages/better-harness-desktop/rust/acp-host/src/connection.rs
@@ -514,7 +514,9 @@ impl AgentConnection {
             Ok(connection) => connection,
             Err(_) => {
                 return Err(diagnostics
-                    .explain_when_drained("the ACP transport closed before it produced a connection")
+                    .explain_when_drained(
+                        "the ACP transport closed before it produced a connection",
+                    )
                     .await);
             }
         };

--- a/packages/better-harness-desktop/rust/acp-host/src/services.rs
+++ b/packages/better-harness-desktop/rust/acp-host/src/services.rs
@@ -306,8 +306,12 @@ impl Terminal {
             // drain the final pipe bytes. Publish the exit only after both are
             // done, so wait_for_exit followed by output cannot race to an empty
             // result.
-            if let Some(task) = stdout_task { let _ = task.await; }
-            if let Some(task) = stderr_task { let _ = task.await; }
+            if let Some(task) = stdout_task {
+                let _ = task.await;
+            }
+            if let Some(task) = stderr_task {
+                let _ = task.await;
+            }
             let _ = exit_tx.send(Some(ExitSnapshot {
                 code: status
                     .and_then(|status| status.code())

--- a/packages/harness-studio/src/app/run/ResizableDebuggerPanes.tsx
+++ b/packages/harness-studio/src/app/run/ResizableDebuggerPanes.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-const DEFAULTS = { tree: 224, inspector: 304 };
+const DEFAULTS = { tree: 200, inspector: 248 };
 const MINIMUM = { tree: 160, inspector: 200 };
 const CENTER_MINIMUM = 240;
 const SASHES = 12;

--- a/packages/harness-studio/test/browser/artifact-host.spec.mjs
+++ b/packages/harness-studio/test/browser/artifact-host.spec.mjs
@@ -1137,7 +1137,9 @@ test("persists the explicit Studio theme and keeps core contrast accessible", as
       return (light + 0.05) / (dark + 0.05);
     };
     const body = getComputedStyle(document.body);
-    const primary = getComputedStyle(document.querySelector("button.primary"));
+    const primaryEl = document.querySelector("button.primary, button.new-run, .studio-project-views > button[aria-current='page']");
+    if (!(primaryEl instanceof Element)) throw new Error("no primary-fill control");
+    const primary = getComputedStyle(primaryEl);
     return {
       body: ratio(body.color, body.backgroundColor),
       primary: ratio(primary.color, primary.backgroundColor),
@@ -1575,7 +1577,8 @@ test("opens a project workspace and compares Inspector-discovered Sessions", asy
 
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.getByRole("navigation", { name: "Studio View navigation" }).getByRole("button", { name: /^Debugger/ }).click();
-  await expect(page.getByText(/Project default · Qoder · fixture-project/u)).toBeVisible();
+  await expect(page.locator(".studio-status-bar")).toContainText("fixture-project");
+  await expect(page.getByRole("button", { name: "New live run" })).toBeVisible();
   await page.getByRole("button", { name: "New live run" }).click();
   await expect(page.getByRole("dialog", { name: "New run" })).toContainText("fixture-project");
   await page.getByPlaceholder("Task prompt for the harness run…").fill("verify the default workspace harness");

--- a/packages/harness-studio/test/browser/tool-call.spec.mjs
+++ b/packages/harness-studio/test/browser/tool-call.spec.mjs
@@ -91,7 +91,10 @@ async function assertRenderedContract(page) {
       belowFloor,
       dockedShadows,
       visibleSurfaceSwitchers: [...document.querySelectorAll('[aria-label="Compare surfaces"]')].filter(visible).length,
-      ownedStyleSheets: [...document.styleSheets].filter((sheet) => sheet.href?.includes("/assets/") && sheet.href.endsWith(".css")).length,
+      ownedStyleSheets: [...document.styleSheets]
+        .filter((sheet) => sheet.href?.includes("/assets/") && sheet.href.endsWith(".css"))
+        .map((sheet) => new URL(sheet.href).pathname.split("/").pop())
+        .sort(),
     };
   });
   expect(contract.documentWidth).toBe(contract.innerWidth);
@@ -99,7 +102,7 @@ async function assertRenderedContract(page) {
   expect(contract.belowFloor).toEqual([]);
   expect(contract.dockedShadows).toEqual([]);
   expect(contract.visibleSurfaceSwitchers).toBeLessThanOrEqual(1);
-  expect(contract.ownedStyleSheets).toBe(3);
+  expect(contract.ownedStyleSheets).toEqual(["live-composer.css", "shell.css", "tokens.css", "workbench.css"]);
 }
 
 test.beforeAll(async () => {


### PR DESCRIPTION
## Summary
Main is red on ACP Host (all three OSes) and CI `ubuntu-latest / Node 22.20.0` after the debugger chrome unification.

- rustfmt the two ACP host hunks that fail `cargo fmt --check`
- name the four owned Studio stylesheets instead of asserting a count of 3
- measure theme contrast from a primary-fill control that still exists
- assert the Debugger status-bar Project label instead of the retired concatenated harness chrome
- shrink default tree/inspector pane widths so compact Debugger keeps the notebook at least half the grid

## Spec
docs/specs/2026-09-07-studio-ci-chrome-contracts.md

## Test evidence
- `cargo fmt --check` in `packages/better-harness-desktop/rust/acp-host`
- Studio Playwright: 65 passed