### PR TITLE
feat(harness): compile pi extensions at runtime with esbuild-wasm

### DIFF
--- a/docs/specs/2026-09-09-pi-wasm-extension-runtime.md
+++ b/docs/specs/2026-09-09-pi-wasm-extension-runtime.md
@@ -1,0 +1,116 @@
+# Compile Pi extensions while the agent is running
+
+## Traceability
+
+- Spec ID: pi-wasm-extension-runtime
+- Status: Implemented experiment (local validation; draft PR)
+- Request: independent experiment from main after native-interface PR #158;
+  use Pi and esbuild-wasm, and compare DSH's reload capabilities.
+- No Story or issue id was supplied.
+
+## Intent
+
+Compile a changing TypeScript extension and its local imports into a module
+that the official Pi runtime loads. Keep Pi's own terminal, commands, tools,
+session lifecycle and extension API. Demonstrate real native reload without
+requiring a model request or copying the Studio interface work from PR #158.
+
+## Acceptance scenarios
+
+- **AC-1:** Build a TypeScript entry and local dependency with esbuild-wasm;
+  return structured diagnostics, SHA-256 revision and timing. No native esbuild
+  dependency is introduced. Require a default export and explicit .ts output
+  path; emitted content is JavaScript, while this suffix keeps Pi's loader from
+  reusing Node's ESM cache for .mjs / type:module .js entries.
+- **AC-2:** Reuse an incremental build context for repeated builds/watch.
+  Publish a complete module by atomic replacement only after a successful
+  build; syntax/import/export errors preserve the prior artifact. Dispose the
+  context on shutdown. Serialize writes and reject builds after disposal.
+- **AC-3:** Run an explicitly provided installed Pi CLI with the generated
+  extension and a small control extension. `/harness-reload` waits for idle,
+  compiles current source, and calls Pi's native `ctx.reload()` only on success.
+  A tool can queue this command through Pi's official follow-up mechanism.
+  Compilation failure leaves the running extension available. Source edits do
+  not implicitly execute code unless the user invokes reload or the tool.
+- **AC-4:** A real pinned Pi SDK loads and executes v1, reloads v2, preserves v2
+  after invalid source, and observes session lifecycle events. No model calls,
+  user profiles or global installs. Record native versus fixture evidence.
+- **AC-5:** CLI help, invalid arguments, JSON output, filesystem paths with
+  spaces/Unicode and process cleanup have observable coverage. Explain DSH's
+  profile/module/bundle boundaries from upstream source and record compiler
+  footprint separately from the unchanged Pi distribution.
+
+## Non-goals
+
+A new Coding Agent host adapter, Studio page, browser execution of Node
+extensions, TypeScript type checking, a sandbox, arbitrary extension activation
+rollback, preservation of extension in-memory state, complete Pi dependency
+replacement, automatic package installation, signed desktop releases, and DSH
+implementation. Existing native side effects remain owned by each extension.
+
+## Plan and tasks
+
+1. Add a copyable capability under `scripts/pi-extension-runtime/`, using the
+   existing root esbuild-wasm dependency. The compiler owns bundle policy and
+   artifact publication; the CLI owns build/watch/run and argv-based launch.
+2. Keep Pi-owned runtime packages external so Pi resolves its own API, TUI and
+   TypeBox modules. Bundle local source imports. Reject unsupported bare
+   imports rather than silently publishing unresolved dependencies.
+3. Add a control extension and a small editable example. Keep its build context
+   for repeated attempts and dispose on session shutdown, including native
+   reload. Native reload creates a new control instance; there is no promise
+   of warm incremental state across a full Pi reload.
+4. Test compilation/publication errors and real native reload. Inspect upstream
+   DSH config hot reload versus opt-in module HMR and bundle restart.
+
+## Test and review evidence
+
+- Capability and usage: [Pi extension runtime compiler](../../scripts/pi-extension-runtime/README.md).
+- AC-1/2/5: Node 24.20.0, 14 focused Vitest tests passed. Tests execute compiled
+  modules, edit local imports, preserve prior output on syntax/resolution/export
+  failure, drain concurrent builds, reject unsafe output paths/suffixes, exercise
+  CLI JSON/error/argv behavior, observe watch recovery, and terminate its process.
+- AC-3/4: real Pi 0.85.1 SDK passed in isolated temporary directories. Three
+  native reloads, seven start/stop events, TypeBox tool registration, v1 -> v2,
+  failed syntax retaining v2, recovery to v3, and tool-dispatched v4. No model
+  requests. The smoke uses the installed package's public SDK entrypoint.
+- AC-3/4: official npm `dist/bundle/cli.js` also ran through `run` in a real PTY,
+  in a project with `type: module`. Native `/harness-hello` observed a changed
+  value after `/harness-reload`; invalid source retained it, and another repaired
+  revision became visible. Ctrl+D exited both Pi and the wrapper successfully.
+  The isolated Pi profile downloaded its own `fd` helper on first startup;
+  that download is not part of the compiler footprint or a model call.
+- Regression found during native terminal verification: `.mjs` and ESM `.js`
+  output can retain the old native ESM module after Pi reports reload success.
+  Using a `.ts` entry containing compiled JavaScript forces Pi's uncached loader.
+  The SDK test's runtime TypeBox import had masked this by forcing fallback
+  resolution; dependency-free official terminal verification caught it.
+- Tool dispatch also needed `expandPromptTemplates: true` with Pi 0.85.1.
+  Without it the command string was treated as literal input. Native smoke now
+  exercises this exact dispatch, beyond registration-only evidence.
+- AC-5: esbuild-wasm 0.28.2 occupies 14,532,821 logical bytes locally; its WASM
+  binary is 13,978,850 bytes. Existing root dependency, no dependency/lockfile
+  changes. This does not replace Pi's own installed native esbuild dependencies.
+- Markdown link tests: 8 passed; generated routing graph unchanged. Preview
+  launch failed at its existing prerequisite: missing Canvas SDK runtime.
+  `/health` and `/canvas-module.js` were not verified. No Studio UI changed.
+- Antigravity artifact and governance mapping checks: 41 passed, 1 skipped.
+  An independent Codex CLI consumer read the help/README, compiled a temporary
+  extension through the documented command, checked the receipt's SHA-256,
+  introduced invalid syntax, and verified exit 1 plus unchanged artifact bytes.
+  No repository edits, package installs or Pi model calls in that validation.
+- Windows/Linux native Pi and installed Desktop packaging are not claimed
+  verified. Hosted cross-platform CI results must be recorded separately.
+- Review: maintainer-requested experiment, no inferred Story. Source/compiler,
+  CLI/control extension, example, behavior tests and spec form one scoped change.
+  AI implementation: Codex. No change from native-interface PR #158 is imported.
+
+## Risks and decision boundaries
+
+Only trusted local extension source is executed. Compilation is not validation
+of a factory's runtime behavior. An exception or side effect during native
+activation is not rolled back by atomic file publication. Reload affects all
+Pi resources and uses upstream session shutdown/start events. Source edits made
+during compilation may require a subsequent build; no per-token compilation.
+WASM adds a portable compiler, but does not remove native esbuild already in the
+installed Pi dependency closure. DSH parity requires a separate accepted slice.

