### PR TITLE
feat(harness): compile dsh plugins at runtime with wasm

### DIFF
--- a/docs/specs/2026-09-09-dsh-wasm-plugin-runtime.md
+++ b/docs/specs/2026-09-09-dsh-wasm-plugin-runtime.md
@@ -1,0 +1,103 @@
+# Compile and reload plugins in the official DSH runtime
+
+## Traceability
+
+- Spec ID: dsh-wasm-plugin-runtime
+- Status: Implemented as a local experiment
+- Request: a DSH equivalent of the Pi runtime extension compiler experiment.
+- Independent branch from main; no Story id was supplied.
+
+## Intent
+
+Keep the preinstalled official DSH runtime and Web interface running while
+compiling a changing local TypeScript plugin with esbuild-wasm. Publish a new
+immutable module and update its Profile entry through DSH's existing live patch
+mechanism, avoiding changes to the installed Bundle set or global module HMR.
+
+## Acceptance scenarios
+
+- **AC-1:** Build an entry and its local imports with existing esbuild-wasm,
+  retaining DSH-owned packages as external imports. Require named `apply` and
+  emit a content-addressed module. Compilation errors preserve the active patch.
+- **AC-2:** A new explicitly selected experiment home owns its Profile manifest
+  and patch. Reject non-owned nonempty homes; never alter the user's default
+  DSH home or an existing general-purpose Profile. Publish the module before
+  atomically replacing the patch. Only one writer may own a given home.
+- **AC-3:** Run an explicitly selected installed DSH JS CLI with the official
+  base/Web bundles and live Profile patches. A later build updates the plugin
+  in the same DSH process. Optional watch mode explicitly authorizes rebuild
+  and activation after saves. Shutdown disposes the compiler and child process.
+- **AC-4:** A real DSH smoke observes v1 -> v2, old-instance disposal, unchanged
+  PID and Web URL, compilation-error retention and recovery. Verify the native
+  Web shell, a registered tool and a probe route without model calls. Test the
+  official browser interface separately from a fixture or HTTP-only claim.
+- **AC-5:** Cover portable path/CLI/JSON contracts, publication failure,
+  ownership and lifecycle; document differences from Pi and runtime limits.
+
+## Non-goals
+
+Studio page changes, a DSH replacement UI, full-application source compilation,
+Bundle installation, default-home mutation, a new supported agent adapter,
+arbitrary runtime side-effect rollback, automatic idle detection across all
+Agents, browser client compilation, packaged desktop acceptance, or removal of
+dependencies already present in DSH.
+
+## Plan and tasks
+
+1. Add a capability under `scripts/dsh-plugin-runtime/` with build/watch/run,
+   a DSH-specific compiler and owned Profile publisher. No imports from Pi's
+   private capability implementation and no package/lockfile changes.
+2. Store content-addressed modules under the experiment Profile, letting DSH's
+   installation fallback resolve native imports. A single named Profile row
+   changes its module URL on each code revision; existing bundles stay fixed.
+3. Demonstrate a native model-facing greeting tool and an inert read-only probe
+   route. Bind routes and lifecycle receipts to Cordis effects so reload removes
+   old registrations. No privileged mutation endpoint is introduced.
+4. Exercise actual official Web boot and native reload, plus compile failures,
+   duplicate publication and graceful shutdown. Record evidence and limitations.
+
+## Test and review evidence
+
+- AC-1/2/3/5: 13 focused runtime and CLI tests pass, including immutable module
+  execution, imported same-length edits, failed-build retention/recovery,
+  ownership/patch mutation rejection, writer lock exclusion, watch activation
+  publication and child shutdown through stdin control.
+- AC-4: native smoke against installed DSH 0.1.2-rc.1 on macOS / Node 24.20.0
+  observes v1 -> v2 -> v3 in one PID and Web URL, with disposal of each replaced
+  instance and final disposal on shutdown. Syntax error leaves v2 callable;
+  recovery activates v3. GET probe invokes the actual registered tool
+  definition; it does not exercise the full tool dispatch or model pipeline.
+- AC-4: Playwright opened official Web, confirmed first-start notice, selected
+  a temporary workspace through the official browser picker, focused the input,
+  and retained an unsent draft across both reloads. Zero console/page errors;
+  before/after screenshots were inspected. No model requests were made.
+- One browser smoke measured 183 ms initial compilation, 83 ms incremental
+  compilation and a 1,369-byte example module. Timings exclude native activation.
+  Receipts/screenshots live under ignored `dist/dsh-wasm-smoke/`.
+- Combined focused, doc-link, scripts architecture and Antigravity artifact
+  checks: 63 passed, 1 skipped. Doc-link graph regeneration produced no diff.
+- A bounded Codex CLI consumer read only README/help before invoking three
+  builds: valid publication, invalid syntax with nonzero exit and unchanged
+  patch, then valid recovery with a different revision. No documentation
+  problem was observed; it did not start DSH or inspect the implementation.
+- `npm run preview` could not start because the local Canvas SDK runtime is
+  absent; its `/health` and `/canvas-module.js` were not verified. This is
+  separate from the successful native DSH Web browser smoke.
+- Windows/Linux native DSH execution, packaged Studio and hosted CI are not
+  part of the local acceptance claim. No Studio visual surface changed.
+
+Readiness scope: the compiler, CLI, example, native smoke, tests and capability
+README implement this spec. No supplied Story id, package changes, generated
+changes or unrelated checkout edits are included. Local code was reviewed for
+publication ordering, native lifecycle cleanup, host path handling and the
+published/activated distinction. The commit records its AI co-author explicitly.
+
+## Risks and boundaries
+
+Trusted local plugin code executes with DSH host authority. Compilation is not
+type checking or a sandbox. Updating a plugin may interrupt its active work;
+use an idle experiment session. Invalid runtime behavior after successful
+compilation is not guaranteed to roll back. Immutable modules avoid ESM cache
+reuse but remain in the process module cache until exit; repeated long-running
+editing sessions should restart periodically. Profile module updates differ
+from changes to Bundle membership, which still require process restart.

