### PR TITLE
fix(session-analysis): recognize lowercase edit tool names from Pi sessions

### DIFF
--- a/scripts/session-analysis/episode-contract.mjs
+++ b/scripts/session-analysis/episode-contract.mjs
@@ -11,13 +11,16 @@ export const EVENT_SCHEMA_VERSION = 2;
 export const TASK_EPISODE_SCHEMA_VERSION = 3;
 export const DEFAULT_EPISODE_GAP_MS = 30 * 60 * 1000;
 
+// Tool-name matching is case-insensitive: providers differ in casing
+// (Claude Code emits "Edit"/"Write", pi emits "edit"/"write"), so entries
+// are stored lowercase and compared against the lowercased tool name.
 const EDIT_TOOL_NAMES = new Set([
-  "Edit",
-  "MultiEdit",
-  "NotebookEdit",
-  "NotebookWrite",
-  "SearchReplace",
-  "Write",
+  "edit",
+  "multiedit",
+  "notebookedit",
+  "notebookwrite",
+  "searchreplace",
+  "write",
 ]);
 const PATHLESS_EDIT_TOOL_NAMES = new Set(["apply_patch"]);
 const LIFECYCLE_USER_EVENT_TYPES = new Set(["user", "last-prompt", "UserPromptSubmit"]);
@@ -131,7 +134,7 @@ export function isEditEvent(event) {
   if (event?.type === "event.patch_apply_end") return true;
   if (PATHLESS_EDIT_TOOL_NAMES.has(String(event?.toolName ?? event?.functionCallName ?? "").toLowerCase())) return true;
   if (/^\s*apply_patch(?:\s|$)/u.test(String(event?.commandText ?? ""))) return true;
-  return targetPaths.length > 0 && EDIT_TOOL_NAMES.has(event?.toolName);
+  return targetPaths.length > 0 && EDIT_TOOL_NAMES.has(String(event?.toolName ?? "").toLowerCase());
 }
 
 export function validationCategory(event) {

--- a/scripts/session-analysis/insights.mjs
+++ b/scripts/session-analysis/insights.mjs
@@ -31,7 +31,8 @@ const FRICTION_TYPE_PATTERNS = Object.freeze([
   { name: "aborted-event", pattern: /\b(?:abort|aborted|cancel|cancelled|interrupted)\b/i },
 ]);
 
-const EDIT_TOOL_NAMES = new Set(["Edit", "MultiEdit", "NotebookEdit", "Write"]);
+// Case-insensitive: providers differ in casing (Claude Code "Edit", pi "edit").
+const EDIT_TOOL_NAMES = new Set(["edit", "multiedit", "notebookedit", "write"]);
 
 const EDIT_COMMAND_PATTERNS = Object.freeze([
   { name: "apply_patch", pattern: /\bapply_patch\b|\*\*\*\s+Begin Patch/i },
@@ -724,7 +725,7 @@ function longSessionRows(rows = []) {
 }
 
 function isEditEvent(event) {
-  if (EDIT_TOOL_NAMES.has(event.toolName)) {
+  if (EDIT_TOOL_NAMES.has(String(event?.toolName ?? "").toLowerCase())) {
     return true;
   }
   const commandText = event.commandText ?? "";


### PR DESCRIPTION
## Why

Pi's coding agent emits lowercase tool names (`edit`, `write`), but edit-event detection in `episode-contract.mjs` and `insights.mjs` matched Claude Code's capitalized names (`Edit`, `Write`) with a case-sensitive `Set` lookup:

```js
const EDIT_TOOL_NAMES = new Set(["Edit", "MultiEdit", "NotebookEdit", "Write"]);
// ...
return targetPaths.length > 0 && EDIT_TOOL_NAMES.has(event?.toolName);  // "edit" never matches
```

Every Pi edit event was therefore missed, which surfaces as `withChanges: 0` in session facts for any Pi workspace that demonstrably has commits — meaning Task-Episode change evidence, `change-gap` classification, and `read-only-work` correction are all broken for the `pi` platform.

Notably, the same function already lowercases its input for `PATHLESS_EDIT_TOOL_NAMES` (`apply_patch`), so case-insensitive matching is the established intent here; the main set just never got the same treatment.

## What changed

- `scripts/session-analysis/episode-contract.mjs`: `EDIT_TOOL_NAMES` entries stored lowercase; `isEditEvent` compares against `String(toolName ?? "").toLowerCase()`
- `scripts/session-analysis/insights.mjs`: same fix for its local `EDIT_TOOL_NAMES` copy, plus null-safe tool-name access

No behavior change for capitalized providers: `"Edit".toLowerCase()` still matches, and the match set strictly grows.

## Validation

Reran `session-analysis facts --platform pi` over a 254-session workspace before/after:

| metric | before | after |
|---|---|---|
| `populationCoverage.withChanges` | 0 | 29 |
| candidate class `change-gap` | 0 | 11 |
| candidate class `read-only-work` | 44 | 21 |
| `candidateEpisodes` | 47 | 53 |

The workspace had ~500 commits in the analyzed window, so `withChanges: 0` was provably a detection failure, not a read-only window.

Backward compatibility: the existing `session-episode-contract` and `lifecycle-demand-signals` tests (28 tests, all using capitalized Claude tool names) pass unchanged, and a spot check against a real Claude session (`Write` tool calls) confirms `isEditEvent` still returns `true` for capitalized names while `Bash`/`Read` stay `false`.