--- a/scripts/pi-extension-runtime/README.md
+++ b/scripts/pi-extension-runtime/README.md
@@ -1,0 +1,113 @@
+# Pi extension runtime compiler
+
+An experimental, local compiler for extensions loaded by **official Pi**.
+It uses the existing `esbuild-wasm@0.28.2` dependency, bundles TypeScript and
+local imports, and publishes complete revisions. It does not install Pi or
+replace its terminal, tool runner, session manager or extension API.
+
+## Try it
+
+Use the repository's supported Node 22.20+ or Node 24 and installed dependencies.
+Supply the JavaScript CLI entry from an existing Pi installation; for the tested
+`@earendil-works/pi-coding-agent@0.85.1` npm package it is `dist/bundle/cli.js`.
+The path is an argument to Node, not an npm shell shim or a compiled executable.
+
+From the repository root (the same single-line command works in supported shells):
+
+```sh
+node scripts/pi-extension-runtime/cli.mjs run --entry scripts/pi-extension-runtime/examples/extension.ts --out dist/pi-extension/compiled.ts --pi-cli /path/to/pi-coding-agent/dist/bundle/cli.js -- --no-session
+```
+
+1. In Pi, enter `/harness-hello` to observe v1.
+2. Edit `scripts/pi-extension-runtime/examples/greeting.ts`.
+3. Enter `/harness-reload`, then `/harness-hello` to observe the new value.
+4. Introduce a syntax error and repeat. Pi reports the compilation error; the
+   previous command still works. Fix the source and reload again to recover.
+
+Pi also receives a `harness_reload` tool. An agent can edit the configured
+source with its native file tools, then queue this reload command. Its immediate
+result says **queued**, not activated. The command waits for idle and reports
+compilation errors through Pi's UI. Native reload recreates extension state and
+reloads other Pi resources too. The smoke tests do not invoke a real model.
+
+The source entry and output are fixed at launch through child-scoped environment
+variables. Existing Pi project/user discovery and trust checks still apply;
+this is the user's normal Pi runtime unless they select an isolated Pi profile.
+For verification, the native smoke uses a temporary project and agent directory.
+
+## Build and watch independently
+
+```sh
+node scripts/pi-extension-runtime/cli.mjs build --entry scripts/pi-extension-runtime/examples/extension.ts --out dist/pi-extension/compiled.ts --json
+node scripts/pi-extension-runtime/cli.mjs watch --entry scripts/pi-extension-runtime/examples/extension.ts --out dist/pi-extension/compiled.ts --json
+```
+
+`build` exits 1 on compilation failure. `watch` polls every 500 ms with an
+incremental esbuild context and emits JSONL on revision or diagnostic changes.
+It retries missing/invalid imports and stops on Ctrl+C or termination. Watch
+compiles only: a separately running Pi requires its native `/reload` to load the
+artifact. Use one writer per output; do not watch an output concurrently with
+the `run` command's control extension. `run` compiles on explicit
+`/harness-reload` or `harness_reload`, not on every file save.
+
+Successful receipts contain a SHA-256 digest of the emitted JavaScript, byte
+count, compilation duration and diagnostics. This is a **code revision**, not a
+digest of external Pi modules or assets. Failure keeps the prior artifact;
+`revision: null` means this compiler instance has not published a valid revision.
+
+## Loading and lifecycle constraints
+
+- The output must use **`.ts`**, although its contents are bundled JavaScript.
+  Pi 0.85.1's Jiti loader can route `.mjs` and ESM-project `.js` files into Node's
+  persistent ESM cache. The official TUI then reports a successful reload while
+  executing old code. A `.ts` entry forces Pi's reloadable loading path. This
+  was reproduced with a dependency-free extension and fixed in the live TUI.
+- Pi-provided API/TUI/AI/TypeBox imports and Node builtins stay external. Local
+  source imports are bundled. Other bare runtime imports fail with a diagnostic;
+  this experiment does not install dependencies or handle arbitrary asset files.
+- `harness_reload` uses `expandPromptTemplates: true` to dispatch the extension
+  command in Pi 0.85.1; otherwise Pi treats the string as literal model input.
+- Syntax, resolution and default-export checks happen before atomic replacement.
+  esbuild does not typecheck or execute the factory. This is trusted local code,
+  not a sandbox. Runtime exceptions and external side effects during activation
+  are not transactionally rolled back. Extension authors own their cleanup.
+- The control extension disposes its compiler on session shutdown, including
+  reload. An incremental context survives repeated attempts within that instance,
+  but a full Pi reload creates a new instance. Whole-session warm state is not
+  promised. Long-running tool calls must reach idle before the reload proceeds.
+
+## DSH comparison and footprint
+
+DSH has a related route, with different lifecycle contracts. At source revision
+`0a53fb55bea101816fa226bb964ae2bed71c343b`, ordinary `cordis.patch.yml` edits can
+reload live. The profile bootstrap installs a configuration-only HMR fallback
+with no module roots when module HMR is not enabled. Source module HMR is opt-in;
+adding/removing/updating Bundle membership requires a Profile restart. Browser
+client bundles still require their own build. Therefore compiling a plugin with
+WASM is plausible, but activation, disposal and client reload need a DSH-specific
+adapter and native verification. This PR implements the Pi experiment only.
+
+Sources: [DSH profile bootstrap](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/apps/cli/src/profile-boot.ts),
+[DSH CLI reference](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/apps/cli/reference/README.md),
+[Pi extensions](https://github.com/earendil-works/pi/blob/faa9863cb8b54689f1d0c2df9dbab1ee1fa9de19/packages/coding-agent/docs/extensions.md),
+[esbuild incremental contexts](https://esbuild.github.io/api/#rebuild).
+
+The local esbuild-wasm package is 14,532,821 bytes (13.86 MiB), including a
+13,978,850-byte WASM binary (13.33 MiB). It is already a root dependency, so this
+PR adds no package or lockfile changes. These are logical file bytes, excluding
+Node, Pi, compiler RSS and application packaging. **Using this compiler does
+not remove native esbuild from Pi's installed dependency closure.** The raw
+distribution comparison remains in [PR #158](https://github.com/QoderAI/better-harness/pull/158).
+
+## Verification
+
+```sh
+npx vitest run test/pi-extension-runtime
+node scripts/pi-extension-runtime/native-smoke.mjs /path/to/installed/pi-coding-agent
+```
+
+The native smoke pins Pi 0.85.1, loads the real SDK with isolated directories,
+executes commands, checks native reload and lifecycle events, exercises the
+reload tool's command dispatch, and verifies recovery after invalid source.
+It does not install packages. SDK evidence and official terminal interaction
+evidence are recorded separately in the [experiment spec](../../docs/specs/2026-09-09-pi-wasm-extension-runtime.md).

--- a/scripts/pi-extension-runtime/cli.mjs
+++ b/scripts/pi-extension-runtime/cli.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { createExtensionCompiler } from "./compiler.mjs";
+
+const help = `Experimental Pi extension runtime compiler
+
+Usage:
+  node scripts/pi-extension-runtime/cli.mjs build --entry <source.ts> --out <compiled.ts> [--json]
+  node scripts/pi-extension-runtime/cli.mjs watch --entry <source.ts> --out <compiled.ts> [--json]
+  node scripts/pi-extension-runtime/cli.mjs run --entry <source.ts> --out <compiled.ts> --pi-cli <installed-cli.js> [-- <Pi args>]
+
+build: Compile once; failure preserves the previous output. Exit 1 on failure.
+watch: Incrementally rebuild every 500 ms; report changes/errors. Ctrl+C stops.
+run:   Compile, then launch official Pi. /harness-reload compiles and reloads.
+       The harness_reload tool queues the same command after a turn.
+
+Paths are relative to the current project. No packages are installed.
+Output contains bundled JavaScript; .ts forces Pi's reloadable module loader.
+Only trusted source should be compiled and loaded. WASM is not a sandbox.
+`;
+
+export function parseArgs(args) {
+  if (!args.length || ["--help", "-h"].includes(args[0])) return { help: true };
+  const [command, ...rest] = args;
+  if (!["build", "watch", "run"].includes(command)) throw new Error(`Unknown command: ${command}`);
+  const options = { command, piArgs: [] };
+  for (let i = 0; i < rest.length; i++) {
+    const flag = rest[i];
+    if (flag === "--help" || flag === "-h") return { help: true };
+    if (flag === "--" && command === "run") { options.piArgs = rest.slice(i + 1); break; }
+    if (flag === "--json" && command !== "run" && !options.json) { options.json = true; continue; }
+    const key = { "--entry": "entry", "--out": "outfile", "--pi-cli": "piCli" }[flag];
+    if (!key || (key === "piCli" && command !== "run")) throw new Error(`Unknown option: ${flag}`);
+    if (options[key]) throw new Error(`Duplicate option: ${flag}`);
+    const value = rest[++i];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
+    options[key] = path.resolve(value);
+  }
+  if (!options.entry || !options.outfile) throw new Error("--entry and --out are required.");
+  if (command === "run" && !options.piCli) throw new Error("run requires --pi-cli pointing to an installed Pi JavaScript CLI.");
+  return options;
+}
+
+export function launchArguments(options) {
+  return [options.piCli, ...options.piArgs, "-e",
+    fileURLToPath(new URL("./pi-extension.mjs", import.meta.url)), "-e", options.outfile];
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) { process.stdout.write(help); return; }
+  if (options.piCli) await access(options.piCli);
+  const compiler = await createExtensionCompiler(options);
+  const controller = new AbortController();
+  const stop = () => controller.abort();
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  let child;
+  const report = (result) => {
+    if (options.json) process.stdout.write(`${JSON.stringify(result)}\n`);
+    else if (result.status === "ready") process.stderr.write(`Compiled ${result.revision.slice(0, 12)}: ${result.bytes} bytes, ${Math.round(result.durationMs)} ms\n`);
+    else process.stderr.write(`${result.diagnostics.map((d) => d.text).join("\n")}\n`);
+  };
+  try {
+    let result = await compiler.rebuild();
+    report(result);
+    if (options.command === "watch") {
+      let previous = JSON.stringify([result.status, result.revision, result.diagnostics]);
+      while (!controller.signal.aborted) {
+        await delay(500, undefined, { signal: controller.signal }).catch(() => {});
+        if (controller.signal.aborted) break;
+        result = await compiler.rebuild();
+        const signature = JSON.stringify([result.status, result.revision, result.diagnostics]);
+        if (signature !== previous) report(result);
+        previous = signature;
+      }
+    } else if (result.status !== "ready") process.exitCode = 1;
+    else if (options.command === "run" && !controller.signal.aborted) {
+      await compiler.dispose();
+      // Use the supplied JS entry and current Node, avoiding npm shell shims.
+      child = spawn(process.execPath, launchArguments(options), {
+        stdio: "inherit", signal: controller.signal,
+        env: { ...process.env, BH_PI_EXTENSION_ENTRY: options.entry, BH_PI_EXTENSION_OUTPUT: options.outfile },
+      });
+      process.exitCode = await new Promise((resolve, reject) => {
+        child.once("error", (error) => error.name === "AbortError" ? undefined : reject(error));
+        child.once("exit", (code, signal) => resolve(code ?? (signal ? 130 : 1)));
+      });
+    }
+  } finally {
+    await compiler.dispose();
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exitCode = 1; });
+}

--- a/scripts/pi-extension-runtime/compiler.mjs
+++ b/scripts/pi-extension-runtime/compiler.mjs
@@ -1,0 +1,109 @@
+import { createHash, randomUUID } from "node:crypto";
+import { builtinModules } from "node:module";
+import { mkdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import * as esbuild from "esbuild-wasm";
+
+// These are provided by Pi's native extension loader, not bundled copies.
+const hostPackages = new Set([
+  "@earendil-works/pi-coding-agent", "@earendil-works/pi-ai",
+  "@earendil-works/pi-ai/compat", "@earendil-works/pi-ai/oauth", "@earendil-works/pi-ai/providers/all",
+  "@earendil-works/pi-agent-core", "@earendil-works/pi-tui",
+  "typebox", "typebox/compile", "typebox/value",
+]);
+const builtins = new Set(builtinModules.flatMap((name) => [name, `node:${name}`]));
+
+function diagnostic(error) {
+  return { text: error.text ?? error.message ?? String(error),
+    ...(error.location ? { location: {
+      file: error.location.file, line: error.location.line,
+      column: error.location.column, lineText: error.location.lineText,
+    } } : {}) };
+}
+
+/** Trusted local source only. Compilation does not execute or sandbox it. */
+export async function createExtensionCompiler({ entry, outfile }) {
+  entry = path.resolve(entry);
+  outfile = path.resolve(outfile);
+  const canonical = async (file) => realpath(file).catch((error) => {
+    if (error.code === "ENOENT") return file;
+    throw error;
+  });
+  if (await canonical(entry) === await canonical(outfile)) throw new Error("Output must differ from the source entry.");
+  // Pi 0.85.1's Jiti loader can route .mjs and type:module .js to Node's
+  // persistent ESM cache. A .ts entry forces Pi's uncached loader even though
+  // esbuild has already lowered/bundled the source to JavaScript.
+  if (path.extname(outfile) !== ".ts") {
+    throw new Error("Output must end in .ts to use Pi's reloadable extension loader.");
+  }
+  const context = await esbuild.context({
+    absWorkingDir: path.dirname(entry), entryPoints: [entry], outfile,
+    bundle: true, write: false, format: "esm", platform: "node", target: "node22",
+    metafile: true, sourcemap: false, logLevel: "silent",
+    plugins: [{ name: "pi-host-imports", setup(build) {
+      build.onResolve({ filter: /^[^./]/ }, ({ path: specifier, kind }) => {
+        if (kind === "entry-point" || path.isAbsolute(specifier)) return;
+        if (hostPackages.has(specifier) || builtins.has(specifier)) {
+          return { path: specifier, external: true };
+        }
+        return { errors: [{ text: `Unsupported runtime import: ${specifier}. Use local source or a Pi-provided package.` }] };
+      });
+    } }],
+  });
+  let closed = false;
+  let tail = Promise.resolve();
+  let revision;
+  let disposePromise;
+
+  async function rebuild() {
+    if (closed) throw new Error("Compiler is disposed.");
+    const job = tail.then(async () => {
+      const started = performance.now();
+      try {
+        const result = await context.rebuild();
+        const output = result.outputFiles.find((file) => path.resolve(file.path) === outfile);
+        const metadata = Object.values(result.metafile.outputs).find((item) => item.entryPoint);
+        if (!output || !metadata?.exports.includes("default")) {
+          throw new Error("Pi extensions must export a default factory.");
+        }
+        // Never replace any source module, even if it was imported by the entry.
+        const sources = await Promise.all(Object.keys(result.metafile.inputs).map((file) =>
+          canonical(path.resolve(path.dirname(entry), file))));
+        if (sources.includes(await canonical(outfile))) {
+          throw new Error("Output must not overwrite an imported source module.");
+        }
+        const next = createHash("sha256").update(output.contents).digest("hex");
+        await mkdir(path.dirname(outfile), { recursive: true });
+        const temporary = path.join(path.dirname(outfile), `.${path.basename(outfile)}.${randomUUID()}.tmp`);
+        try {
+          await writeFile(temporary, output.contents, { flag: "wx" });
+          await rename(temporary, outfile);
+        } finally {
+          await rm(temporary, { force: true });
+        }
+        const changed = revision !== next;
+        revision = next;
+        return { status: "ready", revision, changed, bytes: output.contents.length,
+          durationMs: performance.now() - started, outfile,
+          diagnostics: result.warnings.map(diagnostic) };
+      } catch (error) {
+        return { status: "failed", revision: revision ?? null, outfile,
+          durationMs: performance.now() - started,
+          diagnostics: (error.errors ?? [error]).map(diagnostic) };
+      }
+    });
+    tail = job.catch(() => {});
+    return job;
+  }
+
+  return {
+    rebuild,
+    // A portable polling loop calls rebuild() and lets esbuild reuse its graph.
+    // Serial rebuilds also catch missing imports and newly created source files.
+    dispose() {
+      closed = true;
+      disposePromise ??= tail.then(() => context.dispose());
+      return disposePromise;
+    },
+  };
+}

--- a/scripts/pi-extension-runtime/examples/extension.ts
+++ b/scripts/pi-extension-runtime/examples/extension.ts
@@ -1,0 +1,9 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { greeting } from "./greeting";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("harness-hello", {
+    description: "Show the currently compiled Harness greeting",
+    handler: async (_args, ctx) => ctx.ui.notify(greeting, "info"),
+  });
+}

--- a/scripts/pi-extension-runtime/examples/greeting.ts
+++ b/scripts/pi-extension-runtime/examples/greeting.ts
@@ -1,0 +1,2 @@
+// Edit this value, then run /harness-reload and /harness-hello inside Pi.
+export const greeting: string = "Hello from the WASM-compiled Pi extension, v1";

--- a/scripts/pi-extension-runtime/native-smoke.mjs
+++ b/scripts/pi-extension-runtime/native-smoke.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { createExtensionCompiler } from "./compiler.mjs";
+
+// Opt-in, installed package only. No package download or real model request.
+const packageRoot = process.argv[2];
+if (!packageRoot) throw new Error("Usage: node scripts/pi-extension-runtime/native-smoke.mjs <installed-pi-package-root>");
+const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
+assert.equal(manifest.name, "@earendil-works/pi-coding-agent");
+assert.equal(manifest.version, "0.85.1", "Update the smoke evidence explicitly when changing Pi version.");
+const sdk = await import(pathToFileURL(path.resolve(packageRoot, manifest.main)));
+const scratch = await mkdtemp(path.join(os.tmpdir(), "native-pi-wasm-"));
+const cwd = path.join(scratch, "project 空格");
+const agentDir = path.join(scratch, "agent");
+await mkdir(cwd); await mkdir(agentDir);
+const entry = path.join(cwd, "extension.ts");
+const helper = path.join(cwd, "greeting.ts");
+const outfile = path.join(cwd, "compiled.ts");
+const previousEntry = process.env.BH_PI_EXTENSION_ENTRY;
+const previousOutput = process.env.BH_PI_EXTENSION_OUTPUT;
+process.env.BH_PI_EXTENSION_ENTRY = entry;
+process.env.BH_PI_EXTENSION_OUTPUT = outfile;
+let compiler, session, receipt;
+const notices = [];
+const errors = [];
+let reloads = 0;
+try {
+  await writeFile(path.join(cwd, "package.json"), '{"type":"module"}');
+  await writeFile(entry, `
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { greeting } from "./greeting";
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("harness-hello", { description: "Native smoke", handler: async (_args, ctx) => ctx.ui.notify(greeting) });
+  pi.registerTool({ name: "wasm_echo", label: "WASM echo", description: "Native tool schema probe",
+    parameters: Type.Object({ text: Type.String() }),
+    execute: async (_id, params) => ({ content: [{ type: "text", text: greeting + params.text }], details: {} }) });
+  pi.on("session_start", () => pi.appendEntry("wasm-start", { greeting }));
+  pi.on("session_shutdown", () => pi.appendEntry("wasm-stop", { greeting }));
+}
+`);
+  await writeFile(helper, 'export const greeting: string = "native-v1";');
+  compiler = await createExtensionCompiler({ entry, outfile });
+  const first = await compiler.rebuild();
+  assert.equal(first.status, "ready");
+  const unchanged = await compiler.rebuild();
+  assert.equal(unchanged.changed, false);
+  await compiler.dispose();
+
+  const settingsManager = sdk.SettingsManager.inMemory({ packages: [], compaction: { enabled: false } }, { projectTrusted: true });
+  const loader = new sdk.DefaultResourceLoader({
+    cwd, agentDir, settingsManager,
+    noSkills: true, noPromptTemplates: true, noThemes: true,
+    additionalExtensionPaths: [fileURLToPath(new URL("./pi-extension.mjs", import.meta.url)), outfile],
+  });
+  await loader.reload();
+  assert.deepEqual(loader.getExtensions().errors, []);
+  ({ session } = await sdk.createAgentSession({ cwd, agentDir, resourceLoader: loader,
+    settingsManager, sessionManager: sdk.SessionManager.inMemory(cwd), noTools: "builtin" }));
+  // Fail locally if a command ever falls through to an LLM call.
+  session.agent.prompt = async () => { throw new Error("Native smoke must not call a model."); };
+  await session.bindExtensions({
+    uiContext: { notify: (message, type) => notices.push({ message, type }) },
+    commandContextActions: {
+      waitForIdle: () => session.waitForIdle(),
+      reload: async () => { reloads++; await session.reload(); },
+    },
+    onError: (error) => errors.push(error),
+  });
+  await session.prompt("/harness-hello");
+  assert.equal(notices.at(-1).message, "native-v1");
+  assert.ok(session.getAllTools().some((tool) => tool.name === "wasm_echo"));
+  const echo = session.extensionRunner.getAllRegisteredTools().find((t) => t.definition.name === "wasm_echo");
+  assert.equal((await echo.definition.execute("smoke-echo", { text: "!" })).content[0].text, "native-v1!");
+  await writeFile(helper, 'export const greeting: string = "native-v2";');
+  await session.prompt("/harness-reload");
+  assert.equal(reloads, 1);
+  assert.deepEqual(loader.getExtensions().errors, []);
+  await session.prompt("/harness-hello");
+  assert.equal(notices.at(-1).message, "native-v2");
+  const lastGood = await readFile(outfile);
+  await writeFile(helper, "export const greeting = (");
+  await session.prompt("/harness-reload");
+  assert.equal(reloads, 1);
+  assert.equal(notices.at(-1).type, "error");
+  assert.deepEqual(await readFile(outfile), lastGood);
+  await session.prompt("/harness-hello");
+  assert.equal(notices.at(-1).message, "native-v2");
+  await writeFile(helper, 'export const greeting: string = "native-v3";');
+  await session.prompt("/harness-reload");
+  assert.equal(reloads, 2);
+  await session.prompt("/harness-hello");
+  assert.equal(notices.at(-1).message, "native-v3");
+  await writeFile(helper, 'export const greeting: string = "native-v4";');
+  const reloadTool = session.extensionRunner.getAllRegisteredTools().find((t) => t.definition.name === "harness_reload");
+  const queued = await reloadTool.definition.execute("smoke-reload", {});
+  assert.equal(queued.details.status, "queued");
+  const deadline = Date.now() + 10000;
+  while (!session.sessionManager.getEntries().some((e) => e.customType === "wasm-start" && e.data.greeting === "native-v4")) {
+    assert.ok(Date.now() < deadline, "Queued tool reload did not finish.");
+    await delay(20);
+  }
+  assert.equal(reloads, 3);
+  await session.prompt("/harness-hello");
+  assert.equal(notices.at(-1).message, "native-v4");
+  assert.deepEqual(errors, []);
+  const lifecycle = session.sessionManager.getEntries().filter((e) => ["wasm-start", "wasm-stop"].includes(e.customType));
+  assert.deepEqual(lifecycle.map((e) => [e.customType, e.data.greeting]), [
+    ["wasm-start", "native-v1"], ["wasm-stop", "native-v1"],
+    ["wasm-start", "native-v2"], ["wasm-stop", "native-v2"], ["wasm-start", "native-v3"],
+    ["wasm-stop", "native-v3"], ["wasm-start", "native-v4"],
+  ]);
+  receipt = { status: "passed", pi: manifest.version, node: process.version,
+    platform: process.platform, arch: process.arch, reloads, lifecycleEvents: lifecycle.length,
+    compilationMs: { initial: first.durationMs, unchanged: unchanged.durationMs }, bytes: first.bytes,
+    modelRequests: 0 };
+} finally {
+  if (session) {
+    await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+    session.dispose();
+  }
+  await compiler?.dispose();
+  if (previousEntry === undefined) delete process.env.BH_PI_EXTENSION_ENTRY;
+  else process.env.BH_PI_EXTENSION_ENTRY = previousEntry;
+  if (previousOutput === undefined) delete process.env.BH_PI_EXTENSION_OUTPUT;
+  else process.env.BH_PI_EXTENSION_OUTPUT = previousOutput;
+  await rm(scratch, { recursive: true, force: true });
+}
+process.stdout.write(`${JSON.stringify(receipt)}\n`);

--- a/scripts/pi-extension-runtime/pi-extension.mjs
+++ b/scripts/pi-extension-runtime/pi-extension.mjs
@@ -1,0 +1,59 @@
+import path from "node:path";
+import { createExtensionCompiler } from "./compiler.mjs";
+
+/** Control only: the generated module is loaded separately by official Pi. */
+export default function runtimeCompiler(pi) {
+  let compiler;
+  let building = false;
+  let stopped = false;
+
+  pi.registerCommand("harness-reload", {
+    description: "Compile Harness extension with esbuild-wasm, then reload Pi",
+    handler: async (_args, ctx) => {
+      if (building || stopped) return;
+      building = true;
+      try {
+        await ctx.waitForIdle();
+        if (stopped) return;
+        const entry = process.env.BH_PI_EXTENSION_ENTRY;
+        const outfile = process.env.BH_PI_EXTENSION_OUTPUT;
+        if (!entry || !outfile) throw new Error("Start with the pi-extension-runtime run command to select source and output.");
+        compiler ??= await createExtensionCompiler({
+          entry: path.resolve(ctx.cwd, entry), outfile: path.resolve(ctx.cwd, outfile),
+        });
+        if (stopped) { await compiler.dispose(); return; }
+        const result = await compiler.rebuild();
+        if (stopped) return;
+        if (result.status !== "ready") {
+          ctx.ui.notify(`Harness compilation failed; previous extension retained.\n${result.diagnostics.map((d) => d.text).join("\n")}`, "error");
+          return;
+        }
+        ctx.ui.notify(`Harness compiled ${result.revision.slice(0, 12)} (${Math.round(result.durationMs)} ms). Reloading Pi.`, "info");
+        // A reload invalidates the old context. Only local cleanup follows it.
+        await ctx.reload();
+        return;
+      } catch (error) {
+        if (!stopped) ctx.ui.notify(error.message ?? String(error), "error");
+        return;
+      } finally {
+        building = false;
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "harness_reload", label: "Compile Harness extension",
+    description: "After editing the configured Harness extension source, queue compilation and native Pi reload. Completion is reported by the command, not this tool.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+    async execute() {
+      // Pi 0.85.1 otherwise treats this as literal model input, not a command.
+      pi.sendUserMessage("/harness-reload", { deliverAs: "followUp", expandPromptTemplates: true });
+      return { content: [{ type: "text", text: "Queued /harness-reload; compilation and activation have not completed yet." }], details: { status: "queued" } };
+    },
+  });
+
+  pi.on("session_shutdown", async () => {
+    stopped = true;
+    await compiler?.dispose();
+  });
+}

--- a/test/pi-extension-runtime/cli.test.mjs
+++ b/test/pi-extension-runtime/cli.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { test } from "vitest";
+import { launchArguments, parseArgs } from "../../scripts/pi-extension-runtime/cli.mjs";
+
+const cli = fileURLToPath(new URL("../../scripts/pi-extension-runtime/cli.mjs", import.meta.url));
+function run(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cli, ...args]);
+    let stdout = "", stderr = "";
+    child.stdout.on("data", (d) => { stdout += d; });
+    child.stderr.on("data", (d) => { stderr += d; });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("help succeeds and unknown commands/options or missing values fail", async () => {
+  const help = await run(["--help"]);
+  assert.equal(help.code, 0);
+  assert.match(help.stdout, /harness-reload/);
+  for (const args of [["oops"], ["build", "--wat"], ["build", "--entry"], ["run", "--entry", "a", "--out", "b"]]) {
+    const failure = await run(args);
+    assert.equal(failure.code, 1);
+    assert.equal(failure.stdout, "");
+    assert.ok(failure.stderr.length > 0);
+  }
+});
+
+test("Pi launch keeps paths and native arguments as separate argv entries", () => {
+  const options = parseArgs(["run", "--entry", "source 空格.ts", "--out", "out file.ts", "--pi-cli", "pi cli.js", "--", "--no-session"]);
+  const args = launchArguments(options);
+  assert.equal(args[0], path.resolve("pi cli.js"));
+  assert.equal(args[1], "--no-session");
+  assert.equal(args.at(-1), path.resolve("out file.ts"));
+  assert.equal(args.filter((value) => value === "-e").length, 2);
+});
+
+test("build emits JSON only and failed compile preserves the artifact", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi cli 空格 "));
+  try {
+    const entry = path.join(root, "source.ts"), outfile = path.join(root, "output.ts");
+    const args = ["build", "--entry", entry, "--out", outfile, "--json"];
+    await writeFile(entry, 'export default () => "ok";');
+    const good = await run(args);
+    assert.equal(good.code, 0);
+    assert.equal(good.stderr, "");
+    assert.equal(JSON.parse(good.stdout).status, "ready");
+    const bytes = await readFile(outfile);
+    await writeFile(entry, "export default (");
+    const bad = await run(args);
+    assert.equal(bad.code, 1);
+    assert.equal(JSON.parse(bad.stdout).status, "failed");
+    assert.deepEqual(await readFile(outfile), bytes);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("run launches the supplied JavaScript CLI with native args and selected source/output", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi run 空格 "));
+  try {
+    const entry = path.join(root, "source.ts"), outfile = path.join(root, "output.ts");
+    const fakePi = path.join(root, "fake pi.mjs");
+    await writeFile(entry, 'export default () => "ready";');
+    await writeFile(fakePi, 'process.stdout.write(JSON.stringify({args:process.argv.slice(2),entry:process.env.BH_PI_EXTENSION_ENTRY,outfile:process.env.BH_PI_EXTENSION_OUTPUT}));');
+    const result = await run(["run", "--entry", entry, "--out", outfile, "--pi-cli", fakePi, "--", "--no-session"]);
+    assert.equal(result.code, 0);
+    const observed = JSON.parse(result.stdout);
+    assert.equal(observed.entry, entry);
+    assert.equal(observed.outfile, outfile);
+    assert.equal(observed.args[0], "--no-session");
+    assert.equal(observed.args.at(-1), outfile);
+    await writeFile(entry, "export default (");
+    const failed = await run(["run", "--entry", entry, "--out", outfile, "--pi-cli", fakePi]);
+    assert.equal(failed.code, 1);
+    assert.equal(failed.stdout, "", "Pi must not start after a failed initial build");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("watch observes edits, retains output on error, recovers and exits on termination", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi watch "));
+  let child;
+  try {
+    const entry = path.join(root, "source.ts"), outfile = path.join(root, "output.ts");
+    await writeFile(entry, 'export default () => "v1";');
+    child = spawn(process.execPath, [cli, "watch", "--entry", entry, "--out", outfile, "--json"]);
+    const exit = new Promise((resolve, reject) => { child.once("exit", resolve); child.once("error", reject); });
+    const events = []; let pending = "";
+    child.stdout.on("data", (chunk) => {
+      pending += chunk;
+      let newline;
+      while ((newline = pending.indexOf("\n")) >= 0) {
+        events.push(JSON.parse(pending.slice(0, newline))); pending = pending.slice(newline + 1);
+      }
+    });
+    async function next(status) {
+      const deadline = Date.now() + 20000;
+      while (!events.length) { assert.ok(Date.now() < deadline, "Watcher did not report a build"); await delay(20); }
+      const event = events.shift(); assert.equal(event.status, status); return event;
+    }
+    const first = await next("ready");
+    await writeFile(entry, 'export default () => "v2";');
+    const second = await next("ready");
+    assert.notEqual(second.revision, first.revision);
+    const lastGood = await readFile(outfile);
+    await writeFile(entry, "export default (");
+    await next("failed");
+    assert.deepEqual(await readFile(outfile), lastGood);
+    await writeFile(entry, 'export default () => "v3";');
+    await next("ready");
+    child.kill("SIGTERM");
+    await exit;
+  } finally {
+    child?.kill("SIGKILL");
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/pi-extension-runtime/compiler.test.mjs
+++ b/test/pi-extension-runtime/compiler.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, test } from "vitest";
+import { createExtensionCompiler } from "../../scripts/pi-extension-runtime/compiler.mjs";
+
+const cleanups = [];
+afterEach(async () => { for (const cleanup of cleanups.splice(0).reverse()) await cleanup(); });
+async function fixture(source = 'import { value } from "./helper"; export default () => value;') {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi wasm 空格 "));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const entry = path.join(root, "entry.ts");
+  const outfile = path.join(root, "compiled.ts");
+  const helper = path.join(root, "helper.ts");
+  await writeFile(entry, source);
+  await writeFile(helper, 'export const value: string = "v1";');
+  const compiler = await createExtensionCompiler({ entry, outfile });
+  cleanups.push(() => compiler.dispose());
+  return { root, entry, outfile, helper, compiler };
+}
+const load = async (f, revision) => (await import(`${pathToFileURL(f.outfile).href}?revision=${revision}`)).default();
+
+test("WASM bundles local TypeScript imports and incremental rebuild executes changed code", async () => {
+  const f = await fixture();
+  const one = await f.compiler.rebuild();
+  assert.equal(one.status, "ready");
+  assert.equal(await load(f, one.revision), "v1");
+  assert.equal((await f.compiler.rebuild()).changed, false);
+  await writeFile(f.helper, 'export const value: string = "v2";');
+  const two = await f.compiler.rebuild();
+  assert.equal(two.status, "ready");
+  assert.notEqual(two.revision, one.revision);
+  assert.equal(await load(f, two.revision), "v2");
+});
+
+test.each([
+  ['syntax', 'export default ('],
+  ['missing dependency', 'import x from "./missing"; export default () => x;'],
+  ['missing default', 'export const value = 1;'],
+  ['unsupported runtime import', 'import x from "not-installed"; export default () => x;'],
+])("%s failure preserves last published revision and bytes, then recovers", async (_name, source) => {
+  const f = await fixture();
+  const first = await f.compiler.rebuild();
+  const before = await readFile(f.outfile);
+  await writeFile(f.entry, source);
+  const failure = await f.compiler.rebuild();
+  assert.equal(failure.status, "failed");
+  assert.equal(failure.revision, first.revision);
+  assert.ok(failure.diagnostics.length);
+  assert.deepEqual(await readFile(f.outfile), before);
+  await writeFile(f.entry, 'export default () => "recovered";');
+  const recovered = await f.compiler.rebuild();
+  assert.equal(recovered.status, "ready");
+  assert.equal(await load(f, recovered.revision), "recovered");
+});
+
+test("concurrent builds publish complete output, disposal drains and rejects further work", async () => {
+  const f = await fixture();
+  const builds = [f.compiler.rebuild(), f.compiler.rebuild()];
+  await f.compiler.dispose();
+  const results = await Promise.all(builds);
+  assert.ok(results.every((r) => r.status === "ready"));
+  assert.equal(await load(f, results[1].revision), "v1");
+  await assert.rejects(f.compiler.rebuild(), /disposed/);
+  await f.compiler.dispose();
+});
+
+test("output cannot overwrite entry or imported source", async () => {
+  const f = await fixture();
+  await assert.rejects(createExtensionCompiler({ entry: f.entry, outfile: f.entry }), /differ/);
+  const shared = path.join(f.root, "shared.ts");
+  await writeFile(shared, 'export default "source";');
+  await writeFile(f.entry, 'import value from "./shared.ts"; export default () => value;');
+  const compiler = await createExtensionCompiler({ entry: f.entry, outfile: shared });
+  cleanups.push(() => compiler.dispose());
+  assert.equal((await compiler.rebuild()).status, "failed");
+  assert.equal(await readFile(shared, "utf8"), 'export default "source";');
+});
+
+test("rejects output suffixes that can retain stale modules in official Pi", async () => {
+  const f = await fixture();
+  for (const suffix of [".mjs", ".js", ".cjs"]) {
+    await assert.rejects(createExtensionCompiler({ entry: f.entry, outfile: path.join(f.root, `compiled${suffix}`) }), /reloadable/);
+  }
+});
+
+test("Node builtins execute and Pi imports remain external in the bundle", async () => {
+  const f = await fixture('import { basename } from "node:path"; export default () => basename("hello.txt");');
+  const result = await f.compiler.rebuild();
+  assert.equal(result.status, "ready");
+  assert.equal(await load(f, result.revision), "hello.txt");
+  // Real Pi resolution of TypeBox is exercised by native-smoke.mjs.
+  await writeFile(f.entry, 'import { Type } from "typebox"; export default () => Type.String();');
+  assert.equal((await f.compiler.rebuild()).status, "ready");
+});


### PR DESCRIPTION
This independent experiment compiles changing TypeScript extensions with esbuild-wasm and loads them in official Pi. Editing an imported source file and running `/harness-reload` now compiles a complete revision, waits for idle, and uses Pi's native reload. A compilation error preserves the prior artifact and running extension.

The branch starts directly from `main` at `0c09b891`; it does not include the Studio DSH/Pi UI changes from #158. That PR's description has been updated with the dependency-size analysis and this follow-up boundary.

### Implementation

- A capability-local `build`, `watch`, and `run` CLI, with JSON/JSONL receipts and explicit installed Pi JS entry. No package installation or new host adapter.
- Existing `esbuild-wasm@0.28.2`, incremental build contexts, local-source bundling, Pi-owned imports kept external, SHA-256 revisions, and atomic successful publication.
- Native `/harness-reload` command and `harness_reload` tool. The tool reports queued work and explicitly enables command expansion, preventing the command from becoming literal model input in Pi 0.85.1.
- Compiled JavaScript uses a `.ts` entry. Live official-terminal verification found that `.mjs` and ESM-project `.js` can remain cached after Pi reports reload success; the `.ts` loading path avoids that stale-code behavior.
- A runnable example, behavior tests, pinned native SDK smoke, and source-grounded DSH comparison.

### Validation

- Node 24.20.0: **14 behavior tests**, **8 Markdown link tests**, and **41 related artifact/governance checks passed**, with **1 skipped**. Generated document routing graph is unchanged.
- Actual Pi 0.85.1 SDK: three native reloads and seven lifecycle events; v1/v2 execution, syntax failure preserving v2, recovery to v3, and tool-dispatched v4. Runtime TypeBox tool registration/execution verified. No Pi model calls or global installs.
- Actual npm bundled Pi CLI in a PTY, including an ESM project: observed new command output after reload, old output after compile failure, repaired output after another reload, and clean Ctrl+D shutdown. The isolated Pi profile downloaded its own fd helper on first start.
- Independent Codex CLI consumer successfully followed README/help, checked parseable JSON and artifact SHA-256, then verified exit 1 and unchanged artifact bytes after invalid source.
- Scoped staged diff check passed. Canvas preview could not start because the Canvas SDK runtime is absent; its health/module endpoints are not claimed verified. No Studio UI changes.

### Draft boundaries

This proves runtime extension compilation and native loading; it does not reduce Pi's existing installed dependency closure. The already-present esbuild-wasm package is about 13.86 MiB locally, including a 13.33 MiB WASM binary. No dependency or lockfile changes.

Watch compiles every 500 ms through a reused context but does not activate code automatically. Run activates through the explicit command/tool. Use one writer per output. Native reload disposes the control extension's compiler and creates a new instance; warm state across whole-session reload is not promised. Compilation is not type checking, a sandbox, or rollback of arbitrary factory side effects. Native Windows/Linux, real model-driven editing, and Desktop packaging remain unverified; hosted CI is separate evidence.

DSH supports live profile patches and opt-in source-module HMR, while Bundle membership changes require Profile restart and browser clients have their own build. A WASM-to-DSH activation adapter remains a separate experiment, not implemented here.

Usage: `scripts/pi-extension-runtime/README.md`.
Spec and evidence: `docs/specs/2026-09-09-pi-wasm-extension-runtime.md`.