--- a/scripts/dsh-plugin-runtime/README.md
+++ b/scripts/dsh-plugin-runtime/README.md
@@ -1,0 +1,120 @@
+# DSH plugin runtime compiler
+
+Compile a local TypeScript plugin with esbuild-wasm and replace its registration
+in a running official DSH process. The official Web interface stays open; DSH's
+native Profile loader disposes the previous plugin and applies the next one.
+This is an independent experiment, described in the
+[spec](../../docs/specs/2026-09-09-dsh-wasm-plugin-runtime.md).
+
+## Start and update
+
+Use repository dependencies and Node 24. Supply an already installed
+`@deepseek-ai/dsh` JavaScript CLI; the native smoke is pinned to `0.1.2-rc.1`.
+No installer or DSH dependency is added by this capability.
+
+From the repository root, replace the DSH path below with your installation:
+
+```sh
+node scripts/dsh-plugin-runtime/cli.mjs run --entry scripts/dsh-plugin-runtime/examples/plugin.ts --home dist/dsh-runtime-home --dsh-cli /path/to/node_modules/@deepseek-ai/dsh/lib/bin.js
+```
+
+This compiles first, then starts a **new** official DSH Web process on a random
+loopback port. Open the URL printed by DSH, complete its first-start notice and
+choose a workspace. The explicit home must be empty or already owned by this
+experiment. Your normal DSH home is not used.
+
+Edit `examples/greeting.ts`, then run in another terminal:
+
+```sh
+node scripts/dsh-plugin-runtime/cli.mjs build --entry scripts/dsh-plugin-runtime/examples/plugin.ts --home dist/dsh-runtime-home --json
+```
+
+The running DSH loads the new plugin without a process restart. The example
+registers `harness_greeting` and a GET-only `/harness-wasm-probe` route. The route
+returns the current greeting, the actual registered tool definition's result
+and PID, so activation can be checked without making a model request. It does
+not exercise DSH's full permission/approval/tool dispatch pipeline.
+
+For automatic compilation and activation on save, add `--watch` to `run`, or
+start a separate `watch` command with the same entry and home. Polling compares
+source bytes every 500 ms, including local imported files. Use an idle
+experiment session: this implementation does not coordinate with active Agent
+turns. Without watch, saves take effect only after an explicit build.
+
+Stop `run` with Ctrl+C; it terminates the child it launched. Automation may use
+`run --control-stdio` and send `stop` or close stdin. Standalone `watch` only owns
+its compiler, so stopping it leaves DSH running. `--port` selects a fixed port.
+This command does not discover or attach to arbitrary existing DSH sessions.
+
+## Publication contract
+
+The compiler creates an isolated `wasm` Profile with fixed official base and
+Web bundles and `patchReload: "live"`. Local code is bundled into an immutable
+`profiles/wasm/modules/<sha256>.mjs`. Node built-ins and `@deepseek-ai/*` imports
+stay external and resolve through the installed DSH runtime. Other bare imports
+are rejected; this is not a package installation mechanism.
+
+The module is written before an atomic replacement of `cordis.patch.yml`
+(JSON syntax, which is valid YAML). Each revision changes the same plugin row's
+module URL. This avoids reusing a cached ESM module. Compilation errors leave
+the last published patch intact. Manually changed Profile manifests or patches
+are rejected instead of being overwritten.
+
+`build --json` and `watch --json` emit one result per attempted build. A
+`published` result contains the revision, paths, byte count, duration, whether
+the patch changed, and `activation: "pending-native-loader"`. Publication does
+not prove successful native activation. `failed` contains diagnostics; a failed
+one-shot build exits nonzero. Setup/argument failures go to stderr and exit
+nonzero. An unchanged watch iteration emits nothing.
+
+A per-home directory lock excludes simultaneous compilers. After a crashed
+compiler, use a fresh empty home, or remove its `.compiler-lock` only after
+confirming no compiler is using that home. The experiment does not steal locks.
+
+## Scope and comparison with Pi
+
+Both this experiment and [the Pi experiment PR](https://github.com/QoderAI/better-harness/pull/159)
+keep the application runtime preinstalled and compile only changing extensions.
+Pi uses its extension reload API; DSH uses its existing live Profile patch
+watcher and Cordis lifecycle. No custom conversation UI is introduced here.
+
+The compiler reuses the repository's existing esbuild-wasm dependency. The
+example module is 1,369 bytes in the native smoke; this does **not** reduce the
+installed DSH dependency closure or mean the whole application fits in that
+size. No package or lockfile change is needed.
+
+Plugin code executes with DSH host authority. Compilation does not type-check,
+sandbox code, or guarantee an `apply` export is callable. Native activation
+errors and arbitrary side effects do not have a rollback guarantee. Plugins
+must bind cleanup to Cordis effects; the example scopes its route this way.
+Immutable modules accumulate on disk and in the process ESM cache; restart for
+long editing sessions and delete the dedicated home after stopping the runtime
+if its experiment state is no longer needed.
+
+Changing the Bundle set still requires restart. This does not compile the DSH
+core or browser client at runtime, modify Studio, or add a supported host adapter.
+See the upstream pinned
+[Profile contract](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/apps/cli/reference/README.md)
+and [native loader contract](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/vendor/loader/README.md).
+
+## Validation
+
+```sh
+npx vitest run test/dsh-plugin-runtime
+node scripts/dsh-plugin-runtime/native-smoke.mjs /path/to/node_modules/@deepseek-ai/dsh
+node scripts/dsh-plugin-runtime/native-smoke.mjs /path/to/node_modules/@deepseek-ai/dsh --browser
+```
+
+The optional browser smoke uses the workspace's Playwright and installed
+Chromium. It selects DSH's official browser directory picker for headless use,
+opens a temporary workspace, focuses the official input, retains an unsent
+draft across two native reloads, and captures screenshots and a JSON receipt in
+`dist/dsh-wasm-smoke/`. It cleans up its temporary runtime and makes no model
+requests.
+
+Local macOS / Node 24.20.0 / DSH 0.1.2-rc.1 evidence: two reloads in the same
+process, all three plugin instances disposed, syntax failure retained v2,
+recovery activated v3, official Web draft retained, zero browser errors. One
+run measured 183 ms initial compilation and 83 ms incremental compilation;
+these timings exclude native loader activation and are not a benchmark.
+Windows/Linux native execution and packaged Studio acceptance remain unverified.

--- a/scripts/dsh-plugin-runtime/cli.mjs
+++ b/scripts/dsh-plugin-runtime/cli.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
+import { setTimeout as delay } from "node:timers/promises";
+import { createPluginRuntime } from "./runtime.mjs";
+
+const help = `Experimental DSH plugin runtime compiler
+
+Usage:
+  node scripts/dsh-plugin-runtime/cli.mjs build --entry <plugin.ts> --home <experiment-home> [--json]
+  node scripts/dsh-plugin-runtime/cli.mjs watch --entry <plugin.ts> --home <experiment-home> [--json]
+  node scripts/dsh-plugin-runtime/cli.mjs run --entry <plugin.ts> --home <experiment-home> --dsh-cli <installed-bin.js> [--port <number>] [--watch] [--control-stdio]
+
+build publishes an immutable module and its native DSH Profile patch.
+watch rebuilds and activates after saves in a running experiment DSH.
+run compiles, then starts official DSH Web on loopback. Open its printed URL.
+--watch on run enables compile/activation after saves; default is explicit build.
+--control-stdio accepts "stop" or EOF on stdin for portable automated shutdown.
+Use an empty, dedicated home. Existing general-purpose DSH homes are rejected.
+Use an idle experiment session: plugin reload may interrupt its active work.
+No packages are installed. Published does not mean native activation succeeded.
+`;
+
+export function parseArgs(args) {
+  if (!args.length || ["--help", "-h"].includes(args[0])) return { help: true };
+  const [command, ...rest] = args;
+  if (!["build", "watch", "run"].includes(command)) throw new Error(`Unknown command: ${command}`);
+  const options = { command, port: 0 };
+  for (let i = 0; i < rest.length; i++) {
+    const flag = rest[i];
+    if (["--help", "-h"].includes(flag)) return { help: true };
+    if (flag === "--json" && command !== "run" && !options.json) { options.json = true; continue; }
+    if (flag === "--watch" && command === "run" && !options.watch) { options.watch = true; continue; }
+    if (flag === "--control-stdio" && command === "run" && !options.controlStdio) { options.controlStdio = true; continue; }
+    const key = { "--entry": "entry", "--home": "home", "--dsh-cli": "dshCli", "--port": "port" }[flag];
+    if (!key || (["dshCli", "port"].includes(key) && command !== "run")) throw new Error(`Unknown option: ${flag}`);
+    if (options[key] && key !== "port") throw new Error(`Duplicate option: ${flag}`);
+    const value = rest[++i];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
+    if (key === "port") {
+      if (!/^\d+$/.test(value) || Number(value) > 65535) throw new Error("Port must be an integer from 0 to 65535.");
+      options.port = Number(value);
+    } else options[key] = path.resolve(value);
+  }
+  if (!options.entry || !options.home) throw new Error("--entry and --home are required.");
+  if (command === "run" && !options.dshCli) throw new Error("run requires an installed DSH JavaScript --dsh-cli entry.");
+  return options;
+}
+
+export function launchArguments(options) {
+  return [options.dshCli, "--profile", "wasm", "--host", "127.0.0.1", "--port", String(options.port), "--no-open"];
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) { process.stdout.write(help); return; }
+  if (options.dshCli) await access(options.dshCli);
+  const runtime = await createPluginRuntime(options);
+  const controller = new AbortController();
+  const stop = () => controller.abort();
+  process.once("SIGINT", stop); process.once("SIGTERM", stop);
+  const report = (result) => {
+    if (result.status === "unchanged") return;
+    if (options.json) process.stdout.write(`${JSON.stringify(result)}\n`);
+    else if (result.status === "published") process.stderr.write(`Published ${result.revision.slice(0, 12)} (${Math.round(result.durationMs)} ms); native activation pending.\n`);
+    else process.stderr.write(`${result.diagnostics.map((d) => d.text).join("\n")}\n`);
+  };
+  let child, childExit, killTimer, control;
+  try {
+    const initial = await runtime.build(); report(initial);
+    if (initial.status === "failed" && options.command !== "watch") { process.exitCode = 1; return; }
+    if (options.command === "run") {
+      child = spawn(process.execPath, launchArguments(options), { stdio: ["ignore", "inherit", "inherit"], env: { ...process.env, DSH_HOME: options.home } });
+      childExit = new Promise((resolve) => {
+        child.once("error", (error) => { process.stderr.write(`${error.message}\n`); stop(); resolve(1); });
+        child.once("exit", (code, signal) => { stop(); resolve(code ?? (signal ? 130 : 1)); });
+      });
+      const terminate = () => {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        child.kill("SIGTERM");
+        killTimer = setTimeout(() => child.kill("SIGKILL"), 6000); killTimer.unref();
+      };
+      controller.signal.addEventListener("abort", terminate, { once: true });
+      if (controller.signal.aborted) terminate();
+      if (options.controlStdio) {
+        control = createInterface({ input: process.stdin });
+        control.on("line", (line) => { if (line.trim() === "stop") stop(); });
+        control.on("close", stop);
+      }
+    }
+    if (options.command === "watch" || options.watch) {
+      while (!controller.signal.aborted) {
+        await delay(500, undefined, { signal: controller.signal }).catch(() => {});
+        if (!controller.signal.aborted) report(await runtime.build({ onlyChanged: true }));
+      }
+    }
+    if (childExit) process.exitCode = await childExit;
+  } finally {
+    control?.close(); clearTimeout(killTimer); await runtime.dispose();
+    process.removeListener("SIGINT", stop); process.removeListener("SIGTERM", stop);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exitCode = 1; });
+}

