### PR TITLE
fix(dashboard): render a packet whose links object omits some arrays

### DIFF
--- a/packages/harness-ui/lib/dashboard-model.ts
+++ b/packages/harness-ui/lib/dashboard-model.ts
@@ -335,7 +335,9 @@ export function buildDashboardModel(input: DashboardInput) {
       organizations: [...new Set(deliveries.map((delivery) => delivery.organization))].sort(),
       items: deliveries.map((delivery) => {
         const packet = delivery.packet;
-        const links = packet.links ?? { sessionRefs: [], commitRefs: [], artifactRefs: [] };
+        // The upload contract admits a `links` object that omits some of its arrays,
+        // so default each one rather than trusting the shape the type declares.
+        const links = { sessionRefs: [], commitRefs: [], artifactRefs: [], ...packet.links };
         const changeObservations = packet.observations.filter((entry) => ["change", "artifact"].includes(entry.kind));
         const changeEvidenceCount = changeObservations.filter((entry) => entry.status !== "unobserved").length
           + links.commitRefs.length

--- a/packages/harness-ui/test/dashboard-model.test.mjs
+++ b/packages/harness-ui/test/dashboard-model.test.mjs
@@ -7,7 +7,7 @@ import { test } from "vitest";
 import { runAgentLint } from "../../../scripts/agent-lint/index.mjs";
 import { buildUsageSummary } from "../../../scripts/session-analysis/usage-summary.mjs";
 import { buildDailyUsageActivity } from "../../../scripts/session-analysis/daily-usage.mjs";
-import { createTaskEvidencePacket } from "../../../scripts/task-evidence-upload/index.mjs";
+import { createTaskEvidencePacket, validateTaskEvidencePacket } from "../../../scripts/task-evidence-upload/index.mjs";
 import { dashboardProjectOptions, selectDashboardProject } from "../components/usage-dashboard.tsx";
 import { buildDashboardModel } from "../lib/dashboard-model.ts";
 
@@ -230,6 +230,48 @@ test("dashboard projects values built by the real scripts", async () => {
     });
     assert.equal(Object.hasOwn(model.overview, "cost"), false);
     assert.equal(Object.hasOwn(model.overview, "autonomy"), false);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("a stored packet with a partial links object does not break the Dashboard projection", async () => {
+  // The upload contract admits a `links` object that omits some of its arrays, so
+  // the projection cannot dereference all three unconditionally.
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "harness-ui-partial-links-"));
+  try {
+    const packet = createTaskEvidencePacket(packetInput(), {
+      workspace,
+      workspaceLabel: "fixture",
+      now: new Date("2026-09-01T12:00:00.000Z"),
+    });
+    const stored = { ...packet, links: { commitRefs: packet.links.commitRefs } };
+    // Reachability: the read path admits this shape, so the projection has to
+    // cope with it rather than relying on validation to reject it.
+    assert.doesNotThrow(() => validateTaskEvidencePacket(stored));
+
+    const model = buildDashboardModel({
+      ...baseInput([]),
+      evidenceDeliveries: {
+        items: [{
+          organization: "acme-engineering",
+          endpoint: "https://harness.example.test/evidence",
+          acceptedAt: "2026-09-01T12:05:00.000Z",
+          receiptState: "accepted",
+          packetDigest: "a".repeat(64),
+          packetBytes: 512,
+          packet: stored,
+        }],
+        total: 1,
+        truncated: false,
+      },
+    });
+
+    assert.deepEqual(model.evidenceDeliveries.items[0].links, {
+      sessionRefs: [],
+      commitRefs: packet.links.commitRefs,
+      artifactRefs: [],
+    });
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

`buildDashboardModel` fell back to a default `links` only when the whole object was absent. A packet whose `links` is present but omits `sessionRefs` or `artifactRefs` therefore reached `links.artifactRefs.length` and threw:

```
TypeError: Cannot read properties of undefined (reading 'length')
 ❯ lib/dashboard-model.ts:342:32
```

The throw happens while building the model, so one such packet takes down the entire Dashboard render rather than degrading a single panel.

## Why the shape is reachable

`validateTaskEvidencePacket` admits it. At `scripts/task-evidence-upload/contract.mjs:492-495` the packet validator calls `normalizeLinks`, but `normalizeLinks` builds its key list with `{ optional: [...] }` and no `required`, so a `links` object containing only some of the arrays passes validation. The call's result is discarded, so nothing materializes the missing arrays either. `createTaskEvidencePacket` always writes all three, but the read path does not require them.

The regression test asserts that acceptance explicitly, so the precondition is pinned rather than assumed.

## The change

Default each array and let any supplied value win, which also keeps an optional `projectRef` flowing through as before. One production file.

## Validation

- New test `a stored packet with a partial links object does not break the Dashboard projection` — reports the `TypeError` above before the change.
- `packages/harness-ui`: `tsc --noEmit` exit 0; full vitest suite 58/58 passed, exit 0.