--- a/scripts/dsh-plugin-runtime/examples/greeting.ts
+++ b/scripts/dsh-plugin-runtime/examples/greeting.ts
@@ -1,0 +1,1 @@
+export const greeting: string = "Hello from the WASM-compiled DSH plugin, v1";

--- a/scripts/dsh-plugin-runtime/examples/plugin.ts
+++ b/scripts/dsh-plugin-runtime/examples/plugin.ts
@@ -1,0 +1,28 @@
+import type { Context } from "@deepseek-ai/cordis";
+import { defineTool } from "@deepseek-ai/dsh-tools";
+import { greeting } from "./greeting";
+
+export const inject = ["tools", "webServer"];
+
+export function apply(ctx: Context) {
+  ctx.effect(() => {
+    console.log(`HARNESS_WASM_LIFECYCLE ${JSON.stringify({ event: "start", greeting, pid: process.pid })}`);
+    return () => console.log(`HARNESS_WASM_LIFECYCLE ${JSON.stringify({ event: "stop", greeting, pid: process.pid })}`);
+  });
+  ctx.tools.register(defineTool({
+    name: "harness_greeting", description: "Read the greeting from the currently loaded Harness plugin.",
+    parameters: {}, output: { schema: { type: "string" }, render: (_args, value) => [{ type: "text", text: value }] },
+    async execute() { return greeting; },
+  }));
+  // Inert GET-only probe. The official DSH Web UI and API remain upstream-owned.
+  ctx.effect(() => ctx.webServer.register({ kind: "exact", path: "/harness-wasm-probe",
+    async handler(req, res) {
+      if (req.method !== "GET") { res.writeHead(405); res.end(); return; }
+      const tool = ctx.tools.get("harness_greeting");
+      const value = await tool.execute({}, { signal: new AbortController().signal });
+      res.setHeader("Content-Type", "application/json");
+      res.setHeader("Cache-Control", "no-store");
+      res.end(JSON.stringify({ greeting, toolValue: value, pid: process.pid }));
+    },
+  }));
+}

--- a/scripts/dsh-plugin-runtime/native-smoke.mjs
+++ b/scripts/dsh-plugin-runtime/native-smoke.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { createPluginRuntime } from "./runtime.mjs";
+
+const packageRoot = process.argv[2];
+const browserCheck = process.argv.includes("--browser");
+const output = path.resolve("dist/dsh-wasm-smoke");
+if (!packageRoot) throw new Error("Usage: node scripts/dsh-plugin-runtime/native-smoke.mjs <installed-dsh-package-root> [--browser]");
+const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
+assert.equal(manifest.name, "@deepseek-ai/dsh");
+assert.equal(manifest.version, "0.1.2-rc.1");
+const scratch = await mkdtemp(path.join(os.tmpdir(), "native-dsh-wasm-"));
+const source = path.join(scratch, "source 空格");
+await cp(fileURLToPath(new URL("./examples", import.meta.url)), source, { recursive: true });
+await mkdir(output, { recursive: true });
+const entry = path.join(source, "plugin.ts"), helper = path.join(source, "greeting.ts");
+const home = path.join(scratch, "home");
+let runtime, child, browser, exit, url, receipt;
+let exited = false, logs = "";
+const lifecycle = [], browserErrors = [];
+async function until(check, timeout = 30000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const value = await check(); if (value) return value;
+    if (exited) throw new Error(`DSH exited before verification finished: ${logs.replace(/token=[^\s]+/g, "token=[redacted]").slice(-3000)}`);
+    await delay(100);
+  }
+  throw new Error("Timed out waiting for native DSH evidence.");
+}
+async function probe(expected) {
+  return until(async () => {
+    const response = await fetch(new URL("/harness-wasm-probe", url)).catch(() => undefined);
+    if (!response?.ok) return;
+    const value = await response.json();
+    if (value.greeting === expected && value.toolValue === expected) return value;
+  });
+}
+try {
+  await writeFile(helper, 'export const greeting: string = "native-v1";');
+  runtime = await createPluginRuntime({ entry, home });
+  const first = await runtime.build(); assert.equal(first.status, "published");
+  child = spawn(process.execPath, [path.join(packageRoot, manifest.bin.dsh), "--profile", "wasm", "--host", "127.0.0.1", "--port", "0", "--no-open"],
+    // Select DSH's official browser directory picker for headless interaction.
+    { cwd: source, env: { ...process.env, DSH_HOME: home, DSH_TELEMETRY_DISABLED: "1", SSH_CONNECTION: "native-smoke-browser-picker" }, stdio: ["ignore", "pipe", "pipe"] });
+  exit = new Promise((resolve) => { child.once("exit", (code) => { exited = true; resolve(code); }); });
+  child.once("error", (error) => { logs += error.message; exited = true; });
+  let pending = "";
+  const collect = (chunk) => {
+    logs = (logs + chunk).slice(-20000);
+    pending += chunk;
+    let newline;
+    while ((newline = pending.indexOf("\n")) >= 0) {
+      const line = pending.slice(0, newline); pending = pending.slice(newline + 1);
+      const start = line.indexOf("HARNESS_WASM_LIFECYCLE ");
+      if (start >= 0) lifecycle.push(JSON.parse(line.slice(start + "HARNESS_WASM_LIFECYCLE ".length)));
+      const match = line.match(/dsh web: (http:\/\/127\.0\.0\.1:\d+\/\?token=\S+)/);
+      if (match) url = match[1];
+    }
+  };
+  child.stdout.on("data", collect); child.stderr.on("data", collect);
+  await until(() => url, 60000);
+  const v1 = await probe("native-v1"); assert.equal(v1.pid, child.pid);
+  assert.equal((await fetch(new URL("/harness-wasm-probe", url), { method: "POST" })).status, 405);
+  let editor;
+  if (browserCheck) {
+    const { chromium } = await import("@playwright/test");
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    page.on("pageerror", (error) => browserErrors.push(error.message));
+    page.on("console", (message) => { if (message.type() === "error") browserErrors.push(message.text()); });
+    await page.goto(url);
+    const notice = page.getByRole("button", { name: "Continue", exact: true });
+    await notice.waitFor({ state: "visible", timeout: 3000 }).catch(() => {});
+    if (await notice.isVisible()) await notice.click();
+    const later = page.getByRole("button", { name: "Configure later", exact: true });
+    await later.waitFor({ state: "visible", timeout: 5000 }).catch(() => {});
+    if (await later.isVisible()) await later.click();
+    const workspace = page.getByRole("button", { name: "Choose workspace", exact: true });
+    if (await workspace.isVisible()) {
+      await workspace.click();
+      await page.getByRole("button", { name: "Edit path", exact: true }).click();
+      const pathField = page.getByRole("textbox", { name: "Edit path", exact: true });
+      await pathField.fill(source); await pathField.press("Enter");
+      await page.getByRole("button", { name: "Open", exact: true }).click();
+    }
+    editor = page.locator('[contenteditable="true"][role="textbox"]');
+    try { await editor.waitFor({ state: "visible", timeout: 15000 }); }
+    catch (error) {
+      await page.screenshot({ path: path.join(output, "browser-failure.png") });
+      await writeFile(path.join(output, "browser-failure.json"), JSON.stringify({ text: await page.locator("body").innerText(), errors: browserErrors }, null, 2));
+      throw error;
+    }
+    await editor.fill("DSH runtime compiler draft, never submitted.");
+    assert.equal(await editor.evaluate((el) => document.activeElement === el), true);
+    await page.screenshot({ path: path.join(output, "official-web-before.png") });
+  } else {
+    const handoff = await fetch(url, { redirect: "manual" });
+    const cookie = handoff.headers.getSetCookie().map((value) => value.split(";")[0]).join("; ");
+    const response = await fetch(new URL("/", url), { headers: { cookie } });
+    assert.equal(response.status, 200);
+    assert.ok((await response.text()).includes("__DSH_BOOT__"));
+  }
+  await writeFile(helper, 'export const greeting: string = "native-v2";');
+  const second = await runtime.build({ onlyChanged: true }); assert.equal(second.status, "published");
+  assert.notEqual(second.revision, first.revision);
+  assert.equal((await probe("native-v2")).pid, v1.pid);
+  await until(() => lifecycle.some((e) => e.event === "stop" && e.greeting === "native-v1"));
+  const lastGood = await readFile(second.patch);
+  await writeFile(helper, "export const greeting = (");
+  assert.equal((await runtime.build()).status, "failed");
+  assert.deepEqual(await readFile(second.patch), lastGood);
+  assert.equal((await probe("native-v2")).pid, v1.pid);
+  await writeFile(helper, 'export const greeting: string = "native-v3";');
+  assert.equal((await runtime.build()).status, "published");
+  assert.equal((await probe("native-v3")).pid, v1.pid);
+  await until(() => lifecycle.some((e) => e.event === "stop" && e.greeting === "native-v2"));
+  if (browser) {
+    assert.equal(await editor.innerText(), "DSH runtime compiler draft, never submitted.");
+    const page = browser.contexts()[0].pages()[0];
+    await page.screenshot({ path: path.join(output, "official-web-after.png") });
+    assert.deepEqual(browserErrors, []);
+    await editor.fill(""); await browser.close(); browser = undefined;
+  }
+  child.kill("SIGTERM");
+  const code = await Promise.race([exit, delay(7000).then(() => { throw new Error("DSH did not terminate gracefully."); })]);
+  assert.equal(code, 0);
+  assert.ok(lifecycle.some((e) => e.event === "stop" && e.greeting === "native-v3"));
+  await assert.rejects(fetch(new URL("/harness-wasm-probe", url)));
+  receipt = { status: "passed", dsh: manifest.version, node: process.version, platform: process.platform,
+    nativeReloads: 2, processReused: true, browser: browserCheck, browserErrors, modelRequests: 0,
+    lifecycle: lifecycle.map(({ event, greeting }) => ({ event, greeting })),
+    initialCompileMs: first.durationMs, updateCompileMs: second.durationMs, moduleBytes: first.bytes };
+} finally {
+  await browser?.close();
+  if (child && !exited) { child.kill("SIGKILL"); await exit; }
+  await runtime?.dispose();
+  await rm(scratch, { recursive: true, force: true });
+}
+await writeFile(path.join(output, "receipt.json"), JSON.stringify(receipt, null, 2));
+process.stdout.write(`${JSON.stringify(receipt)}\n`);

--- a/scripts/dsh-plugin-runtime/runtime.mjs
+++ b/scripts/dsh-plugin-runtime/runtime.mjs
@@ -1,0 +1,132 @@
+import { createHash, randomUUID } from "node:crypto";
+import { builtinModules } from "node:module";
+import { mkdir, readFile, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import * as esbuild from "esbuild-wasm";
+
+const owner = { kind: "better-harness.dsh-plugin-runtime", version: 1 };
+const manifest = { name: "better-harness-dsh-runtime-experiment", private: true, type: "module",
+  dsh: { profile: { bundles: ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"], patchReload: "live" } } };
+const builtins = new Set(builtinModules.flatMap((name) => [name, `node:${name}`]));
+const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const json = (value) => `${JSON.stringify(value, null, 2)}\n`;
+
+async function atomicWrite(filename, content) {
+  const temporary = `${filename}.${randomUUID()}.tmp`;
+  try { await writeFile(temporary, content, { flag: "wx" }); await rename(temporary, filename); }
+  finally { await rm(temporary, { force: true }); }
+}
+
+/** Only our isolated home is writable. A running DSH process does not own the build lock. */
+async function prepare(home) {
+  await mkdir(home, { recursive: true });
+  const marker = path.join(home, ".better-harness-dsh.json");
+  try {
+    const existing = JSON.parse(await readFile(marker, "utf8"));
+    if (existing.kind !== owner.kind || existing.version !== owner.version) throw new Error("Unknown experiment home owner.");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    if ((await readdir(home)).length) throw new Error("Use an empty experiment home; refusing to modify an existing DSH home.");
+    await writeFile(marker, json(owner), { flag: "wx" });
+  }
+  const profile = path.join(home, "profiles", "wasm");
+  await mkdir(path.join(profile, "modules"), { recursive: true });
+  const manifestPath = path.join(profile, "package.json");
+  try {
+    const existing = JSON.parse(await readFile(manifestPath, "utf8"));
+    if (JSON.stringify(existing) !== JSON.stringify(manifest)) throw new Error("Experiment Profile manifest was changed; refusing to overwrite it.");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    await writeFile(manifestPath, json(manifest), { flag: "wx" });
+  }
+  return profile;
+}
+
+export async function createPluginRuntime({ entry, home }) {
+  entry = await realpath(path.resolve(entry)); home = path.resolve(home);
+  const profile = await prepare(home);
+  const patch = path.join(profile, "cordis.patch.yml");
+  const lock = path.join(home, ".compiler-lock");
+  const capturedInputs = new Map();
+  const context = await esbuild.context({
+    absWorkingDir: path.dirname(entry), entryPoints: [entry],
+    outfile: path.join(profile, "candidate.mjs"), bundle: true, write: false,
+    format: "esm", platform: "node", target: "node22", metafile: true, logLevel: "silent",
+    plugins: [{ name: "dsh-runtime-imports", setup(build) {
+      build.onLoad({ filter: /\.(?:[cm]?[jt]sx?|json)$/ }, async ({ path: filename }) => {
+        const bytes = await readFile(filename);
+        capturedInputs.set(path.resolve(filename), digest(bytes));
+        const extension = path.extname(filename).slice(1);
+        const loader = ["mts", "cts"].includes(extension) ? "ts" : ["mjs", "cjs"].includes(extension) ? "js" : extension;
+        return { contents: bytes, loader, resolveDir: path.dirname(filename) };
+      });
+      build.onResolve({ filter: /^[^./]/ }, ({ path: specifier, kind }) => {
+        if (kind === "entry-point" || path.isAbsolute(specifier)) return;
+        if (builtins.has(specifier) || specifier.startsWith("@deepseek-ai/")) return { path: specifier, external: true };
+        return { errors: [{ text: `Unsupported runtime import: ${specifier}. Use local files or DSH-owned packages.` }] };
+      });
+    } }],
+  });
+  let closed = false, tail = Promise.resolve(), disposal;
+  let inputHashes;
+  async function build({ onlyChanged = false } = {}) {
+    if (closed) throw new Error("Runtime compiler is disposed.");
+    const job = tail.then(async () => {
+      const started = performance.now();
+      if (onlyChanged && inputHashes) {
+        const unchanged = await Promise.all([...inputHashes].map(async ([file, hash]) =>
+          readFile(file).then((bytes) => digest(bytes) === hash, () => false)));
+        if (unchanged.every(Boolean)) return { status: "unchanged" };
+      }
+      let locked = false;
+      try {
+        try { await mkdir(lock); locked = true; }
+        catch (error) { if (error.code === "EEXIST") throw new Error("Another compiler owns this home. Retry after it exits."); throw error; }
+        await prepare(home);
+        const result = await context.rebuild();
+        const metadata = Object.values(result.metafile.outputs).find((item) => item.entryPoint);
+        if (!metadata?.exports.includes("apply")) throw new Error("DSH plugins must export a named apply function.");
+        const output = result.outputFiles[0].contents;
+        const revision = digest(output);
+        const moduleName = `./modules/${revision}.mjs`;
+        const artifact = path.join(profile, "modules", `${revision}.mjs`);
+        const nextPatch = [{ insert: [{ id: "harness-wasm-plugin", name: moduleName }] }];
+        let previous;
+        try {
+          previous = JSON.parse(await readFile(patch, "utf8"));
+          const row = previous?.[0]?.insert?.[0];
+          if (!Array.isArray(previous) || previous.length !== 1 || Object.keys(previous[0]).length !== 1
+            || !Array.isArray(previous[0].insert) || previous[0].insert.length !== 1 || row?.id !== "harness-wasm-plugin"
+            || Object.keys(row).length !== 2 || !/^\.\/modules\/[a-f0-9]{64}\.mjs$/.test(row.name)) {
+            throw new Error("Experiment patch was changed; refusing to overwrite it.");
+          }
+        } catch (error) { if (error.code !== "ENOENT") throw error; }
+        try { await writeFile(artifact, output, { flag: "wx" }); }
+        catch (error) {
+          if (error.code !== "EEXIST") throw error;
+          if (digest(await readFile(artifact)) !== revision) throw new Error("Existing compiled module failed its content digest.");
+        }
+        const changed = JSON.stringify(previous) !== JSON.stringify(nextPatch);
+        if (changed) await atomicWrite(patch, json(nextPatch));
+        // Compare future saves with exactly the bytes given to esbuild, so an
+        // edit during compilation cannot get mistaken for the compiled source.
+        inputHashes = new Map();
+        for (const file of Object.keys(result.metafile.inputs)) {
+          const absolute = path.resolve(path.dirname(entry), file);
+          const hash = capturedInputs.get(absolute);
+          if (hash === undefined) { inputHashes = undefined; break; }
+          inputHashes.set(absolute, hash);
+        }
+        return { status: "published", revision, changed, bytes: output.length,
+          durationMs: performance.now() - started, artifact, patch,
+          activation: "pending-native-loader", diagnostics: result.warnings.map((warning) => ({ text: warning.text })) };
+      } catch (error) {
+        inputHashes = undefined;
+        return { status: "failed", diagnostics: (error.errors ?? [error]).map((item) => ({ text: item.text ?? item.message ?? String(item), ...(item.location ? { location: item.location } : {}) })) };
+      } finally { if (locked) await rm(lock, { recursive: true }); }
+    });
+    tail = job.catch(() => {});
+    return job;
+  }
+  return { home, profile, build, dispose() { closed = true; disposal ??= tail.then(() => context.dispose()); return disposal; } };
+}

--- a/test/dsh-plugin-runtime/cli.test.mjs
+++ b/test/dsh-plugin-runtime/cli.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { test } from "vitest";
+import { launchArguments, parseArgs } from "../../scripts/dsh-plugin-runtime/cli.mjs";
+
+const cli = fileURLToPath(new URL("../../scripts/dsh-plugin-runtime/cli.mjs", import.meta.url));
+const run = (args) => spawnSync(process.execPath, [cli, ...args], { encoding: "utf8", timeout: 20000 });
+
+test("help and strict option parsing report actionable errors", () => {
+  const result = run(["--help"]);
+  assert.equal(result.status, 0); assert.match(result.stdout, /activation/);
+  for (const args of [["oops"], ["build", "--entry"], ["run", "--port", "-1"], ["run", "--entry", "a", "--home", "b"]]) {
+    const failure = run(args);
+    assert.equal(failure.status, 1); assert.equal(failure.stdout, ""); assert.ok(failure.stderr);
+  }
+});
+
+test("DSH launch keeps native paths as argv and fixes loopback/profile arguments", () => {
+  const options = parseArgs(["run", "--entry", "plugin 空格.ts", "--home", "isolated home", "--dsh-cli", "dsh cli.js", "--port", "12345", "--watch"]);
+  assert.deepEqual(launchArguments(options), [path.resolve("dsh cli.js"), "--profile", "wasm", "--host", "127.0.0.1", "--port", "12345", "--no-open"]);
+  assert.equal(options.watch, true);
+});
+
+test("build emits JSON and syntax failure exits nonzero without changing its published patch", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dsh cli "));
+  try {
+    const entry = path.join(root, "plugin.ts");
+    await writeFile(entry, "export function apply() {}");
+    const args = ["build", "--entry", entry, "--home", path.join(root, "home"), "--json"];
+    const good = run(args); assert.equal(good.status, 0); assert.equal(good.stderr, "");
+    const receipt = JSON.parse(good.stdout); assert.equal(receipt.status, "published");
+    const before = await readFile(receipt.patch);
+    await writeFile(entry, "export function apply(");
+    const bad = run(args); assert.equal(bad.status, 1);
+    assert.equal(JSON.parse(bad.stdout).status, "failed");
+    assert.deepEqual(await readFile(receipt.patch), before);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("run --watch publishes source edits and terminates its launched DSH process", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dsh watch 空格 "));
+  let child;
+  try {
+    const entry = path.join(root, "plugin.ts"), fakeDsh = path.join(root, "fake dsh.mjs"), home = path.join(root, "home");
+    await writeFile(entry, 'export function apply(ctx) { ctx.value = "one"; }');
+    await writeFile(fakeDsh, 'console.log(JSON.stringify({pid:process.pid,home:process.env.DSH_HOME,args:process.argv.slice(2)})); setInterval(()=>{},1000);');
+    child = spawn(process.execPath, [cli, "run", "--entry", entry, "--home", home, "--dsh-cli", fakeDsh, "--watch", "--control-stdio"]);
+    const exit = new Promise((resolve, reject) => { child.once("exit", resolve); child.once("error", reject); });
+    let stdout = "", stderr = "";
+    child.stdout.on("data", (d) => { stdout += d; }); child.stderr.on("data", (d) => { stderr += d; });
+    const patch = path.join(home, "profiles", "wasm", "cordis.patch.yml");
+    async function until(check) {
+      const deadline = Date.now() + 15000;
+      while (!(await check())) { assert.ok(Date.now() < deadline, "CLI watch did not make progress"); await delay(30); }
+    }
+    await until(() => stdout.includes("\n"));
+    const started = JSON.parse(stdout);
+    assert.equal(started.home, home);
+    assert.deepEqual(started.args.slice(0, 2), ["--profile", "wasm"]);
+    const first = await readFile(patch, "utf8");
+    await writeFile(entry, 'export function apply(ctx) { ctx.value = "two"; }');
+    await until(async () => (await readFile(patch, "utf8")) !== first);
+    const second = await readFile(patch, "utf8");
+    await writeFile(entry, "export function apply(");
+    await until(() => stderr.includes("Expected identifier") || stderr.includes("Unexpected end"));
+    assert.equal(await readFile(patch, "utf8"), second);
+    child.stdin.end("stop\n");
+    await exit;
+    assert.throws(() => process.kill(started.pid, 0), { code: "ESRCH" });
+  } finally {
+    child?.kill("SIGKILL"); await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/dsh-plugin-runtime/runtime.test.mjs
+++ b/test/dsh-plugin-runtime/runtime.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, test } from "vitest";
+import { createPluginRuntime } from "../../scripts/dsh-plugin-runtime/runtime.mjs";
+
+const cleanup = [];
+afterEach(async () => { for (const fn of cleanup.splice(0).reverse()) await fn(); });
+async function fixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dsh wasm 空格 "));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  const entry = path.join(root, "plugin.ts"), helper = path.join(root, "greeting.ts"), home = path.join(root, "home");
+  await writeFile(entry, 'import { value } from "./greeting"; export function apply(ctx) { ctx.value = value; }');
+  await writeFile(helper, 'export const value: string = "one";');
+  const runtime = await createPluginRuntime({ entry, home });
+  cleanup.push(() => runtime.dispose());
+  return { entry, helper, home, runtime };
+}
+
+test("publishes a native Profile and immutable modules; same-length source changes rebuild", async () => {
+  const f = await fixture();
+  const one = await f.runtime.build();
+  assert.equal(one.status, "published");
+  assert.equal(one.activation, "pending-native-loader");
+  const context = {};
+  (await import(pathToFileURL(one.artifact))).apply(context);
+  assert.equal(context.value, "one");
+  assert.equal((await f.runtime.build({ onlyChanged: true })).status, "unchanged");
+  await writeFile(f.helper, 'export const value: string = "two";');
+  const two = await f.runtime.build({ onlyChanged: true });
+  assert.equal(two.status, "published");
+  assert.notEqual(two.artifact, one.artifact);
+  (await import(pathToFileURL(two.artifact))).apply(context);
+  assert.equal(context.value, "two");
+  const patch = JSON.parse(await readFile(two.patch, "utf8"));
+  assert.equal(patch[0].insert[0].name, `./modules/${two.revision}.mjs`);
+  assert.equal((await f.runtime.build()).changed, false);
+  assert.equal((await readdir(path.dirname(two.artifact))).length, 2);
+});
+
+test.each([
+  ['syntax error', 'export function apply('],
+  ['missing import', 'import x from "./missing"; export function apply() { return x; }'],
+  ['unsupported package', 'import x from "uninstalled"; export function apply() { return x; }'],
+  ['wrong entry contract', 'export default () => {};'],
+])("%s retains the previous Profile patch and recovers", async (_name, source) => {
+  const f = await fixture();
+  const good = await f.runtime.build();
+  const before = await readFile(good.patch);
+  await writeFile(f.entry, source);
+  const result = await f.runtime.build();
+  assert.equal(result.status, "failed");
+  assert.ok(result.diagnostics.length);
+  assert.deepEqual(await readFile(good.patch), before);
+  await writeFile(f.entry, 'export function apply(ctx) { ctx.value = "recovered"; }');
+  assert.equal((await f.runtime.build()).status, "published");
+});
+
+test("refuses a non-owned home and preserves its files", async () => {
+  const f = await fixture();
+  const home = path.join(f.home, "unowned"); await mkdir(home);
+  await writeFile(path.join(home, "settings.yaml"), "untouched");
+  await assert.rejects(createPluginRuntime({ entry: f.entry, home }), /empty experiment home/);
+  assert.deepEqual(await readdir(home), ["settings.yaml"]);
+});
+
+test("refuses a modified Profile manifest and manually changed patch", async () => {
+  const f = await fixture();
+  const good = await f.runtime.build();
+  await writeFile(good.patch, JSON.stringify([{ insert: [{ id: "personal", name: "my-plugin" }] }]));
+  assert.equal((await f.runtime.build()).status, "failed");
+  assert.equal(JSON.parse(await readFile(good.patch, "utf8"))[0].insert[0].id, "personal");
+  const extraPatch = [{ insert: [{ id: "harness-wasm-plugin", name: `./modules/${good.revision}.mjs` }], remove: ["personal"] }];
+  await writeFile(good.patch, JSON.stringify(extraPatch));
+  assert.equal((await f.runtime.build()).status, "failed");
+  assert.deepEqual(JSON.parse(await readFile(good.patch, "utf8")), extraPatch);
+  await writeFile(path.join(f.runtime.profile, "package.json"), "{}");
+  await assert.rejects(createPluginRuntime({ entry: f.entry, home: f.home }), /manifest was changed/);
+});
+
+test("concurrent writers are excluded, then retry works; corrupt immutable modules fail closed", async () => {
+  const f = await fixture();
+  const lock = path.join(f.home, ".compiler-lock");
+  await mkdir(lock);
+  assert.equal((await f.runtime.build()).status, "failed");
+  assert.deepEqual(await readdir(lock), []);
+  await rm(lock, { recursive: true });
+  const good = await f.runtime.build();
+  await writeFile(good.artifact, "corrupt");
+  const failed = await f.runtime.build();
+  assert.equal(failed.status, "failed");
+  assert.match(failed.diagnostics[0].text, /digest/);
+});
+
+test("disposal drains accepted builds, removes the writer lock and rejects later builds", async () => {
+  const f = await fixture();
+  const pending = f.runtime.build();
+  await f.runtime.dispose();
+  assert.equal((await pending).status, "published");
+  assert.ok(!(await readdir(f.home)).includes(".compiler-lock"));
+  await assert.rejects(f.runtime.build(), /disposed/);
+  await f.runtime.dispose();
+});


### PR DESCRIPTION
Changing a DSH plugin can now compile and activate inside a running official
DSH Web process. This independent experiment, branched directly from main,
adds `build`, `watch` and `run` commands under `scripts/dsh-plugin-runtime/`.
It complements the Pi experiment in #159 and the Studio comparison in #158.

`run` compiles first and launches a new installed DSH runtime with an isolated
home. Later builds publish content-addressed ESM modules and atomically change
one native Profile patch row. DSH replaces the plugin through its own live
loader, disposes old Cordis effects and keeps the official Web page open.
Watch mode explicitly enables activation on save; compilation failures keep
the last published version. No package or lockfile changes are needed.

Spec and usage:
- `docs/specs/2026-09-09-dsh-wasm-plugin-runtime.md`
- `scripts/dsh-plugin-runtime/README.md`

Validation:
- Focused compiler/CLI, doc-link, script architecture and artifact checks:
  **63 passed, 1 skipped**. Regenerated doc-link graph is unchanged.
- Real DSH **0.1.2-rc.1**, macOS, Node **24.20.0**: v1 → v2 → v3 in the same
  PID, old plugin disposal, syntax-error retention, recovery and final cleanup.
- Playwright drove official Web onboarding and workspace selection, focused
  the input and verified its unsent draft survived both reloads. Zero browser
  console/page errors; before/after screenshots inspected locally.
- Native probe called the actual registered tool definition; no model requests
  or full tool approval/dispatch claim. A bounded agent consumer also verified
  documented JSON build, error retention and recovery commands.
- One run: **183 ms** initial compile, **83 ms** incremental compile, **1,369 B**
  example module. Timings exclude native activation and are not a benchmark.

Boundaries: this compiles trusted local plugins against preinstalled DSH. Core
and browser-client compilation, runtime-error rollback, automatic Agent idle
coordination, Studio integration and packaged acceptance are outside this
experiment. Immutable modules accumulate until process exit; the installed DSH
dependency closure is unchanged. Windows/Linux native execution is unverified.
`npm run preview` was attempted but the local Canvas SDK runtime is missing, so
its health/module endpoints are unverified. Hosted CI is separate from these
local results.
